### PR TITLE
[BUGFIX] Fix f:format.raw used with "value" argument

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -42,7 +42,7 @@ Direct access of numeric prefixed variable: {123numericprefix}
 </f:section>
 
 <f:section name="Secondary">
-Received $array.foobar with value {array.foobar -> f:format.raw()}
+Received $array.foobar with value {array.foobar -> f:format.raw()} (same using "value" argument: {f:format.raw(value: array.foobar)})
 Received $array.printf with formatted string {array.printf -> f:format.printf(arguments: {0: 'formatted'})}
 Received $array.baz with value {array.baz}
 Received $array.xyz.foobar with value {array.xyz.foobar}

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -88,6 +88,14 @@ class RawViewHelper extends AbstractViewHelper
      */
     public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
     {
-        return sprintf('%s()', $closureName);
+        $contentArgumentName = $this->resolveContentArgumentName();
+        return sprintf(
+            'isset(%s[\'%s\']) ? %s[\'%s\'] : %s()',
+            $argumentsName,
+            $contentArgumentName,
+            $argumentsName,
+            $contentArgumentName,
+            $closureName
+        );
     }
 }

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -201,7 +201,7 @@ class ExamplesTest extends BaseTestCase
                     'Array member in $array[$dynamic2]: Dynamic key in $array[$dynamic2]',
                     'Direct access of numeric prefixed variable: Numeric prefixed variable',
                     'Aliased access of numeric prefixed variable: Numeric prefixed variable',
-                    'Received $array.foobar with value <b>Unescaped string</b>',
+                    'Received $array.foobar with value <b>Unescaped string</b> (same using "value" argument: <b>Unescaped string</b>)',
                     'Received $array.printf with formatted string Formatted string, value: formatted',
                     'Received $array.baz with value 42',
                     'Received $array.xyz.foobar with value Escaped sub-string',


### PR DESCRIPTION
Since https://github.com/TYPO3/Fluid/pull/113, `f:format.raw` needs
a corresponding ternary condition in compiled template code because
it overrides the `compile()` method inherited by the Trait.

Close: #209