### PR TITLE
[BUGFIX] Use sanitized identifier in TemplateCompiler::has()

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -142,13 +142,14 @@ class TemplateCompiler
      */
     public function has($identifier)
     {
+        $identifier = $this->sanitizeIdentifier($identifier);
+
         if (isset($this->syntaxTreeInstanceCache[$identifier])) {
             return true;
         }
         if (!$this->renderingContext->isCacheEnabled()) {
             return false;
         }
-        $identifier = $this->sanitizeIdentifier($identifier);
         return !empty($identifier) && $this->renderingContext->getCache()->get($identifier);
     }
 
@@ -185,6 +186,8 @@ class TemplateCompiler
      */
     public function store($identifier, ParsingState $parsingState)
     {
+        $identifier = $this->sanitizeIdentifier($identifier);
+
         if ($this->isDisabled()) {
             $cache = $this->renderingContext->getCache();
             if ($cache) {
@@ -196,7 +199,6 @@ class TemplateCompiler
         }
 
         $this->currentlyProcessingState = $parsingState;
-        $identifier = $this->sanitizeIdentifier($identifier);
         $this->nodeConverter->setVariableCounter(0);
         $generatedRenderFunctions = $this->generateSectionCodeFromParsingState($parsingState);
 

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -49,10 +49,10 @@ class TemplateCompilerTest extends UnitTestCase
     public function testHasReturnsFalseWithoutCache()
     {
         $instance = $this->getMock(TemplateCompiler::class, ['sanitizeIdentifier']);
-        $renderingContext = new RenderingContextFixture();
+        $renderingContext = $this->getMock(RenderingContextFixture::class, ['getCache']);
         $renderingContext->cacheDisabled = true;
+        $renderingContext->expects($this->never())->method('getCache');
         $instance->setRenderingContext($renderingContext);
-        $instance->expects($this->never())->method('sanitizeIdentifier');
         $result = $instance->has('test');
         $this->assertFalse($result);
     }
@@ -126,9 +126,9 @@ class TemplateCompilerTest extends UnitTestCase
     {
         $renderingContext = new RenderingContextFixture();
         $renderingContext->cacheDisabled = true;
-        $instance = $this->getMock(TemplateCompiler::class, ['sanitizeIdentifier']);
+        $instance = $this->getMock(TemplateCompiler::class, ['generateSectionCodeFromParsingState']);
         $instance->setRenderingContext($renderingContext);
-        $instance->expects($this->never())->method('sanitizeIdentifier');
+        $instance->expects($this->never())->method('generateSectionCodeFromParsingState');
         $instance->store('foobar', new ParsingState());
     }
 


### PR DESCRIPTION
Instances are stored with the sanitzied identifier into a runtime cache.
The `TemplateCompiler::has()` must also use the sanitzed version of the
identifier to check if the instance exists in the runtime cache.