### PR TITLE
[WIP][TASK] Refactor condition ViewHelper logic

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -24,14 +24,13 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * <[aConditionViewHelperName] .... then="condition true" else="condition false" />,
  * or as well use the "then" and "else" child nodes.
  *
- * @see TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper for a more detailed explanation and a simple usage example.
+ * @see \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper for a more detailed explanation and a simple usage example.
  * Make sure to NOT OVERRIDE the constructor.
  *
  * @api
  */
 abstract class AbstractConditionViewHelper extends AbstractViewHelper
 {
-
     /**
      * @var boolean
      */
@@ -44,7 +43,6 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
     {
         $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
         $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
-        $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
     }
 
     /**
@@ -60,13 +58,24 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * subclasses that will be using this base class in the future. Let this
      * be a warning if someone considers changing this method signature!
      *
-     * @param array|NULL $arguments
+     * @param array $arguments
      * @return boolean
      * @api
      */
-    protected static function evaluateCondition($arguments = null)
+    abstract protected static function evaluateCondition($arguments = null);
+
+    /**
+     * Renders <f:then> child if condition is true, otherwise renders <f:else> child.
+     *
+     * @return string the rendered string
+     */
+    public function render()
     {
-        return (boolean) $arguments['condition'];
+        if (static::evaluateCondition($this->arguments)) {
+            return $this->renderThenChild();
+        } else {
+            return $this->renderElseChild();
+        }
     }
 
     /**
@@ -90,14 +99,14 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         } elseif (array_key_exists('else', $arguments)) {
             return $arguments['else'];
         }
-        return '';
+        return null;
     }
 
     /**
      * @param array $closures
      * @param array $conditionClosures
      * @param RenderingContextInterface $renderingContext
-     * @return string
+     * @return mixed
      */
     private static function evaluateElseClosures(array $closures, array $conditionClosures, RenderingContextInterface $renderingContext)
     {
@@ -110,7 +119,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                 }
             }
         }
-        return '';
+        return null;
     }
 
     /**

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -83,17 +83,25 @@ class IfViewHelper extends AbstractConditionViewHelper
 {
 
     /**
-     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+     * Initializes the "then" and "else" arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
+    }
+
+    /**
+     * Simplest of all possible evaluations - returns true if the
+     * boolean argument in "condition" is true.
      *
-     * @return string the rendered string
+     * @param array|NULL $arguments
+     * @return boolean
      * @api
      */
-    public function render()
+    protected static function evaluateCondition($arguments = null)
     {
-        if ($this->arguments['condition']) {
-            return $this->renderThenChild();
-        } else {
-            return $this->renderElseChild();
-        }
+        return (boolean) $arguments['condition'];
     }
+
 }

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -15,6 +15,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3Fluid\Fluid\ViewHelpers\ElseViewHelper;
+use TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper;
 use TYPO3Fluid\Fluid\ViewHelpers\ThenViewHelper;
 
 /**
@@ -31,7 +32,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function setUp()
     {
         parent::setUp();
-        $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['renderChildren', 'hasArgument']);
+        $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['renderChildren', 'hasArgument', 'evaluateCondition']);
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
     }
 
@@ -109,10 +110,10 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRenderFromArgumentsReturnsExpectedValue(array $arguments, $expected)
     {
-        $viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['dummy']);
+        $viewHelper = $this->getMockBuilder(IfViewHelper::class)->setMethods(['dummy'])->getMock();
         $viewHelper->setArguments($arguments);
         $viewHelper->setViewHelperNode(new ViewHelperNode($this->renderingContext, 'f', 'if', [], new ParsingState()));
-        $result = AbstractConditionViewHelper::renderStatic($arguments, function () {
+        $result = IfViewHelper::renderStatic($arguments, function () {
             return '';
         }, $this->renderingContext);
         $this->assertEquals($expected, $result);
@@ -310,9 +311,10 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRenderStatic(array $arguments, $expected)
     {
-        $this->viewHelper->setArguments($arguments);
+        $subject = $this->getMockBuilder(IfViewHelper::class)->setMethods(['dummy'])->getMock();
+        $subject->setArguments($arguments);
         $result = call_user_func_array(
-            [$this->viewHelper, 'renderStatic'],
+            [$subject, 'renderStatic'],
             [$arguments, function () {
                 return '';
             }, new RenderingContextFixture()]


### PR DESCRIPTION
This patch makes a few but breaking changes to the
way AbstractConditionViewHelper and implementations
function. The following is changed:

* Method `render` is now delared on AbstractConditionViewHelper
   and removed from IfViewHelper. Implementers of the
   AbstractConditionViewHelper class no longer need to
   implement a `render` method - `evaluateCondition` is
   enough; and if necessary, additional/other VH arguments.
* Method `evaluateCondition` is now declared abstract
   on AbstractConditionViewHelper, meaning that any
   implementations must implement this method.
* Argument `condition` is no longer automatically added
   by subclassing AbstractConditionViewHelper. This
   argument is instead added by implementations, which
   must also call `parent::initializeArguments` to gain "then"
   and "else" argument support. The "then" and "else"
   arguments are in addition now optional (but `f:then` and
   `f:else` node support is forced).
* Implementations of AbstractConditionViewHelper can now
   implement any argument as condition (file for "file exists",
   haystack and needle for "string contains", and so on).

The change is breaking to any implementations of the
AbstractConditionViewHelper class which 1) do not declare
an `evaluateCondition` method and/or 2) overrides arguments
initialisation without calling `parent::initializeArguments` or
finally, 3) assumes that `condition` argument gets passed but
does not explicitly declare it as argument.

Subclasses of IfViewHelper are not prone to this problem.
Should you need a quick fix for your custom condition VH then
simply switching parent class to IfViewHelper should in most
cases make your subclass work again.