### PR TITLE
[TASK] Remove never-reached line in DebugViewHelper

### DIFF
--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -117,8 +117,6 @@ class DebugViewHelper extends AbstractViewHelper
                     $typeLabel,
                     htmlspecialchars(var_export($variable, true), ENT_COMPAT, 'UTF-8', false)
                 );
-            } elseif (is_null($variable)) {
-                $string = 'null' . PHP_EOL;
             } else {
                 $string = sprintf('<code>%s</code>', $typeLabel);
                 if ($level > $levels) {


### PR DESCRIPTION
Removes a line that would never be reached; previous
condition includes the same check and would trigger
instead of the removed code.