### PR TITLE
[BUGFIX] Require minimum pcre lib 8.36

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
 	"description": "The TYPO3 Fluid template rendering engine",
 	"license": ["LGPL-3.0"],
 	"require": {
-		"php": ">=5.5.0"
+		"php": ">=5.5.0",
+	        "lib-pcre": ">=8.36"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8",


### PR DESCRIPTION
This clearly reports a requirement of the TemplateParser
which uses expressions that are only supported on the
stated minimum version of PCRE. Before this the parser
might cause segmentation faults.
