### PR TITLE
[TASK] Remove redundant example code

### DIFF
--- a/examples/example_namespaceresolving.php
+++ b/examples/example_namespaceresolving.php
@@ -9,10 +9,6 @@
  * namespace entry.
  */
 
-if (!defined('FLUID_CACHE_DIRECTORY')) {
-    define('FLUID_CACHE_DIRECTORY', __DIR__ . '/cache/');
-}
-
 require __DIR__ . '/include/view_init.php';
 require_once __DIR__ . '/include/class_customviewhelper.php';
 


### PR DESCRIPTION
One example file contains code which has been moved
to the view_init.php file in examples include folder. The
code should be removed from the example file.