### PR TITLE
[FEATURE] Add additional VH assistant Traits

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileEmpty.php
+++ b/src/Core/ViewHelper/Traits/CompileEmpty.php
@@ -1,20 +1,22 @@
 <?php
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
+
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
- * Class CompilableWithRenderStatic
+ * Class CompileEmpty
  *
- * Provides default methods for rendering and compiling
- * any ViewHelper that conforms to the `renderStatic`
- * method pattern.
+ * Implemented by ViewHelpers which must compile to provide empty
+ * content (e.g. ViewHelper is a structure ViewHelper which uses
+ * postParseEvent and/or are not supposed to render once compiled).
  */
-trait CompileWithRenderStatic
+trait CompileEmpty
 {
     /**
+     * Return empty string to be placed in the compiled template.
+     *
      * @param string $argumentsName
      * @param string $closureName
      * @param string $initializationPhpCode
@@ -29,12 +31,6 @@ trait CompileWithRenderStatic
         ViewHelperNode $node,
         TemplateCompiler $compiler
     ) {
-        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
-            $this,
-            $argumentsName,
-            $closureName
-        );
-        $initializationPhpCode .= $initialization;
-        return $execution;
+        return '\'\'';
     }
 }

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -5,6 +5,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
 use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Class CompilableWithContentArgumentAndRenderStatic
@@ -18,7 +19,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
  */
 trait CompileWithContentArgumentAndRenderStatic
 {
-
     /**
      * Name of variable that contains the value to use
      * instead of render children closure, if specified.
@@ -37,31 +37,6 @@ trait CompileWithContentArgumentAndRenderStatic
     protected $contentArgumentName;
 
     /**
-     * Default render method to render ViewHelper with
-     * first defined optional argument as content.
-     *
-     * @return string Rendered string
-     * @api
-     */
-    public function render()
-    {
-        $argumentName = $this->resolveContentArgumentName();
-        $arguments = $this->arguments;
-        if (!empty($argumentName) && isset($arguments[$argumentName])) {
-            $renderChildrenClosure = function() use ($arguments, $argumentName) {
-                return $arguments[$argumentName];
-            };
-        } else {
-            $renderChildrenClosure = call_user_func_array([$this, 'buildRenderChildrenClosure'], []);
-        }
-        return self::renderStatic(
-            $arguments,
-            $renderChildrenClosure,
-            $this->renderingContext
-        );
-    }
-
-    /**
      * @param string $argumentsName
      * @param string $closureName
      * @param string $initializationPhpCode
@@ -76,16 +51,40 @@ trait CompileWithContentArgumentAndRenderStatic
         ViewHelperNode $node,
         TemplateCompiler $compiler
     ) {
-        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethodAndContentFromArgumentName(
+        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
             $this,
             $argumentsName,
             $closureName,
-            $this->resolveContentArgumentName(),
             ViewHelperCompiler::RENDER_STATIC,
             static::class
         );
         $initializationPhpCode .= $initialization;
         return $execution;
+    }
+
+    /**
+     * Helper which is mostly needed when calling renderStatic() from within
+     * render().
+     *
+     * No public API yet.
+     *
+     * @return \Closure
+     */
+    protected function buildRenderChildrenClosure()
+    {
+        $argumentName = $this->resolveContentArgumentName();
+        $arguments = $this->arguments;
+        if (!empty($argumentName) && isset($arguments[$argumentName])) {
+            $renderChildrenClosure = function () use ($arguments, $argumentName) {
+                return $arguments[$argumentName];
+            };
+        } else {
+            $self = clone $this;
+            $renderChildrenClosure = function () use ($self) {
+                return $self->renderChildren();
+            };
+        }
+        return $renderChildrenClosure;
     }
 
     /**

--- a/src/Core/ViewHelper/Traits/DefaultRenderMethod.php
+++ b/src/Core/ViewHelper/Traits/DefaultRenderMethod.php
@@ -1,0 +1,48 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class DefaultRenderMethod
+ *
+ * Contains a default implementation of a render method which calls
+ * renderStatic.
+ *
+ * Implement this trait to indicate that your ViewHelper is exclusively
+ * static callable and implements renderStatic().
+ */
+trait DefaultRenderMethod
+{
+    /**
+     * Forced implementation to build a rendering closure
+     *
+     * @return \Closure
+     */
+    abstract public function buildRenderChildrenClosure();
+
+    /**
+     * @return mixed
+     */
+    abstract static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    );
+
+    /**
+     * Default render method to render ViewHelper with
+     * first defined optional argument as content.
+     *
+     * @return string Rendered string
+     * @api
+     */
+    public function render()
+    {
+        return static::renderStatic(
+            $this->arguments,
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext
+        );
+    }
+}

--- a/src/Core/ViewHelper/Traits/PassthroughRenderChildren.php
+++ b/src/Core/ViewHelper/Traits/PassthroughRenderChildren.php
@@ -1,0 +1,23 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
+
+/**
+ * Class PassthroughRenderChildren
+ */
+trait PassthroughRenderChildren
+{
+    /**
+     * @return mixed
+     */
+    abstract protected function renderChildren();
+
+    /**
+     * @return string the rendered string
+     * @api
+     */
+    public function render()
+    {
+        return $this->renderChildren();
+    }
+
+}

--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Declares new variables which are aliases of other variables.
@@ -43,7 +44,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class AliasViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithRenderStatic;
 
     /**

--- a/src/ViewHelpers/CaseViewHelper.php
+++ b/src/ViewHelpers/CaseViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
 
 /**
  * Case view helper that is only usable within the SwitchViewHelper.
@@ -19,6 +20,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class CaseViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
 
     /**
      * @var boolean
@@ -54,18 +56,5 @@ class CaseViewHelper extends AbstractViewHelper
             return $this->renderChildren();
         }
         return '';
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '\'\'';
     }
 }

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
 
 /**
  * This ViewHelper prevents rendering of any content inside the tag
@@ -47,6 +48,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class CommentViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
 
     /**
      * @var boolean
@@ -66,18 +68,5 @@ class CommentViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return null
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return null;
     }
 }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * This ViewHelper counts elements of the specified array or countable object.
@@ -34,7 +35,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CountViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  *
@@ -34,7 +35,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class DebugViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithRenderStatic;
 
     /**

--- a/src/ViewHelpers/DefaultCaseViewHelper.php
+++ b/src/ViewHelpers/DefaultCaseViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
 
 /**
  * A view helper which specifies the "default" case when used within the SwitchViewHelper.
@@ -19,6 +20,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class DefaultCaseViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
 
     /**
      * @var boolean
@@ -37,18 +39,5 @@ class DefaultCaseViewHelper extends AbstractViewHelper
             throw new ViewHelper\Exception('The "default case" View helper can only be used within a switch View helper', 1368112037);
         }
         return $this->renderChildren();
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '\'\'';
     }
 }

--- a/src/ViewHelpers/ElseViewHelper.php
+++ b/src/ViewHelpers/ElseViewHelper.php
@@ -9,6 +9,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\PassthroughRenderChildren;
 
 /**
  * Else-Branch of a condition. Only has an effect inside of "If". See the If-ViewHelper for documentation.
@@ -32,6 +34,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ElseViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
+    use PassthroughRenderChildren;
 
     /**
      * @var boolean
@@ -46,25 +50,4 @@ class ElseViewHelper extends AbstractViewHelper
         $this->registerArgument('if', 'boolean', 'Condition expression conforming to Fluid boolean rules');
     }
 
-    /**
-     * @return string the rendered string
-     * @api
-     */
-    public function render()
-    {
-        return $this->renderChildren();
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string|NULL
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '\'\'';
-    }
 }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -12,6 +12,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Loop view helper which can be used to iterate over arrays.
@@ -62,7 +63,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class ForViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithRenderStatic;
     
     /**

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Outputs an argument/value without any escaping and wraps it with CDATA tags.
@@ -43,7 +44,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CdataViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * A view helper for formatting values with printf. Either supply an array for
@@ -49,7 +50,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class PrintfViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Outputs an argument/value without any escaping. Is normally used to output
@@ -46,7 +47,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class RawViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Grouped loop view helper.
@@ -75,7 +76,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class GroupedForViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithRenderStatic;
 
     /**

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -11,6 +11,8 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\PostParseInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\PassthroughRenderChildren;
 
 /**
  * With this tag, you can select a layout to be used for the current template.
@@ -28,6 +30,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
  */
 class LayoutViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
+    use PassthroughRenderChildren;
 
     /**
      * Initialize arguments
@@ -60,15 +64,5 @@ class LayoutViewHelper extends AbstractViewHelper
         }
 
         $variableContainer->add('layoutName', $layoutNameNode);
-    }
-
-    /**
-     * This tag will not be rendered at all.
-     *
-     * @return void
-     * @api
-     */
-    public function render()
-    {
     }
 }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -9,13 +9,14 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * If content is empty use alternative text
  */
 class OrViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithContentArgumentAndRenderStatic;
 
     /**

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -12,6 +12,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
 
 /**
  * A ViewHelper to declare sections in templates for later use with e.g. the RenderViewHelper.
@@ -57,6 +58,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
  */
 class SectionViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
 
     /**
      * @var boolean
@@ -109,18 +111,4 @@ class SectionViewHelper extends AbstractViewHelper
         return $content;
     }
 
-    /**
-     * The inner contents of a section should not be rendered.
-     *
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '\'\'';
-    }
 }

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\DefaultRenderMethod;
 
 /**
  * Space Removal ViewHelper
@@ -37,7 +38,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class SpacelessViewHelper extends AbstractViewHelper
 {
-
+    use DefaultRenderMethod;
     use CompileWithRenderStatic;
 
     /**

--- a/src/ViewHelpers/ThenViewHelper.php
+++ b/src/ViewHelpers/ThenViewHelper.php
@@ -9,6 +9,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileEmpty;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\PassthroughRenderChildren;
 
 /**
  * "THEN" -> only has an effect inside of "IF". See If-ViewHelper for documentation.
@@ -18,33 +20,11 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class ThenViewHelper extends AbstractViewHelper
 {
+    use CompileEmpty;
+    use PassthroughRenderChildren;
 
     /**
      * @var boolean
      */
     protected $escapeOutput = false;
-
-    /**
-     * Just render everything.
-     *
-     * @return string the rendered string
-     * @api
-     */
-    public function render()
-    {
-        return $this->renderChildren();
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '\'\'';
-    }
 }

--- a/tests/Unit/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CountViewHelperTest.php
@@ -30,9 +30,8 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderReturnsNumberOfElementsInAnArray()
     {
-        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')->willReturn(function() { return ['foo', 'bar', 'Baz']; });
         $expectedResult = 3;
-        $this->arguments = ['subject' => ['foo', 'bar', 'Baz']];
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $actualResult = $this->viewHelper->initializeArgumentsAndRender();
         $this->assertSame($expectedResult, $actualResult);
@@ -43,9 +42,8 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderReturnsNumberOfElementsInAnArrayObject()
     {
-        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')->willReturn(function() { return new \ArrayObject(['foo', 'bar']); });
         $expectedResult = 2;
-        $this->arguments = ['subject' => new \ArrayObject(['foo', 'bar'])];
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $actualResult = $this->viewHelper->initializeArgumentsAndRender();
         $this->assertSame($expectedResult, $actualResult);
@@ -56,9 +54,8 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderReturnsZeroIfGivenArrayIsEmpty()
     {
-        $this->viewHelper->expects($this->never())->method('buildRenderChildrenClosure');
+        $this->viewHelper->expects($this->once())->method('buildRenderChildrenClosure')->willReturn(function() { return []; });
         $expectedResult = 0;
-        $this->arguments = ['subject' => []];
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $actualResult = $this->viewHelper->render();
         $this->assertSame($expectedResult, $actualResult);

--- a/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
@@ -35,7 +35,7 @@ class LayoutViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRenderReturnsNull()
     {
-        $instance = new LayoutViewHelper();
+        $instance = $this->getMock(LayoutViewHelper::class, ['renderChildren']);
         $result = $instance->render();
         $this->assertNull($result);
     }


### PR DESCRIPTION
This adds three new traits:

* DefaultRenderMethod which contains the frequently duplicated render() method passthrough to renderStatic.
* PassthroughRenderChildren which has a render() method that only returns child content.
* CompileEmpty which causes the ViewHelper to compile to an empty string.

Together they remove some code duplication and provide further ways to remove code
duplication in packages providing ViewHelpers.