### PR TITLE
[BUGFIX] Prevent re-loading cached classes that already exist

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -150,12 +150,7 @@ class TemplateCompiler
         if (!$this->renderingContext->isCacheEnabled()) {
             return false;
         }
-<<<<<<< HEAD
-        $identifier = $this->sanitizeIdentifier($identifier);
         return !empty($identifier) && (class_exists($identifier, false) || $this->renderingContext->getCache()->get($identifier));
-=======
-        return !empty($identifier) && $this->renderingContext->getCache()->get($identifier);
->>>>>>> master
     }
 
     /**

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -149,7 +149,7 @@ class TemplateCompiler
             return false;
         }
         $identifier = $this->sanitizeIdentifier($identifier);
-        return !empty($identifier) && $this->renderingContext->getCache()->get($identifier);
+        return !empty($identifier) && (class_exists($identifier, false) || $this->renderingContext->getCache()->get($identifier));
     }
 
     /**
@@ -161,9 +161,12 @@ class TemplateCompiler
         $identifier = $this->sanitizeIdentifier($identifier);
 
         if (!isset($this->syntaxTreeInstanceCache[$identifier])) {
-            $this->renderingContext->getCache()->get($identifier);
+            if (!class_exists($identifier, false)) {
+                $this->renderingContext->getCache()->get($identifier);
+            }
             $this->syntaxTreeInstanceCache[$identifier] = new $identifier();
         }
+
 
         return $this->syntaxTreeInstanceCache[$identifier];
     }


### PR DESCRIPTION
This patch prevents a problem where it is made up to the individual cache implementation whether or not to re-load a class file when a class is already defined. Instead, making the compiler only fetch the class from cache if it is not already loaded (by checking class_exists without allowing autoloading!) prevents re-loading classes with “class already declared” errors to follow.