### PR TITLE
[BUGFIX] Avoid count() when checking types with "[]" notation

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -361,10 +361,10 @@ abstract class AbstractViewHelper implements ViewHelperInterface
         } elseif ($type === 'array' || substr($type, -2) === '[]') {
             if (!is_array($value) && !$value instanceof \ArrayAccess && !$value instanceof \Traversable && !empty($value)) {
                 return false;
-            } elseif (count($value) > 0 && substr($type, -2) === '[]') {
+            } elseif (substr($type, -2) === '[]') {
                 $firstElement = $this->getFirstElementOfNonEmpty($value);
-                if ($firstElement == null) {
-                    return false;
+                if ($firstElement === null) {
+                    return true;
                 }
                 return $this->isValidType(substr($type, 0, -2), $firstElement);
             }

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -345,8 +345,7 @@ class AbstractViewHelperTest extends UnitTestCase
             [new ArgumentDefinition('test', 'DateTime', '', true), 'test'],
             [new ArgumentDefinition('test', 'integer', '', true), new \ArrayIterator(['bar'])],
             [new ArgumentDefinition('test', 'object', '', true), 'test'],
-            [new ArgumentDefinition('test', 'string[]', '', true), [new \DateTime('now'),'test']],
-            [new ArgumentDefinition('test', 'string[]', '', true), [null]],
+            [new ArgumentDefinition('test', 'string[]', '', true), [new \DateTime('now'),'test']]
         ];
     }
 


### PR DESCRIPTION
This prevents calling count() on argument to check validity
of first item. Cases where first value is "null" now means
that the value itself is valid (e.g. container is empty).