### PR TITLE
[BUGFIX] File resolving related fixes

### DIFF
--- a/tests/Unit/View/Fixtures/LegacyTemplatePathsFixture.php
+++ b/tests/Unit/View/Fixtures/LegacyTemplatePathsFixture.php
@@ -1,0 +1,82 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures;
+
+use TYPO3Fluid\Fluid\View\TemplatePaths;
+
+/**
+ * Legacy implementation of TemplatePaths with original method
+ * signatures to protect against breaking changes until this
+ * fixture is removed.
+ */
+class LegacyTemplatePathsFixture extends TemplatePaths
+{
+    public function resolveAvailableTemplateFiles($controllerName, $format = self::DEFAULT_FORMAT)
+    {
+        return parent::resolveAvailableTemplateFiles($controllerName, $format);
+    }
+
+    public function resolveAvailablePartialFiles($format = self::DEFAULT_FORMAT)
+    {
+        return parent::resolveAvailablePartialFiles($format);
+    }
+
+    public function resolveAvailableLayoutFiles($format = self::DEFAULT_FORMAT)
+    {
+        return parent::resolveAvailableLayoutFiles($format);
+    }
+
+    protected function resolveFilesInFolders(array $folders, $format)
+    {
+        return parent::resolveFilesInFolders($folders, $format);
+    }
+
+    protected function resolveFilesInFolder($folder, $format)
+    {
+        return parent::resolveFilesInFolder($folder, $format);
+    }
+
+    public function getLayoutIdentifier($layoutName = 'Default')
+    {
+        return parent::getLayoutIdentifier($layoutName);
+    }
+
+    public function getLayoutSource($layoutName = 'Default')
+    {
+        return parent::getLayoutSource($layoutName);
+    }
+
+    public function getTemplateIdentifier($controller = 'Default', $action = 'Default')
+    {
+        return parent::getTemplateIdentifier($controller, $action);
+    }
+
+    public function getTemplateSource($controller = 'Default', $action = 'Default')
+    {
+        return parent::getTemplateSource($controller, $action);
+    }
+
+    public function getLayoutPathAndFilename($layoutName = 'Default')
+    {
+        return parent::getLayoutPathAndFilename($layoutName);
+    }
+
+    public function getPartialIdentifier($partialName)
+    {
+        return parent::getPartialIdentifier($partialName);
+    }
+
+    public function getPartialSource($partialName)
+    {
+        return parent::getPartialSource($partialName);
+    }
+
+    public function getPartialPathAndFilename($partialName)
+    {
+        return parent::getPartialPathAndFilename($partialName);
+    }
+
+    protected function resolveFileInPaths(array $paths, $relativePathAndFilename, $format = self::DEFAULT_FORMAT)
+    {
+        return parent::resolveFileInPaths($paths, $relativePathAndFilename, $format);
+    }
+}

--- a/tests/Unit/View/LegacyTemplatePathsTest.php
+++ b/tests/Unit/View/LegacyTemplatePathsTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\View;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\LegacyTemplatePathsFixture;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
+
+/**
+ * Class TemplatePathsTest
+ */
+class LegacyTemplatePathsTest extends TemplatePathsTest
+{
+    /**
+     * @return string
+     */
+    protected function getSubjectClassName()
+    {
+        return LegacyTemplatePathsFixture::class;
+    }
+}

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace FluidTYPO3Fluid\Flux\Tests\Unit\View;
+namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 /*
  * This file belongs to the package "TYPO3 Fluid".
@@ -17,6 +17,13 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
  */
 class TemplatePathsTest extends BaseTestCase
 {
+    /**
+     * @return string
+     */
+    protected function getSubjectClassName()
+    {
+        return TemplatePaths::class;
+    }
 
     /**
      * @param string|array $input
@@ -26,7 +33,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testSanitizePath($input, $expected)
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $method = new \ReflectionMethod($instance, 'sanitizePath');
         $method->setAccessible(true);
         $output = $method->invokeArgs($instance, [$input]);
@@ -58,7 +66,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testSanitizePaths($input, $expected)
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $method = new \ReflectionMethod($instance, 'sanitizePaths');
         $method->setAccessible(true);
         $output = $method->invokeArgs($instance, [$input]);
@@ -82,7 +91,7 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function setsLayoutPathAndFilename()
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance = $this->getMock($this->getSubjectClassName(), ['sanitizePath']);
         $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
         $instance->setLayoutPathAndFilename('foobar');
         $this->assertAttributeEquals('foobar', 'layoutPathAndFilename', $instance);
@@ -94,7 +103,7 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function setsTemplatePathAndFilename()
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance = $this->getMock($this->getSubjectClassName(), ['sanitizePath']);
         $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
         $instance->setTemplatePathAndFilename('foobar');
         $this->assertAttributeEquals('foobar', 'templatePathAndFilename', $instance);
@@ -109,7 +118,7 @@ class TemplatePathsTest extends BaseTestCase
     {
         $getter = 'get' . ucfirst($property);
         $setter = 'set' . ucfirst($property);
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance = $this->getMock($this->getSubjectClassName(), ['sanitizePath']);
         $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
         $instance->$setter($value);
         $this->assertEquals($value, $instance->$getter());
@@ -132,7 +141,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testFillByPackageName()
     {
-        $instance = new TemplatePaths('FluidTYPO3.Flux');
+        $className = $this->getSubjectClassName();
+        $instance = new $className('FluidTYPO3.Flux');
         $this->assertNotEmpty($instance->getTemplateRootPaths());
     }
 
@@ -141,7 +151,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testFillByConfigurationArray()
     {
-        $instance = new TemplatePaths([
+        $className = $this->getSubjectClassName();
+        $instance = new $className([
             TemplatePaths::CONFIG_TEMPLATEROOTPATHS => ['Resources/Private/Templates/'],
             TemplatePaths::CONFIG_LAYOUTROOTPATHS => ['Resources/Private/Layouts/'],
             TemplatePaths::CONFIG_PARTIALROOTPATHS => ['Resources/Private/Partials/'],
@@ -156,7 +167,7 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testResolveFilesMethodCallsResolveFilesInFolders($method, $pathsMethod)
     {
-        $instance = $this->getMock(TemplatePaths::class, ['resolveFilesInFolders']);
+        $instance = $this->getMock($this->getSubjectClassName(), ['resolveFilesInFolders']);
         $instance->$pathsMethod(['foo']);
         $instance->expects($this->once())->method('resolveFilesInFolders')->with($this->anything(), 'format');
         $instance->$method('format', 'format');
@@ -179,7 +190,7 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testToArray()
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
+        $instance = $this->getMock($this->getSubjectClassName(), ['sanitizePath']);
         $instance->expects($this->any())->method('sanitizePath')->willReturnArgument(0);
         $instance->setTemplateRootPaths(['1']);
         $instance->setLayoutRootPaths(['2']);
@@ -198,7 +209,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testResolveFilesInFolders()
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $method = new \ReflectionMethod($instance, 'resolveFilesInFolders');
         $method->setAccessible(true);
         $result = $method->invokeArgs(
@@ -220,7 +232,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testGetTemplateSourceThrowsExceptionIfFileNotFound()
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $this->setExpectedException(InvalidTemplateResourceException::class);
         $instance->getTemplateSource();
     }
@@ -231,7 +244,8 @@ class TemplatePathsTest extends BaseTestCase
     public function testGetTemplateSourceReadsStreamWrappers()
     {
         $fixture = __DIR__ . '/Fixtures/LayoutFixture.html';
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $stream = fopen($fixture, 'r');
         $instance->setTemplateSource($stream);
         $this->assertEquals(stream_get_contents($stream), $instance->getTemplateSource());
@@ -243,7 +257,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testResolveFileInPathsThrowsExceptionIfFileNotFound()
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
         $method->setAccessible(true);
         $this->setExpectedException(InvalidTemplateResourceException::class);
@@ -255,7 +270,8 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat()
     {
-        $instance = new TemplatePaths();
+        $className = $this->getSubjectClassName();
+        $instance = new $className();
         $instance->setTemplateSource('foobar');
         $this->assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
     }


### PR DESCRIPTION
This patch addresses the following issues, all in TemplatePaths.

**Format-related issues**

* Method signatures contain default format which means the
  configured format (setFormat($format)) would not be respected
  and had to be passed every time. Changed to null and call to
  getFormat() when value is null.
* When extracting path arrays, default format would always be
  "html" instead of what was configured in TemplatePaths.
* Layout name prefix did not contain format when generating
  an identifier, which could cause colissions between two Layouts
  with the same name but different formats.

**General issues/improvements**

* Exception message improved to explicitly report "no paths set".
* Removed `array_values` when extracting template paths, thus
  preserving the paths' original indexes.

In addition to this, since the method signatures are changed, a
new test fixture and aliased test class for TemplatePaths is added,
which will error out if the signatures should at any point become
incompatible. The reasoning being that this particular class is
very likely to be overridden by frameworks.