### PR TITLE
[BUGFIX] Disable variable extractors

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -445,12 +445,7 @@ class TemplateParser
 
         // Object Accessor
         if (strlen($objectAccessorString) > 0) {
-            if ($state->isCompilable() && !$state->isCompiled()) {
-                $accessors = VariableExtractor::extractAccessors($state->getVariableContainer(), $objectAccessorString);
-            } else {
-                $accessors = [];
-            }
-            $node = new ObjectAccessorNode($objectAccessorString, $accessors);
+            $node = new ObjectAccessorNode($objectAccessorString);
             $this->callInterceptor($node, InterceptorInterface::INTERCEPT_OBJECTACCESSOR, $state);
             $state->getNodeFromStack()->addChildNode($node);
         }


### PR DESCRIPTION
Although this means a minor performance hit in compiled
templates in particular, we drop the variable extraction method
detection temporarily.

The extractor detection will be restored in another and much
larger pull request which will also merge the variable extraction
detection and the extraction logic into VariableProvider rather
than forcing use of Fluid's VariableExtractor.

Close: #255