### PR TITLE
[TASK] Remove unnecessary View-level partial identifier cache

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -48,15 +48,6 @@ abstract class AbstractTemplateView extends AbstractView
     protected $renderingStack = [];
 
     /**
-     * Partial Name -> Partial Identifier cache.
-     * This is a performance optimization, effective when rendering a
-     * single partial many times.
-     *
-     * @var array
-     */
-    protected $partialIdentifierCache = [];
-
-    /**
      * Constructor
      *
      * @param null|RenderingContextInterface $context
@@ -284,12 +275,8 @@ abstract class AbstractTemplateView extends AbstractView
      */
     public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = false)
     {
-        if (!isset($this->partialIdentifierCache[$partialName])) {
-            $this->partialIdentifierCache[$partialName] = $this->baseRenderingContext->getTemplatePaths()->getPartialIdentifier($partialName);
-        }
-        $partialIdentifier = $this->partialIdentifierCache[$partialName];
         $parsedPartial = $this->baseRenderingContext->getTemplateParser()->getOrParseAndStoreTemplate(
-            $partialIdentifier,
+            $this->baseRenderingContext->getTemplatePaths()->getPartialIdentifier($partialName),
             function ($parent, TemplatePaths $paths) use ($partialName) {
                 return $paths->getPartialSource($partialName);
             }


### PR DESCRIPTION
Identifiers are already cache in TemplatePaths which
is consulted directly from the View. One function call
replaces one condition - and decreases total LOC.