### PR TITLE
[BUGFIX] Remove detected {namespace} declarations

### DIFF
--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -117,6 +117,9 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
             }
             $viewHelperResolver->addNamespace($identifier, $namespace);
         }
+        foreach ($namespaces[0] as $removal) {
+            $templateSource = str_replace($removal, '', $templateSource);
+        }
     }
 
     /**


### PR DESCRIPTION
This patch removes all {namespace} declarations after
they have been detected, thus preventing them from
being output when rendering the template which does
not use sections but contains {namespace} declarations.