### PR TITLE
[BUGFIX] Don't render else-child if its "if" condition evaluates to "false"

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -168,8 +168,10 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
             if ($childNode instanceof ViewHelperNode
                 && substr($childNode->getViewHelperClassName(), -14) === 'ElseViewHelper') {
                 $arguments = $childNode->getArguments();
-                if (isset($arguments['if']) && $arguments['if']->evaluate($this->renderingContext)) {
-                    return $childNode->evaluate($this->renderingContext);
+                if (isset($arguments['if'])) {
+                    if ($arguments['if']->evaluate($this->renderingContext)) {
+                        return $childNode->evaluate($this->renderingContext);
+                    }
                 } else {
                     $elseNode = $childNode;
                 }

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -254,6 +254,21 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     /**
      * @test
      */
+    public function renderElseChildReturnsEmptyStringIfConditionIsFalseAndElseViewHelperChildIfArgumentConditionIsFalseToo()
+    {
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'getArguments', 'evaluate'], [], '', false);
+        $mockElseViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
+        $mockElseViewHelperNode->expects($this->at(1))->method('getArguments')->will($this->returnValue(['if' => new BooleanNode(false)]));
+        $mockElseViewHelperNode->expects($this->never())->method('evaluate');
+
+        $this->viewHelper->setChildNodes([$mockElseViewHelperNode]);
+        $actualResult = $this->viewHelper->_call('renderElseChild');
+        $this->assertEquals('', $actualResult);
+    }
+
+    /**
+     * @test
+     */
     public function thenArgumentHasPriorityOverChildNodesIfConditionIsTrue()
     {
         $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate', 'setRenderingContext'], [], '', false);


### PR DESCRIPTION
This simple example should render an empty string because the `condition` argument of the `f:if` tag evaluates to `false` and the `if` argument of the `f:else` tag evaluates to `false` too.
```html
<f:if condition="0">
	<f:then>Not true</f:then>
	<f:else if="0">Not true either!</f:else>
</f:if>
```
But the last else-child in a conditional view helper was rendered regardless of the outcome of its "if" condition in a non-compiled (i.e. the first) run. The compiled code seems to work fine, though.

Fixes #284 