### PR TITLE
[BUGFIX] Allow late static binding for renderStatic

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -45,7 +45,7 @@ trait CompileWithContentArgumentAndRenderStatic
      */
     public function render()
     {
-        return self::renderStatic(
+        return static::renderStatic(
             $this->arguments,
             $this->buildRenderChildrenClosure(),
             $this->renderingContext

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -24,7 +24,7 @@ trait CompileWithRenderStatic
      */
     public function render()
     {
-        return self::renderStatic(
+        return static::renderStatic(
             $this->arguments,
             call_user_func_array([$this, 'buildRenderChildrenClosure'], []),
             $this->renderingContext


### PR DESCRIPTION
Fixes usage of `self::` in Traits for ViewHelpers. Allows
the renderStatic method to be inherited from parents.