### PR TITLE
[BUGFIX] Make ViewHelperResolver internal cache non-static

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -26,7 +26,7 @@ class ViewHelperResolver
     /**
      * @var array
      */
-    protected static $resolvedViewHelperClassNames = [];
+    protected $resolvedViewHelperClassNames = [];
 
     /**
      * Namespaces requested by the template being rendered,
@@ -244,7 +244,7 @@ class ViewHelperResolver
      */
     public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier)
     {
-        if (!isset(static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier])) {
+        if (!isset($this->resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier])) {
             $resolvedViewHelperClassName = $this->resolveViewHelperName($namespaceIdentifier, $methodIdentifier);
             $actualViewHelperClassName = implode('\\', array_map('ucfirst', explode('.', $resolvedViewHelperClassName)));
             if (false === class_exists($actualViewHelperClassName) || $actualViewHelperClassName === false) {
@@ -256,9 +256,9 @@ class ViewHelperResolver
                     $resolvedViewHelperClassName
                 ), 1407060572);
             }
-            static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier] = $actualViewHelperClassName;
+            $this->resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier] = $actualViewHelperClassName;
         }
-        return static::$resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier];
+        return $this->resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier];
     }
 
     /**


### PR DESCRIPTION
Using a static class property for the cache could have bad
side effects for setups which have multiple contexts for
Fluid and may change the namespaces between contexts.

Converting the cache to a non-static property cleans it
properly when a new ViewHelperResolver is created.