### PR TITLE
[BUGFIX] MathExpression not working with camel case variables

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -26,7 +26,7 @@ class MathExpressionNode extends AbstractExpressionNode
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
-					[a-zA-Z0-9\.]+[\s]?[*+\^\/\%\-]{1}[\s]?[a-zA-Z0-9\.]+   # Various math expressions left and right sides with any spaces
+					[a-zA-Z0-9\.]+(?:[\s]?[*+\^\/\%\-]{1}[\s]?[a-zA-Z0-9\.]+)+   # Various math expressions left and right sides with any spaces
 					|(?R)                    # Other expressions inside
 				)+
 			}                                # End of shorthand syntax

--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -42,7 +42,7 @@ class MathExpressionNode extends AbstractExpressionNode
     {
         // Split the expression on all recognized operators
         $matches = [];
-        preg_match_all('/([+\-*\^\/\%]|[a-z0-9\.]+)/s', $expression, $matches);
+        preg_match_all('/([+\-*\^\/\%]|[a-zA-Z0-9\.]+)/s', $expression, $matches);
         $matches[0] = array_map('trim', $matches[0]);
         // Like the BooleanNode, we dumb down the processing logic to not apply
         // any special precedence on the priority of operators. We simply process


### PR DESCRIPTION
Adjust the regular expression to allow camel case variable names.