### PR TITLE
[FEATURE] Add Hide ViewHelper

### DIFF
--- a/src/ViewHelpers/Format/HideViewHelper.php
+++ b/src/ViewHelpers/Format/HideViewHelper.php
@@ -1,0 +1,56 @@
+<?php
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Hides, but still executes, the tag content.
+ *
+ * Useful when you have Fluid code that you want to execute
+ * but do not wish to output. For example, around variable
+ * assignments to remove resulting whitespace.
+ *
+ * = Examples =
+ *
+ * <code title="Hiding output">
+ * <f:format.hide>
+ *      <!-- Everything inside the tag is executed but not output -->
+ *      <!--
+ *          Which menas that among other things, you can use HTML
+ *          comments which will not be output but are visible to
+ *          developers reading the template source code.
+ *      -->
+ *      {string -> f:format.htmlspecialchars() -> f:variable(name: 'newvariable')}
+ * </f:format.hide>
+ * </code>
+ * <output>
+ * (Content of {string} without any conversion/escaping)
+ * </output>
+ *
+ * @api
+ */
+class HideViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $renderChildrenClosure();
+    }
+
+}

--- a/tests/Unit/ViewHelpers/Format/HideViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/HideViewHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Format;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\ViewHelpers\Format\HideViewHelper;
+use TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper;
+
+/**
+ * Test for \TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper
+ */
+class HideViewHelperTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function executesButDoesNotOutput()
+    {
+        $object = new \stdClass();
+        $object->touched = false;
+        $closure = function() use ($object) {
+            $object->touched = true;
+            return 'mustnotbeseen';
+        };
+        $actualResult = HideViewHelper::renderStatic([], $closure, new RenderingContextFixture());
+        $this->assertNull($actualResult, 'HideViewHelper caused vislble output');
+        $this->assertTrue($object->touched, 'HideViewHelper did not execute renderchildren closure');
+    }
+}


### PR DESCRIPTION
Adds a new ViewHelper which executes but does
not output anything in the tag content.

Inspired by the "Nothing" formatting ViewHelper
from the TYPO3 extension "news".