### PR TITLE
[DOC] Add variable access example of {{dynamicVariableName}}

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -17,6 +17,7 @@ A comma-separated value iterated as array:
 <!-- Dynamic string: changing "dynamic1" to "dynamic2" reads other string -->
 String variable name with dynamic1 part: {stringwith{dynamic1}part}.
 String variable name with dynamic2 part: {stringwith{dynamic2}part}.
+Output of variable whose name is stored in a variable: {{dynamicVariableName}}
 
 <!-- Dynamic array: changing "dynanic1" to "dynamic2" reads other array member -->
 Array member in $array[$dynamic1]: {array.{dynamic1}}

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -43,7 +43,9 @@ $view->assignMultiple([
         $dynamic1 => 'Dynamic key in $array[$dynamic1]',
         $dynamic2 => 'Dynamic key in $array[$dynamic2]',
     ],
-    '123numericprefix' => 'Numeric prefixed variable'
+    '123numericprefix' => 'Numeric prefixed variable',
+    // A variable whose value refers to another variable name
+    'dynamicVariableName' => 'foobar'
 ]);
 
 // Assigning the template path and filename to be rendered. Doing this overrides

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -199,6 +199,7 @@ class ExamplesTest extends BaseTestCase
                     'String variable name with dynamic2 part: String using $dynamic2.',
                     'Array member in $array[$dynamic1]: Dynamic key in $array[$dynamic1]',
                     'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
+                    'Output of variable whose name is stored in a variable: string foo',
                     'Direct access of numeric prefixed variable: Numeric prefixed variable',
                     'Aliased access of numeric prefixed variable: Numeric prefixed variable',
                     'Received $array.foobar with value <b>Unescaped string</b>',


### PR DESCRIPTION
Adds an example of the Fluid-equivalent of PHP $$variable to output
the other variable identified by the value of the given, named variable.

Close: #213