### PR TITLE
[FEATURE] Introduce concept of Renderables

### DIFF
--- a/src/Core/Rendering/AbstractRenderable.php
+++ b/src/Core/Rendering/AbstractRenderable.php
@@ -1,0 +1,63 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Rendering;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class AbstractRenderable
+ */
+abstract class AbstractRenderable implements RenderableInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $node;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return RenderableClosure
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @param NodeInterface $node
+     * @return RenderableClosure
+     */
+    public function setNode(NodeInterface $node)
+    {
+        $this->node = $node;
+        return $this;
+    }
+
+    /**
+     * @return NodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node ? $this->node : new TextNode(sprintf('%s (%s)', static::class, $this->name));
+    }
+}

--- a/src/Core/Rendering/RenderableClosure.php
+++ b/src/Core/Rendering/RenderableClosure.php
@@ -1,0 +1,40 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Rendering;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class RenderableClosure
+ */
+class RenderableClosure extends AbstractRenderable
+{
+    /**
+     * @var \Closure
+     */
+    protected $closure;
+
+    /**
+     * @param \Closure $closure
+     * @return RenderableClosure
+     */
+    public function setClosure(\Closure $closure)
+    {
+        $this->closure = $closure;
+        return $this;
+    }
+
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public function render(RenderingContextInterface $renderingContext)
+    {
+        return call_user_func_array($this->closure, [$renderingContext, $this->node]);
+    }
+}

--- a/src/Core/Rendering/RenderableInterface.php
+++ b/src/Core/Rendering/RenderableInterface.php
@@ -1,0 +1,59 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Rendering;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * This interface is implemented by objects which can be rendered
+ * directly by Fluid.
+ *
+ * A "Renderable" is simply a named object which is aware of both
+ * ViewHelperNode (during parse time only) and RenderingContext
+ * during rendering wether template is compiled or not.
+ */
+interface RenderableInterface
+{
+    /**
+     * Returns the name of this Renderable - name must also be passed in constructor.
+     * Implementations must always return a non-empty string even if setName() is not
+     * called to set the specific name.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Setter for the name of this Renderable.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function setName($name);
+
+    /**
+     * Sets the parsed RootNode which must be handled by this Renderable. In the
+     * default implementation these nodes are evaluated by render() and extracted
+     * by the NodeConverter
+     *
+     * @param NodeInterface $node
+     * @return void
+     */
+    public function setNode(NodeInterface $node);
+
+    /**
+     * @return NodeInterface
+     */
+    public function getNode();
+
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public function render(RenderingContextInterface $renderingContext);
+}

--- a/src/Core/Rendering/StandardRenderable.php
+++ b/src/Core/Rendering/StandardRenderable.php
@@ -1,0 +1,25 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Rendering;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * Class StandardRenderable
+ */
+class StandardRenderable extends AbstractRenderable
+{
+    /**
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public function render(RenderingContextInterface $renderingContext)
+    {
+        return $this->getNode()->evaluate($renderingContext);
+    }
+}

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\ParsedTemplateImplementationFixture;
@@ -52,10 +53,11 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
         $instance->expects($this->at(0))->method('registerArgument')->with('section', 'string', $this->anything());
         $instance->expects($this->at(1))->method('registerArgument')->with('partial', 'string', $this->anything());
         $instance->expects($this->at(2))->method('registerArgument')->with('delegate', 'string', $this->anything());
-        $instance->expects($this->at(3))->method('registerArgument')->with('arguments', 'array', $this->anything(), false, []);
-        $instance->expects($this->at(4))->method('registerArgument')->with('optional', 'boolean', $this->anything(), false, false);
-        $instance->expects($this->at(5))->method('registerArgument')->with('default', 'mixed', $this->anything());
-        $instance->expects($this->at(6))->method('registerArgument')->with('contentAs', 'string', $this->anything());
+        $instance->expects($this->at(3))->method('registerArgument')->with('renderable', RenderableInterface::class, $this->anything());
+        $instance->expects($this->at(4))->method('registerArgument')->with('arguments', 'array', $this->anything(), false, []);
+        $instance->expects($this->at(5))->method('registerArgument')->with('optional', 'boolean', $this->anything(), false, false);
+        $instance->expects($this->at(6))->method('registerArgument')->with('default', 'mixed', $this->anything());
+        $instance->expects($this->at(7))->method('registerArgument')->with('contentAs', 'string', $this->anything());
         $instance->initializeArguments();
     }
 
@@ -69,6 +71,7 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
             'partial' => null,
             'section' => null,
             'delegate' => null,
+            'renderable' => null,
             'arguments' => [],
             'optional' => false,
             'default' => null,
@@ -88,6 +91,7 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
             'partial' => null,
             'section' => null,
             'delegate' => RenderingContextFixture::class,
+            'renderable' => null,
             'arguments' => [],
             'optional' => false,
             'default' => null,
@@ -107,6 +111,29 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
             'partial' => null,
             'section' => null,
             'delegate' => ParsedTemplateImplementationFixture::class,
+            'renderable' => null,
+            'arguments' => [],
+            'optional' => false,
+            'default' => null,
+            'contentAs' => null
+        ]);
+        $result = $this->subject->render();
+        $this->assertEquals('rendered by fixture', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testRenderWithRenderable()
+    {
+        $renderable = $this->getMockBuilder(RenderableInterface::class)->getMockForAbstractClass();
+        $renderable->expects($this->once())->method('render')->willReturn('rendered by fixture');
+        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
+        $this->subject->setArguments([
+            'partial' => null,
+            'section' => null,
+            'delegate' => null,
+            'renderable' => $renderable,
             'arguments' => [],
             'optional' => false,
             'default' => null,
@@ -139,19 +166,19 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
     {
         return [
             [
-                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'renderable' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
                 null
             ],
             [
-                ['partial' => 'foo-partial', 'section' => null, 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                ['partial' => 'foo-partial', 'section' => null, 'delegate' => null, 'renderable' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
                 'renderPartial'
             ],
             [
-                ['partial' => 'foo-partial', 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                ['partial' => 'foo-partial', 'section' => 'foo-section', 'delegate' => null, 'renderable' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
                 'renderPartial'
             ],
             [
-                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
+                ['partial' => null, 'section' => 'foo-section', 'delegate' => null, 'renderable' => null, 'arguments' => [], 'optional' => false, 'default' => null, 'contentAs' => null],
                 'renderSection'
             ],
         ];
@@ -169,6 +196,7 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
                 'partial' => 'test',
                 'section' => null,
                 'delegate' => null,
+                'renderable' => null,
                 'arguments' => [],
                 'optional' => true,
                 'default' => 'default-foobar',
@@ -192,6 +220,7 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
                 'partial' => 'test1',
                 'section' => 'test2',
                 'delegate' => null,
+                'renderable' => null,
                 'arguments' => [
                     'foo' => 'bar'
                 ],


### PR DESCRIPTION
This patch adds a new interface for "renderable" objects,
which allows any object to adopt the interface and when
assigned to the template, render itself based on the current
RenderingContext. A new argument "renderable" is added
to `f:render` to render such objects. Two implementations
are added: a StandardRenderable which renders a Node,
and a ClosureRenderable which renders arbitrary closures.

The feature is also the basis for a larger refactoring which
finally stop storing sections in the VariableProvider while
parsing, by providing a proper API for getting sections
from a parsed template object.