### PR TITLE
[FEATURE] Add getAll / addAll to ViewHelperVariableContainer

### DIFF
--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -45,6 +45,30 @@ class ViewHelperVariableContainer
     }
 
     /**
+     * Adds, or overrides recursively, all current variables defined in associative
+     * array or Traversable (with string keys!).
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param array|\Traversable $variables An associative array of all variables to add
+     * @return void
+     * @api
+     */
+    public function addAll($viewHelperName, $variables)
+    {
+        if (!is_array($variables) && !$variables instanceof \Traversable) {
+            throw new \InvalidArgumentException(
+                'Invalid argument type for $variables in ViewHelperVariableContainer->addAll(). Expects array/Traversable ' .
+                'but received ' . (is_object($variables) ? get_class($variables) : gettype($variables)),
+                1501425195
+            );
+        }
+        $this->objects[$viewHelperName] = array_replace_recursive(
+            isset($this->objects[$viewHelperName]) ? $this->objects[$viewHelperName] : [],
+            $variables instanceof \Traversable ? iterator_to_array($variables) : $variables
+        );
+    }
+
+    /**
      * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
      * to your fully qualified ViewHelper Class Name.
      * In case the value is already inside, it is silently overridden.
@@ -73,10 +97,18 @@ class ViewHelperVariableContainer
      */
     public function get($viewHelperName, $key, $default = null)
     {
-        if ($this->exists($viewHelperName, $key)) {
-            return $this->objects[$viewHelperName][$key];
-        }
-        return $default;
+        return $this->exists($viewHelperName, $key) ? $this->objects[$viewHelperName][$key] : $default;
+    }
+
+    /**
+     * Gets all variables stored for a particular ViewHelper
+     *
+     * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
+     * @param mixed $default
+     */
+    public function getAll($viewHelperName, $default = null)
+    {
+        return array_key_exists($viewHelperName, $this->objects) ? $this->objects[$viewHelperName] : $default;
     }
 
     /**

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -108,6 +108,33 @@ class ViewHelperVariableContainerTest extends UnitTestCase
     /**
      * @test
      */
+    public function getAllGetsAllVariables()
+    {
+        $this->viewHelperVariableContainer->addAll('Foo\\Bar', ['foo' => 'foo', 'bar' => 'bar']);
+        $this->assertSame(['foo' => 'foo', 'bar' => 'bar'], $this->viewHelperVariableContainer->getAll('Foo\\Bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function getAllReturnsDefaultIfNotFound()
+    {
+        $this->viewHelperVariableContainer->addAll('Foo\\Bar', ['foo' => 'foo']);
+        $this->assertSame(['foo' => 'bar'], $this->viewHelperVariableContainer->getAll('Baz\\Baz', ['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function addAllThrowsInvalidArgumentExceptionOnUnsupportedType()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->viewHelperVariableContainer->addAll('Foo\\Bar', new \DateTime('now'));
+    }
+
+    /**
+     * @test
+     */
     public function testSleepReturnsExpectedPropertyNames()
     {
         $subject = new ViewHelperVariableContainer();


### PR DESCRIPTION
A method `getAll` is added to ViewHelperVariableContainer
which allows getting all variables for a ViewHelper as array.

A new method `addAll` is added as well, allowing a complete
set of variables to be added/overridden at the same time.

The resulting two methods allows a ViewHelper to use many
options with defaults as needed, and just one method call to
retrieve all of them and another call to update all of them.