### PR TITLE
[BUGFIX] Fixes layoutPathAndFilename behavior in TemplatePaths (#309)

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -147,7 +147,7 @@ class TemplatePaths
      */
     public function setLayoutPathAndFilename($layoutPathAndFilename)
     {
-        $this->layoutPathAndFilename = $layoutPathAndFilename;
+        $this->layoutPathAndFilename = (string) $this->sanitizePath($layoutPathAndFilename);
     }
 
     /**
@@ -632,6 +632,9 @@ class TemplatePaths
      */
     public function getLayoutPathAndFilename($layoutName = 'Default')
     {
+        if ($this->layoutPathAndFilename !== null) {
+            return $this->layoutPathAndFilename;
+        }
         $format = $this->getFormat();
         $layoutName = ucfirst($layoutName);
         $layoutKey = $layoutName . '.' . $format;

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -85,6 +85,7 @@ class TemplatePathsTest extends BaseTestCase
         $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
         $instance->setLayoutPathAndFilename('foobar');
         $this->assertAttributeEquals('foobar', 'layoutPathAndFilename', $instance);
+        $this->assertEquals('foobar', $instance->getLayoutPathAndFilename());
     }
 
     /**


### PR DESCRIPTION
Class TemplatePaths will now correctly return the class variable layoutPathAndFilename if it was set before

Resolve: #309