### PR TITLE
[TASK] Discontinue HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ php:
   - 5.6
   - 7
   - 7.1
-  - hhvm
 
 before_install:
   - composer self-update


### PR DESCRIPTION
HHVM is no longer supported by testing framework
(and not very popular since the arrival of PHP7+).

This patch disables testing; manifest of tested PHP
versions designate officially supported versions.