### PR TITLE
[BUGFIX] Make CompileWithContentArgumentAndRenderStatic compile closure

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -74,6 +74,17 @@ trait CompileWithContentArgumentAndRenderStatic
             ViewHelperCompiler::RENDER_STATIC,
             static::class
         );
+        $contentArgumentName = $this->resolveContentArgumentName();
+        $initializationPhpCode .= sprintf(
+            '%s = %s[\'%s\'] ? function() use (%s) { return %s[\'%s\']; } : %s;',
+            $closureName,
+            $argumentsName,
+            $contentArgumentName,
+            $argumentsName,
+            $argumentsName,
+            $contentArgumentName,
+            $closureName
+        );
         $initializationPhpCode .= $initialization;
         return $execution;
     }


### PR DESCRIPTION
To let the content argument trait work in compiled templates, yet
another fix is required which prepends the compiled initialisation
code with a custom closure that is either built on-the-fly or
reuses the existing render children closure if the content argument
was not set (=NULL) in the arguments array.