### PR TITLE
[FEATURE] Template source passthrough pre-processor

### DIFF
--- a/examples/Resources/Private/Singles/Passthrough.html
+++ b/examples/Resources/Private/Singles/Passthrough.html
@@ -1,0 +1,5 @@
+{parsing off}
+
+<f:section name="Main">
+    <f:format.raw>This does not get parsed; the source is passed through with Fluid markup</f:format.raw>
+</f:section>

--- a/examples/example_passthrough.php
+++ b/examples/example_passthrough.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * EXAMPLE: Parsing modifier
+ *
+ * This example shows you how to use the "parsing off"
+ * modifier in template files to disable all Fluid
+ * parsing. Useful when for example you want to render
+ * a template or partial file without processing it as
+ * Fluid, but still being able to render it (=reading
+ * and passing through) using `f:render`.
+ */
+
+require __DIR__ . '/include/view_init.php';
+
+// Assigning the template path and filename to be rendered. Doing this overrides
+// resolving normally done by the TemplatePaths and directly renders this file.
+$paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Passthrough.html');
+
+// Rendering the View: plain old rendering of single file, no bells and whistles.
+$output = $view->render();
+
+// Output using helper from view_init.php
+example_output($output);

--- a/src/Core/Parser/PassthroughSourceException.php
+++ b/src/Core/Parser/PassthroughSourceException.php
@@ -1,0 +1,38 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Exception which when thrown causes the template rendering
+ * to output the full source of the Fluid template file rather
+ * than allow it to be parsed.
+ *
+ * @api
+ */
+class PassthroughSourceException extends \TYPO3Fluid\Fluid\Core\Exception
+{
+    /**
+     * @var string
+     */
+    protected $source;
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @param string $source
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+    }
+}

--- a/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
@@ -1,0 +1,51 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\PassthroughSourceException;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * This template processor has a single purpose:
+ *
+ * When a template file contains the string `{parsing off}`, the processor
+ * throws an Exception instructing the parser to display the source instead
+ * of attempting to parse the template source.
+ *
+ * Doing so completely disables the parser and template splitting since it
+ * happens before the parser receives the source.
+ */
+class PassthroughSourceModifierTemplateProcessor implements TemplateProcessorInterface
+{
+    /**
+     * @param string $templateSource
+     * @return string
+     * @throws PassthroughSourceException
+     */
+    public function preProcessSource($templateSource)
+    {
+        if (strpos($templateSource, '{parsing off}') !== false) {
+            $templateSource = str_replace('{parsing off}', '', $templateSource);
+            $stopException = new PassthroughSourceException();
+            $stopException->setSource($templateSource);
+            throw $stopException;
+        } elseif (strpos($templateSource, '{parsing on}') !== false) {
+            return str_replace('{parsing on}', '', $templateSource);
+        }
+        return $templateSource;
+    }
+
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        // void
+    }
+}

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -15,6 +15,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\PassthroughSourceModifierTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
@@ -124,7 +125,12 @@ class RenderingContext implements RenderingContextInterface
         $this->setTemplateParser(new TemplateParser());
         $this->setTemplateCompiler(new TemplateCompiler());
         $this->setTemplatePaths(new TemplatePaths());
-        $this->setTemplateProcessors([new NamespaceDetectionTemplateProcessor()]);
+        $this->setTemplateProcessors(
+            [
+                new PassthroughSourceModifierTemplateProcessor(),
+                new NamespaceDetectionTemplateProcessor()
+            ]
+        );
         $this->setViewHelperResolver(new ViewHelperResolver());
         $this->setViewHelperInvoker(new ViewHelperInvoker());
         $this->setViewHelperVariableContainer(new ViewHelperVariableContainer());

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -229,6 +229,12 @@ class ExamplesTest extends BaseTestCase
                     'Cached as static text 2',
                     'Cached as static text 3',
                 ]
+            ],
+            'example_passthrough.php' => [
+                'example_passthrough.php',
+                [
+                    '<f:format.raw>This does not get parsed; the source is passed through with Fluid markup</f:format.raw>'
+                ]
             ]
         ];
     }


### PR DESCRIPTION
This adds a new pre-processor which handles a new type of
modifer in templates:

`{passthrough on}`

Which when enabled causes the template to be output instead
of parsed. This can then be used in partials, templates or layouts
to completely avoid parsing the template.

Useful if you have a piece of template code that collides with
Fluid's syntax - putting this code in a partial, enabling passthrough
and rendering that partial then outputs the source (and removes
the modifier itself).

Close: #219