### PR TITLE
[BUGFIX] Allow renderSection() to be called directly

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -169,6 +169,16 @@ class TemplateCompiler
     }
 
     /**
+     * Resets the currently processing state
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->currentlyProcessingState = null;
+    }
+
+    /**
      * @param string $identifier
      * @param ParsingState $parsingState
      * @return void


### PR DESCRIPTION
Refactors AbstractTemplateView slightly so that
the parsed template reading code can be called
from both render() and renderSection(), causing
the template to be loaded correctly.

Without this patch it is not possible to call
renderSection() via the View's API without getting
an error that no parsed template exists.

Also adds a public method on TemplateCompiler
to reset the current processing state.