### PR TITLE
[BUGFIX] Evaluate negative numbers as boolean like PHP does

### DIFF
--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -155,7 +155,7 @@ class BooleanNode extends AbstractNode
             return $value;
         }
         if (is_numeric($value)) {
-            return (boolean) ((float) $value > 0);
+            return (boolean) ((float) $value);
         }
         if (is_string($value)) {
             if (strlen($value) === 0) {

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -85,9 +85,9 @@ class BooleanNodeTest extends UnitTestCase
     {
         return [
             [0, false],
-            [-1, false],
-            ['-1', false],
-            [-.5, false],
+            [-1, true],
+            ['-1', true],
+            [-.5, true],
             [1, true],
             [.5, true],
         ];


### PR DESCRIPTION
This fixes https://github.com/TYPO3/Fluid/issues/301

Even the docs are not right:
https://docs.typo3.org/typo3cms/ExtbaseFluidBook/8-Fluid/7-using-boolean-conditions.html

> A number for example is evaluated as true if it is greater than 0.

See http://php.net/manual/en/language.types.boolean.php
> Warning
-1 is considered TRUE, like any other non-zero (whether negative or positive) number!

https://softwareengineering.stackexchange.com/a/300792/41772

Negative numbers in PHP are true. Currently it is not consistent with the negative number handling in PHP. This PR fixes it.