### PR TITLE
[FEATURE] Add variable assigning ViewHelper

### DIFF
--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -1,0 +1,64 @@
+<?php
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Variable assigning ViewHelper
+ *
+ * Assigns one template variable which will exist also
+ * after the ViewHelper is done rendering, i.e. adds
+ * template variables.
+ *
+ * If you require a variable assignment which does not
+ * exist in the template after a piece of Fluid code
+ * is rendered, consider using `f:alias` instead.
+ *
+ * Usages:
+ *
+ *     {f:variable(name: 'myvariable', value: 'some value')}
+ *     <f:variable name="myvariable">some value</f:variable>
+ *     {oldvariable -> f:format.htmlspecialchars() -> f:variable(name: 'newvariable')}
+ *     <f:variable name="myvariable"><f:format.htmlspecialchars>{oldvariable}</f:format.htmlspecialchars></f:variable>
+ *
+ * @see \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
+ * @api
+ */
+class VariableViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('value', 'mixed', 'Value to assign. If not in arguments then taken from tag content');
+        $this->registerArgument('name', 'string', 'Name of variable to create', true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return null
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $value = $renderChildrenClosure();
+        $renderingContext->getVariableProvider()->add($arguments['name'], $value);
+    }
+
+}

--- a/tests/Unit/ViewHelpers/VariableViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/VariableViewHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\ViewHelpers\VariableViewHelper;
+
+/**
+ * Testcase for VariableViewHelper
+ */
+class VariableViewHelperTest extends ViewHelperBaseTestcase
+{
+
+    /**
+     * @test
+     */
+    public function assignsVariableInVariableProvider()
+    {
+        $variableProvider = $this->getMockBuilder(StandardVariableProvider::class)->setMethods(['add'])->getMock();
+        $variableProvider->expects($this->once())->method('add')->with('name', 'value');
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->setVariableProvider($variableProvider);
+        VariableViewHelper::renderStatic(['name' => 'name', 'value' => null], function() { return 'value'; }, $renderingContext);
+    }
+
+}


### PR DESCRIPTION
New ViewHelper `f:variable` with arguments "name"
and "value", assigns a variable in the VariableProvider
using the `add()` method and does not remove the
variable again afterwards.

Usages:

    {f:variable(name: 'myvariable', value: 'some value')}
    <f:variable name="myvariable">some value</f:variable>
    {oldvariable -> f:format.htmlspecialchars() -> f:variable(name: 'newvariable')}
    <f:variable name="myvariable"><f:format.htmlspecialchars>{oldvariable}</f:format.htmlspecialchars></f:variable>