### PR TITLE
[BUGFIX] Convert bool arguments into BooleanNodes

### DIFF
--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -164,7 +164,8 @@ class ViewHelperNode extends AbstractNode
     {
         /** @var $argumentDefinition ArgumentDefinition */
         foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
-            if ($argumentDefinition->getType() === 'boolean' && isset($argumentsObjectTree[$argumentName])) {
+            if (($argumentDefinition->getType() === 'boolean' || $argumentDefinition->getType() === 'bool')
+                 && isset($argumentsObjectTree[$argumentName])) {
                 $argumentsObjectTree[$argumentName] = new BooleanNode($argumentsObjectTree[$argumentName]);
             }
         }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -8,6 +8,8 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
@@ -122,5 +124,30 @@ class ViewHelperNodeTest extends UnitTestCase
         $mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
         // dummy assertion to avoid "did not perform any assertions" error
         $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     * @group foo
+     */
+    public function booleanArgumentsMustBeConvertedIntoBooleanNodes()
+    {
+        $argumentDefinitions = [
+            'var1' => new ArgumentDefinition('var1', 'bool', 'desc', false),
+            'var2' => new ArgumentDefinition('var2', 'boolean', 'desc', false)
+        ];
+        $argumentsObjectTree = [
+            'var1' => new TextNode('true'),
+            'var2' => new TextNode('true')
+        ];
+
+        $mockTemplateParser = $this->getAccessibleMock(ViewHelperNode::class, ['dummy'], [], '', false);
+
+        $mockTemplateParser->_callRef('rewriteBooleanNodesInArgumentsObjectTree', $argumentDefinitions, $argumentsObjectTree);
+
+        $this->assertEquals($argumentsObjectTree, [
+            'var1' => new BooleanNode(new TextNode('true')),
+            'var2' => new BooleanNode(new TextNode('true'))
+        ]);
     }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -128,7 +128,6 @@ class ViewHelperNodeTest extends UnitTestCase
 
     /**
      * @test
-     * @group foo
      */
     public function booleanArgumentsMustBeConvertedIntoBooleanNodes()
     {


### PR DESCRIPTION
Currently only the argument type „boolean“ got converted into the proper BooleanNode, causing arguments defined as „bool“ to be passed as TextNodes instead of BooleanNode.

closes #253 