### PR TITLE
[BUGFIX] Cache did not flush when compiler disabled

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -176,9 +176,10 @@ class TemplateCompiler
     public function store($identifier, ParsingState $parsingState)
     {
         if ($this->isDisabled()) {
-            if ($this->renderingContext->isCacheEnabled()) {
+            $cache = $this->renderingContext->getCache();
+            if ($cache) {
                 // Compiler is disabled but cache is enabled. Flush cache to make sure.
-                $this->renderingContext->getCache()->flush($identifier);
+                $cache->flush($identifier);
             }
             $parsingState->setCompilable(false);
             return;

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -156,11 +156,14 @@ class TemplateCompilerTest extends UnitTestCase
      */
     public function testStoreWhenDisabledFlushesCache()
     {
-        $renderingContext = new RenderingContextFixture();
+        $cacheMock = $this->getMockBuilder(SimpleFileCache::class)->setMethods(['flush'])->getMock();
+        $cacheMock->expects($this->once())->method('flush');
+        $renderingContext = $this->getMockBuilder(RenderingContextFixture::class)->setMethods(['isCacheEnabled', 'getCache'])->getMock();
+        $renderingContext->expects($this->once())->method('isCacheEnabled')->willReturn(false);
+        $renderingContext->expects($this->once())->method('getCache')->willReturn($cacheMock);
         $state = new ParsingState();
-        $instance = $this->getAccessibleMock(TemplateCompiler::class);
-        $instance->_set('renderingContext', $renderingContext);
-        $instance->_set('disabled', true);
+        $instance = new TemplateCompiler();
+        $instance->setRenderingContext($renderingContext);
         $instance->store('fakeidentifier', $state);
     }
 


### PR DESCRIPTION
A previous refactoring changed isDisabled() on
TemplateCompiler, causing the condition which
would normally flush the cache to remove the
current template, if the template is uncompilable
(read: was compiled, then became uncompilable)