### PR TITLE
[BUGFIX] Reset compiler after each render operation

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -324,6 +324,7 @@ abstract class AbstractTemplateView extends AbstractView
      */
     protected function stopRendering()
     {
+        $this->getCurrentRenderingContext()->getTemplateCompiler()->reset();
         array_pop($this->renderingStack);
     }
 
@@ -364,7 +365,6 @@ abstract class AbstractTemplateView extends AbstractView
         if ($parsedTemplate->isCompiled()) {
             $parsedTemplate->addCompiledNamespaces($this->baseRenderingContext);
         }
-        $renderingContext->getTemplateCompiler()->reset();
         return $parsedTemplate;
     }
 

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -211,7 +211,7 @@ class AbstractTemplateViewTest extends UnitTestCase
             true,
             ['getCurrentParsedTemplate', 'getCurrentRenderingType', 'getCurrentRenderingContext']
         );
-        $view->expects($this->once())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
+        $view->expects($this->atLeastOnce())->method('getCurrentRenderingContext')->willReturn($this->renderingContext);
         $view->expects($this->once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
         $view->expects($this->once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
         $view->renderSection('Section', [], true);


### PR DESCRIPTION
Prevents issues where calling renderSection multiple
times caused incorrect results because TemplateCompiler
holds on to the first parsed template.

By resetting the compiler in stopRendering() we ensure
that we have a fresh scope when a user calls render,
renderPartial or renderSection multiple times on the
same View instance.