### PR TITLE
[TASK] Force renderChildrenClosure for CompileWithRenderStatic

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -26,10 +26,15 @@ trait CompileWithRenderStatic
     {
         return static::renderStatic(
             $this->arguments,
-            call_user_func_array([$this, 'buildRenderChildrenClosure'], []),
+            $this->buildRenderChildrenClosure(),
             $this->renderingContext
         );
     }
+
+    /**
+     * @return \Closure
+     */
+    protected abstract function buildRenderChildrenClosure();
 
     /**
      * @param string $argumentsName


### PR DESCRIPTION
Adds a contract to force the presence and signature of
the buildRenderChildrenClosure method on implementers
of CompileWithRenderStatic trait. And cleans up a
usage of call_user_func_array to call this method.