### PR TITLE
[BUGFIX] use the Trusty build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+
 language: php
 
 branches:


### PR DESCRIPTION
This fixes the Travis build for HHVM. HHVM is available on Trusty but not Precise anymore.