### PR TITLE
[FEATURE] Add TagGenerating trait and TagViewHelper

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -76,18 +76,12 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     }
 
     /**
-     * Sets the tag name to $this->tagName.
-     * Additionally, sets all tag attributes which were registered in
-     * $this->tagAttributes and additionalArguments.
-     *
-     * Will be invoked just before the render method.
-     *
-     * @return void
-     * @api
+     * @param array $arguments
      */
-    public function initialize()
+    public function setArguments(array $arguments)
     {
-        parent::initialize();
+        $this->tag->reset();
+        parent::setArguments($arguments);
         if ($this->hasArgument('additionalAttributes') && is_array($this->arguments['additionalAttributes'])) {
             $this->tag->addAttributes($this->arguments['additionalAttributes']);
         }

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -47,7 +47,7 @@ class TagBuilder
      * Constructor
      *
      * @param string $tagName name of the tag to be rendered
-     * @param string $tagContent content of the tag to be rendered
+     * @param string|\Closure $tagContent content of the tag to be rendered
      * @api
      */
     public function __construct($tagName = '', $tagContent = '')
@@ -60,12 +60,13 @@ class TagBuilder
      * Sets the tag name
      *
      * @param string $tagName name of the tag to be rendered
-     * @return void
+     * @return TagBuilder
      * @api
      */
     public function setTagName($tagName)
     {
         $this->tagName = $tagName;
+        return $this;
     }
 
     /**
@@ -83,12 +84,13 @@ class TagBuilder
      * Sets the content of the tag
      *
      * @param string $tagContent content of the tag to be rendered
-     * @return void
+     * @return TagBuilder
      * @api
      */
     public function setContent($tagContent)
     {
         $this->content = $tagContent;
+        return $this;
     }
 
     /**
@@ -121,11 +123,13 @@ class TagBuilder
      * E.g. <textarea> cant be self-closing even if its empty
      *
      * @param boolean $forceClosingTag
+     * @return TagBuilder
      * @api
      */
     public function forceClosingTag($forceClosingTag)
     {
         $this->forceClosingTag = $forceClosingTag;
+        return $this;
     }
 
     /**
@@ -188,7 +192,7 @@ class TagBuilder
      *
      * @param array $attributes collection of attributes to add. key = attribute name, value = attribute value
      * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute values#
-     * @return void
+     * @return TagBuilder
      * @api
      */
     public function addAttributes(array $attributes, $escapeSpecialCharacters = true)
@@ -196,24 +200,26 @@ class TagBuilder
         foreach ($attributes as $attributeName => $attributeValue) {
             $this->addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters);
         }
+        return $this;
     }
 
     /**
      * Removes an attribute from the $attributes-collection
      *
      * @param string $attributeName name of the attribute to be removed from the tag
-     * @return void
+     * @return TagBuilder
      * @api
      */
     public function removeAttribute($attributeName)
     {
         unset($this->attributes[$attributeName]);
+        return $this;
     }
 
     /**
      * Resets the TagBuilder by setting all members to their default value
      *
-     * @return void
+     * @return TagBuilder
      * @api
      */
     public function reset()
@@ -222,6 +228,7 @@ class TagBuilder
         $this->content = '';
         $this->attributes = [];
         $this->forceClosingTag = false;
+        return $this;
     }
 
     /**
@@ -240,7 +247,7 @@ class TagBuilder
             $output .= ' ' . $attributeName . '="' . $attributeValue . '"';
         }
         if ($this->hasContent() || $this->forceClosingTag) {
-            $output .= '>' . $this->content . '</' . $this->tagName . '>';
+            $output .= '>' . (is_callable($this->content) ? call_user_func($this->content) : $this->content) . '</' . $this->tagName . '>';
         } else {
             $output .= ' />';
         }

--- a/src/Core/ViewHelper/Traits/TagGenerating.php
+++ b/src/Core/ViewHelper/Traits/TagGenerating.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
+
+/**
+ * Tag Generating ViewHelper Trait
+ *
+ * Implement in ViewHelpers which should generate tags.
+ */
+trait TagGenerating
+{
+    /**
+     * @return ArgumentDefinition[]
+     */
+    abstract public function prepareArguments();
+
+    /**
+     * @param array $arguments
+     * @param array $attributes
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return TagBuilder
+     */
+    public static function createTag(
+        array $arguments,
+        array $attributes,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): TagBuilder {
+        return (new TagBuilder('div', $renderChildrenClosure))
+            ->addAttributes($attributes + (isset($arguments['additionalAttributes']) ? $arguments['additionalAttributes'] : []));
+    }
+
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        return static::createTag(
+            $arguments,
+            array_diff_key($arguments, $renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper(new static)),
+            $renderChildrenClosure,
+            $renderingContext
+        )->render();
+    }
+
+    /**
+     * @param array $arguments
+     * @return void
+     */
+    public function handleAdditionalArguments(array $arguments)
+    {
+    }
+
+    /**
+     * @param array $arguments
+     * @return void
+     */
+    public function validateAdditionalArguments(array $arguments)
+    {
+    }
+}

--- a/src/ViewHelpers/TagViewHelper.php
+++ b/src/ViewHelpers/TagViewHelper.php
@@ -1,0 +1,80 @@
+<?php
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\TagGenerating;
+
+/**
+ * Tag Generating ViewHelper
+ *
+ * Generates a single HTML/XML tag with an optional tag name
+ * and arbitrary attributes. Supports the special `data` attribute
+ * which can be an array of sub-attributes that get expanded to
+ * `data-attributename` format and added as tag attribute.
+ * You can combine the `data` attribute with any number of `data-`
+ * prefixed attributes. Specific attributes take priority over array.
+ *
+ * Example:
+ *
+ *     <!-- Declare array of data-prefixed attributes -->
+ *     <f:variable name="myDataArray" value="{foo: 'foo', bar: 'bar'}" />
+ *     <f:tag tag="pre" data="{myDataArray}" data-bar="priority">Content of tag</f:tag>
+ *
+ * Output:
+ *
+ *     <pre data-foo="foo" data-bar="priority">Content of tag</pre>
+ */
+class TagViewHelper extends AbstractViewHelper
+{
+    use TagGenerating;
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * @var boolean
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('content', 'string', 'Tag name (default "div")', false, '');
+        parent::initializeArguments();
+        $this->registerArgument('tag', 'string', 'Tag name (default "div")', false, 'div');
+        $this->registerArgument('forceClosingTag', 'boolean', 'Force a closing tag (disallow self-closing). Off by default.', false, false);
+        $this->registerArgument('ignoreEmptyAttributes', 'boolean', 'Ignores attributes with empty values (zero not regarded as empty!). On by default.', false, true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param array $attributes
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return TagBuilder
+     */
+    public static function createTag(
+        array $arguments,
+        array $attributes,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): TagBuilder {
+        return (new TagBuilder($arguments['tag'], $renderChildrenClosure))
+            ->addAttributes($attributes)
+            ->forceClosingTag($arguments['forceClosingTag'])
+            ->ignoreEmptyAttributes($arguments['ignoreEmptyAttributes']);
+    }
+}

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -36,6 +36,15 @@ class TagBuilderTest extends UnitTestCase
     /**
      * @test
      */
+    public function contentSupportsClosure()
+    {
+        $tagBuilder = new TagBuilder('div', function () { return 'some text'; });
+        $this->assertEquals('<div>some text</div>', $tagBuilder->render());
+    }
+
+    /**
+     * @test
+     */
     public function setContentDoesNotEscapeValue()
     {
         $tagBuilder = new TagBuilder();

--- a/tests/Unit/Core/ViewHelper/Traits/TagGeneratingTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/TagGeneratingTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\TagGenerating;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\TagGeneratingViewHelperFixture;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+
+/**
+ * Class TagGeneratingTest
+ */
+class TagGeneratingTest extends UnitTestCase
+{
+    /**
+     * @param array $arguments
+     * @param string $expected
+     * @test
+     * @dataProvider getTestValues
+     */
+    public function testTagGenerator(array $arguments, string $expected)
+    {
+        $mock = new TagGeneratingViewHelperFixture();
+        $this->assertEquals($expected, $mock::renderStatic($arguments, function() { return ''; }, new RenderingContextFixture()));
+    }
+
+    /**
+     * @param array $arguments
+     * @test
+     * @dataProvider getTestValues
+     */
+    public function testHandleAdditionalArguments(array $arguments)
+    {
+        $mock = $this->getMockBuilder(TagGenerating::class)->getMockForTrait();
+        $before = clone $mock;
+        $mock->handleAdditionalArguments($arguments);
+        $this->assertEquals($before, $mock);
+    }
+
+    /**
+     * @param array $arguments
+     * @test
+     * @dataProvider getTestValues
+     */
+    public function testValidateAdditionalArguments(array $arguments)
+    {
+        $mock = $this->getMockBuilder(TagGenerating::class)->getMockForTrait();
+        $before = clone $mock;
+        $mock->validateAdditionalArguments($arguments);
+        $this->assertEquals($before, $mock);
+    }
+
+    /**
+     * @return array
+     */
+    public function getTestValues(): array
+    {
+        return [
+            [['test' => 'something'], '<div />'],
+            [['foobar' => ''], '<div foobar="" />'],
+            [['data-something' => 'foo'], '<div data-something="foo" />'],
+            [['data' => ['something' => 'foo', 'second' => '2']], '<div data-something="foo" data-second="2" />'],
+        ];
+    }
+}

--- a/tests/Unit/ViewHelpers/Fixtures/TagGeneratingViewHelperFixture.php
+++ b/tests/Unit/ViewHelpers/Fixtures/TagGeneratingViewHelperFixture.php
@@ -1,0 +1,27 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\TagGenerating;
+
+/**
+ * Class TagGeneratingViewHelperFixture
+ */
+class TagGeneratingViewHelperFixture extends AbstractViewHelper
+{
+    use TagGenerating;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('test', 'mixed', '');
+    }
+}

--- a/tests/Unit/ViewHelpers/TagViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/TagViewHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\ViewHelpers\SpacelessViewHelper;
+use TYPO3Fluid\Fluid\ViewHelpers\TagViewHelper;
+
+/**
+ * Testcase for TagViewHelper
+ */
+class TagViewHelperTest extends ViewHelperBaseTestcase
+{
+
+    /**
+     * @param array $arguments
+     * @param mixed $tagContent
+     * @param string $expected
+     * @dataProvider getRenderStaticData
+     * @test
+     */
+    public function testRenderStatic(array $arguments, $tagContent, $expected)
+    {
+        $context = $this->getMock(RenderingContextInterface::class);
+        $this->assertEquals($expected, TagViewHelper::renderStatic($arguments, function () use ($tagContent) {
+            return $tagContent;
+        }, $context));
+    }
+
+    /**
+     * @return array
+     */
+    public function getRenderStaticData()
+    {
+        return [
+            'standard empty tag' => [['tag' => 'div', 'forceClosingTag' => false, 'ignoreEmptyAttributes' => false], null, '<div />'],
+            'forces closing tag' => [['tag' => 'div', 'forceClosingTag' => true, 'ignoreEmptyAttributes' => false], null, '<div></div>'],
+            'ignores empty attribute' => [['tag' => 'div', 'forceClosingTag' => false, 'ignoreEmptyAttributes' => true, 'somethingempty' => ''], null, '<div />'],
+            'includes empty attribute' => [['tag' => 'div', 'forceClosingTag' => false, 'ignoreEmptyAttributes' => false, 'somethingempty' => ''], null, '<div somethingempty="" />'],
+            'supports data array' => [['tag' => 'div', 'forceClosingTag' => false, 'ignoreEmptyAttributes' => false, 'data' => ['foo' => 'bar']], null, '<div data-foo="bar" />'],
+            'data prefix has priority over data array' => [['tag' => 'div', 'forceClosingTag' => false, 'ignoreEmptyAttributes' => false, 'data' => ['bar' => 'baz', 'foo' => 'bar'], 'data-foo' => 'baz'], null, '<div data-bar="baz" data-foo="baz" />'],
+        ];
+    }
+}


### PR DESCRIPTION
Provides a Trait as replacement for tag based ViewHelpers,
which can be implemented by any ViewHelper, along with
an implementation that allows generating arbitrary tags while
utilising the features of the TagBuilder.

Using the trait is slightly different from using the tag based
abstract ViewHelper class in that all the actual rendering
takes place through a static API method createTag() which
receives arguments and attributes separately and returns
an instance of TagBuilder which is then rendered automatically.

Also refactors TagBuilder to allow chaining and support for
closures as tag content.