### PR TITLE
[FEATURE] Add escaping modifier pre-processor

### DIFF
--- a/examples/Resources/Private/Partials/EscapingModifierPartial.html
+++ b/examples/Resources/Private/Partials/EscapingModifierPartial.html
@@ -1,0 +1,2 @@
+{escaping off}
+From partial: {html}

--- a/examples/Resources/Private/Singles/EscapingModifier.html
+++ b/examples/Resources/Private/Singles/EscapingModifier.html
@@ -1,0 +1,10 @@
+{escaping off}
+<f:layout name="Default" />
+
+<f:section name="Main">
+Escaping is disabled!
+Value of "html": {html}.
+
+Rendering of partial:
+<f:render partial="EscapingModifierPartial" arguments="{html: html}" />
+</f:section>

--- a/examples/example_escapingmodifier.php
+++ b/examples/example_escapingmodifier.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * EXAMPLE: Use of escaping modifier
+ *
+ * This example shows how to use the `{escaping on|off|true|false}`
+ * modifier in templates. Using the modifier switches escaping off
+ * for the entire template file parsing.
+ */
+
+require __DIR__ . '/include/view_init.php';
+
+// Assigning View variables: one variable containing HTML
+$view->assign('html', '<strong>This is not escaped</strong>');
+
+// Assigning the template path and filename to be rendered. Doing this overrides
+// resolving normally done by the TemplatePaths and directly renders this file.
+$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/EscapingModifier.html');
+
+// Rendering the View: we don't specify the optional `$action` parameter for the
+// `render()` method - and internally, the View doesn't try to resolve an action
+// name because an action is irrelevant when rendering a file directly.
+$output = $view->render();
+
+// Output using helper from view_init.php
+example_output($output);

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -7,7 +7,6 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  */
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
-use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionNodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
@@ -17,8 +16,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 
 /**
  * Template parser building up an object syntax tree
@@ -95,6 +92,23 @@ class TemplateParser
     public function getCurrentParsingPointers()
     {
         return [$this->pointerLineNumber, $this->pointerLineCharacter, $this->pointerTemplateCode];
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEscapingEnabled()
+    {
+        return $this->escapingEnabled;
+    }
+
+    /**
+     * @param boolean $escapingEnabled
+     * @return void
+     */
+    public function setEscapingEnabled($escapingEnabled)
+    {
+        $this->escapingEnabled = (boolean) $escapingEnabled;
     }
 
     /**

--- a/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
@@ -1,0 +1,71 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
+
+/*
+ * This file is part of the Neos.FluidAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Preprocessor to detect the "escapingEnabled" inline flag in a template.
+ */
+class EscapingModifierTemplateProcessor implements TemplateProcessorInterface
+{
+    /**
+     * @var RenderingContextInterface
+     */
+    protected $renderingContext;
+
+    const SCAN_PATTERN_ESCAPINGMODIFIER = '/{(escaping|escapingEnabled)\s*=*\s*(true|false|on|off)\s*}/i';
+
+    /**
+     * @param RenderingContextInterface $renderingContext
+     */
+    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    {
+        $this->renderingContext = $renderingContext;
+    }
+
+    /**
+     * Pre-process the template source before it is
+     * returned to the TemplateParser or passed to
+     * the next TemplateProcessorInterface instance.
+     *
+     * @param string $templateSource
+     * @return string
+     */
+    public function preProcessSource($templateSource)
+    {
+        if (strpos($templateSource, '{escaping') === false) {
+            // No escaping modifier detected - early return to skip preg processing
+            return $templateSource;
+        }
+        $matches = [];
+        preg_match_all(static::SCAN_PATTERN_ESCAPINGMODIFIER, $templateSource, $matches, PREG_SET_ORDER);
+        if ($matches === []) {
+            return $templateSource;
+        }
+        if (count($matches) > 1) {
+            throw new Exception(
+                'There is more than one escaping modifier defined. There can only be one {escapingEnabled=...} per template.',
+                1407331080
+            );
+        }
+        if (strtolower($matches[0][2]) === 'false' || strtolower($matches[0][2]) === 'off') {
+            $this->renderingContext->getTemplateParser()->setEscapingEnabled(false);
+        }
+
+        $templateSource = str_replace($matches[0][0], '', $templateSource);
+
+        return $templateSource;
+    }
+}

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -14,6 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\PassthroughSourceModifierTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
@@ -127,6 +128,7 @@ class RenderingContext implements RenderingContextInterface
         $this->setTemplatePaths(new TemplatePaths());
         $this->setTemplateProcessors(
             [
+                new EscapingModifierTemplateProcessor(),
                 new PassthroughSourceModifierTemplateProcessor(),
                 new NamespaceDetectionTemplateProcessor()
             ]

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -172,6 +172,13 @@ class ExamplesTest extends BaseTestCase
                     'Value of "foobar": Single template'
                 ]
             ],
+            'example_escapingmodifier.php' => [
+                'example_escapingmodifier.php',
+                [
+                    'Value of "html": <strong>This is not escaped</strong>',
+                    'From partial: <strong>This is not escaped</strong>',
+                ]
+            ],
             'example_structures.php' => [
                 'example_structures.php',
                 [

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -73,6 +73,17 @@ class TemplateParserTest extends UnitTestCase
     /**
      * @test
      */
+    public function testPublicGetAndSetEscapingEnabledWorks()
+    {
+        $subject = new TemplateParser();
+        $default = $subject->isEscapingEnabled();
+        $subject->setEscapingEnabled(!$default);
+        $this->assertAttributeSame(!$default, 'escapingEnabled', $subject);
+    }
+
+    /**
+     * @test
+     */
     public function testBuildObjectTreeThrowsExceptionOnUnclosedViewHelperTag()
     {
         $renderingContext = new RenderingContextFixture();

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProcessor;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+
+/**
+ * Testcase for EscapingModifierTemplateProcessor
+ */
+class EscapingModifierTemplateProcessorTest extends UnitTestCase
+{
+
+    /**
+     * @dataProvider getEscapingTestValues
+     * @param string $templateSource
+     * @param boolean $expected
+     */
+    public function testSetsEscapingToExpectedValueAndStripsModifier($templateSource, $expected)
+    {
+        $subject = new EscapingModifierTemplateProcessor();
+        $context = new RenderingContextFixture();
+        $parser = $this->getMockBuilder(TemplateParser::class)->setMethods(['setEscapingEnabled'])->getMock();
+        if (!$expected) {
+            $parser->expects($this->once())->method('setEscapingEnabled')->with(false);
+        } else {
+            $parser->expects($this->never())->method('setEscapingEnabled');
+        }
+        $context->setTemplateParser($parser);
+        $subject->setRenderingContext($context);
+        $processedSource = $subject->preProcessSource($templateSource);
+        $this->assertNotContains('{escaping', $processedSource);
+    }
+
+    /**
+     * @return array
+     */
+    public function getEscapingTestValues()
+    {
+        return [
+            [
+                '{escaping on}', true,
+                '{escaping = on}', true,
+                '{escaping=on}', true,
+                '{escaping off}', false,
+                '{escaping = off}', false,
+                '{escaping=off}', false,
+                '{escapingEnabled on}', true,
+                '{escapingEnabled = on}', true,
+                '{escapingEnabled=on}', true,
+                '{escapingEnabled off}', false,
+                '{escapingEnabled = off}', false,
+                '{escapingEnabled=off}', false,
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorTestValues
+     * @param string $templateSource
+     */
+    public function testThrowsExceptionOnMultipleDefinitions($templateSource)
+    {
+        $subject = new EscapingModifierTemplateProcessor();
+        $context = new RenderingContextFixture();
+        $parser = $this->getMockBuilder(TemplateParser::class)->setMethods(['setEscapingEnabled'])->getMock();
+        $context->setTemplateParser($parser);
+        $subject->setRenderingContext($context);
+        $this->setExpectedException(Exception::class);
+        $subject->preProcessSource($templateSource);
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrorTestValues()
+    {
+        return [
+            [
+                '{escapingEnabled off}' . PHP_EOL . '{escapingEnabled off}',
+                '{escapingEnabled on}' . PHP_EOL . '{escapingEnabled on}',
+                '{escapingEnabled on}' . PHP_EOL . '{escapingEnabled off}',
+                '{escaping off}' . PHP_EOL . '{escaping off}',
+                '{escaping off}' . PHP_EOL . '{escaping true}',
+                '{escaping off}' . PHP_EOL . '{escaping false}',
+            ]
+        ];
+    }
+
+}


### PR DESCRIPTION
This patch adds support for disabling escaping throughout
an entire template file. This is done by using:

```
{escaping off}
```

In a template, layout or partial. When toggled off it
causes the template parser to skip escaping of all
outputs from ViewHelpers, variable outputs etc.

For legacy reasons the feature is added with backwards
compatibility for the original escaping modifier which
was introduced in Flow. Therefore, the following values
are all equally possible and mean the same:

```
{escaping off}
{escapingEnabled off}
{escaping false}
{escaping=false}
{escaping=off}
{escaping = off}
{escapingEnabled = off}
{escapingEnabled = false}
{escapingEnabled off}
{escapingEnabled false}
```

While it is possible to set a `true` value for the modifier,
this simply gets ignored (because escaping is the default).