### PR TITLE
[BUGFIX] Handle potential array input in sanitizePath method

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -395,12 +395,15 @@ class TemplatePaths
      * Sanitize a path, ensuring it is absolute and
      * if a directory, suffixed by a trailing slash.
      *
-     * @param string $path
+     * @param string|array $path
      * @return string
      */
     protected function sanitizePath($path)
     {
-        if (strpos($path, 'php://') === 0) {
+        if (is_array($path)) {
+            $paths = array_map([$this, 'sanitizePath'], $path);
+            return array_unique($paths);
+        } elseif (strpos($path, 'php://') === 0) {
             return $path;
         } elseif (!empty($path)) {
             $path = str_replace(['\\', '//'], '/', (string) $path);


### PR DESCRIPTION
Since the method does not explicitly require nor check for
a string being passed, a check is added to detect arrays
and call `array_map` to (recursively) sanitize each path.