### PR TITLE
[BUGFIX] PHP warning with "empty" namespaces

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -89,7 +89,7 @@ class ViewHelperResolver
             $this->namespaces[$identifier] = $phpNamespace === null ? null : (array) $phpNamespace;
         } elseif (is_array($phpNamespace)) {
             $this->namespaces[$identifier] = array_unique(array_merge($this->namespaces[$identifier], $phpNamespace));
-        } elseif (!in_array($phpNamespace, $this->namespaces[$identifier])) {
+        } elseif (isset($this->namespaces[$identifier]) && !in_array($phpNamespace, $this->namespaces[$identifier])) {
             $this->namespaces[$identifier][] = $phpNamespace;
         }
     }


### PR DESCRIPTION
Check if the namespace identifier exists and is not null before calling
in_array to avoid php warnings.

This is necessary to successfully work with construct like
```xml
{namespace content}
....
<content:encoded>
...
</content:encoded>
```
This is used in templates for rss feeds.