### PR TITLE
[FEATURE] add and/or alternative for ||/&& syntax

### DIFF
--- a/src/Core/Parser/BooleanParser.php
+++ b/src/Core/Parser/BooleanParser.php
@@ -74,7 +74,11 @@ class BooleanParser
 			|
 				\|\|
 			|
+			    [aA][nN][dD]
+			|
 				&&
+			|
+			    [oO][rR]
 			|
 				.?
 			)\s*
@@ -180,8 +184,8 @@ class BooleanParser
     protected function parseOrToken()
     {
         $x = $this->parseAndToken();
-        while ($this->peek() === '||') {
-            $this->consume('||');
+        while (($token = $this->peek()) && in_array(strtolower($token), ['||', 'or'])) {
+            $this->consume($token);
             $y = $this->parseAndToken();
 
             if ($this->compileToCode === true) {
@@ -202,8 +206,8 @@ class BooleanParser
     protected function parseAndToken()
     {
         $x = $this->parseCompareToken();
-        while ($this->peek() === '&&') {
-            $this->consume('&&');
+        while (($token = $this->peek()) && in_array(strtolower($token), ['&&', 'and'])) {
+            $this->consume($token);
             $y = $this->parseCompareToken();
 
             if ($this->compileToCode === true) {

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -29,6 +29,8 @@ class BasicConditionsTest extends BaseConditionalFunctionalTestCase
             ['(FALSE || (FALSE || 1)', true],
             ['(FALSE || (FALSE || 1)', true],
 
+            ['(FALSE or (FALSE or 1)', true],
+
             // integers
             ['13 == \'13\'', true],
             ['13 === \'13\'', false],

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -110,6 +110,22 @@ class BooleanParserTest extends UnitTestCase
             ['(0 && 0) || 0', true],
             ['(1 && 1) || 0', true],
 
+            ['0 and 1', false],
+            ['1 and 1', true],
+            ['0 or 0', false],
+            ['0 or 1', true],
+            ['(0 and 1) or 1', true],
+            ['(0 and 0) or 0', true],
+            ['(1 and 1) or 0', true],
+            ['0 And 1', false],
+            ['1 anD 1', true],
+            ['0 oR 0', false],
+            ['0 Or 1', true],
+            ['0 AND 1', false],
+            ['1 AND 1', true],
+            ['0 OR 0', false],
+            ['0 OR 1', true],
+
             // edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
             ['\'foo\' == 0', true],
             ['1.1 >= foo', true],


### PR DESCRIPTION
With this commit the user can choose to use „and“ instead of „&&“ and „or“ instead of „||“ in boolean conditions

closes #319