### PR TITLE
[TASK] Implement CompileWithRenderChildren on CycleViewHelper

### DIFF
--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper cycles through the specified values.
@@ -48,6 +49,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class CycleViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
     /**
      * @var boolean
      */
@@ -59,19 +62,8 @@ class CycleViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('values', 'array', 'The array or object implementing \ArrayAccess (for example \SplObjectStorage) to iterated over', false);
+        $this->registerArgument('values', 'array', 'The array or object implementing \ArrayAccess (for example \SplObjectStorage) to iterated over');
         $this->registerArgument('as', 'strong', 'The name of the iteration variable', true);
-    }
-
-    /**
-     * Renders cycle view helper
-     *
-     * @return string Rendered result
-     * @api
-     */
-    public function render()
-    {
-        return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
     }
 
     /**


### PR DESCRIPTION
Saves a duplicated `render()` method - low priority.