### PR TITLE
[BUGFIX] Avoid iteration data in f:for without "iteration" argument

### DIFF
--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -93,7 +93,7 @@ class ForViewHelper extends AbstractViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
         $templateVariableContainer = $renderingContext->getVariableProvider();
-        if ($arguments['each'] === null) {
+        if (!isset($arguments['each'])) {
             return '';
         }
         if (is_object($arguments['each']) && !$arguments['each'] instanceof \Traversable) {
@@ -109,19 +109,21 @@ class ForViewHelper extends AbstractViewHelper
             }
             $arguments['each'] = array_reverse($arguments['each']);
         }
-        $iterationData = [
-            'index' => 0,
-            'cycle' => 1,
-            'total' => count($arguments['each'])
-        ];
+        if (isset($arguments['iteration'])) {
+            $iterationData = [
+                'index' => 0,
+                'cycle' => 1,
+                'total' => count($arguments['each'])
+            ];
+        }
 
         $output = '';
         foreach ($arguments['each'] as $keyValue => $singleElement) {
             $templateVariableContainer->add($arguments['as'], $singleElement);
-            if ($arguments['key'] !== null) {
+            if (isset($arguments['key'])) {
                 $templateVariableContainer->add($arguments['key'], $keyValue);
             }
-            if ($arguments['iteration'] !== null) {
+            if (isset($arguments['iteration'])) {
                 $iterationData['isFirst'] = $iterationData['cycle'] === 1;
                 $iterationData['isLast'] = $iterationData['cycle'] === $iterationData['total'];
                 $iterationData['isEven'] = $iterationData['cycle'] % 2 === 0;
@@ -132,10 +134,10 @@ class ForViewHelper extends AbstractViewHelper
             }
             $output .= $renderChildrenClosure();
             $templateVariableContainer->remove($arguments['as']);
-            if ($arguments['key'] !== null) {
+            if (isset($arguments['key'])) {
                 $templateVariableContainer->remove($arguments['key']);
             }
-            if ($arguments['iteration'] !== null) {
+            if (isset($arguments['iteration'])) {
                 $templateVariableContainer->remove($arguments['iteration']);
             }
         }

--- a/tests/Unit/ViewHelpers/Fixtures/CountableIterator.php
+++ b/tests/Unit/ViewHelpers/Fixtures/CountableIterator.php
@@ -1,0 +1,40 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Class CountableIterator
+ *
+ * Fixture for an iterator with a count() method.
+ */
+class CountableIterator implements \Iterator, \Countable
+{
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function count()
+    {
+    }
+
+}

--- a/tests/Unit/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ForViewHelperTest.php
@@ -9,6 +9,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\ConstraintSyntaxTreeNode;
+use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\CountableIterator;
 use TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper;
 
 /**
@@ -444,6 +445,33 @@ class ForViewHelperTest extends ViewHelperBaseTestcase
         $this->arguments['each'] = new \DateTime('now');
         $this->injectDependenciesIntoViewHelper($viewHelper);
         $this->setExpectedException(Exception::class);
+        $viewHelper->render();
+    }
+
+    /**
+     * @test
+     */
+    public function renderCountsSubjectIfIterationArgumentProvided()
+    {
+        $subject = $this->getMockBuilder(CountableIterator::class)->setMethods(['count'])->getMock();
+        $subject->expects($this->once())->method('count')->willReturn(1);
+        $viewHelper = new ForViewHelper();
+        $this->arguments['each'] = $subject;
+        $this->arguments['iteration'] = 'test';
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+        $viewHelper->render();
+    }
+    /**
+     * @test
+     */
+    public function renderDoesNotCountSubjectIfIterationArgumentNotProvided()
+    {
+        $subject = $this->getMockBuilder(CountableIterator::class)->setMethods(['count'])->getMock();
+        $subject->expects($this->never())->method('count');
+        $viewHelper = new ForViewHelper();
+        $this->arguments['each'] = $subject;
+        $this->arguments['iteration'] = null;
+        $this->injectDependenciesIntoViewHelper($viewHelper);
         $viewHelper->render();
     }
 }


### PR DESCRIPTION
Skip counting and other operations for iteration data when
the "iteration" argument is not set. Counting for example
QueryResult can be rather expensive so avoiding it whenever
possible makes good sense.

Also switches some `!== null` checks in favor of `isset()`,
which is done for consistency and to avoid potential e_notice.

Close: #243