### PR TITLE
[TASK] require and include are statements

### DIFF
--- a/src/Core/Cache/SimpleFileCache.php
+++ b/src/Core/Cache/SimpleFileCache.php
@@ -65,7 +65,7 @@ class SimpleFileCache implements FluidCacheInterface
         }
         $file = $this->getCachedFilePathAndFilename($name);
         if (file_exists($file) && !class_exists($name)) {
-            include_once($file);
+            include_once $file;
             return true;
         }
         return false;

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -195,7 +195,7 @@ class TemplateParserTest extends UnitTestCase
     public function splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate($templateName)
     {
         $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html', FILE_TEXT);
-        $expectedResult = require(__DIR__ . '/Fixtures/' . $templateName . '-split.php');
+        $expectedResult = require __DIR__ . '/Fixtures/' . $templateName . '-split.php';
         $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
         $this->assertSame($expectedResult, $templateParser->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);
     }


### PR DESCRIPTION
`require` and `include` are statements, not functions. Therefore the parentheses are not needed.