### PR TITLE
[BUGFIX] Make casting of numbers the same in arguments and arrays

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -669,7 +669,8 @@ class TemplateParser
                 if (!empty($singleMatch['VariableIdentifier'])) {
                     $arrayToBuild[$arrayKey] = new ObjectAccessorNode($singleMatch['VariableIdentifier']);
                 } elseif (array_key_exists('Number', $singleMatch) && (!empty($singleMatch['Number']) || $singleMatch['Number'] === '0')) {
-                    $arrayToBuild[$arrayKey] = (float)$singleMatch['Number'];
+                    // Note: this method of casting picks "int" when value is a natural number and "float" if any decimals are found. See also NumericNode.
+                    $arrayToBuild[$arrayKey] = $singleMatch['Number'] + 0;
                 } elseif ((array_key_exists('QuotedString', $singleMatch) && !empty($singleMatch['QuotedString']))) {
                     $argumentString = $this->unquoteString($singleMatch['QuotedString']);
                     $arrayToBuild[$arrayKey] = $this->buildArgumentObjectTree($argumentString);


### PR DESCRIPTION
Problem briefly described: numbers passed in tag attributes vs. numbers passed in inline syntax (which internally uses the array
syntax parsing) handles numeric values in two different ways:

* In tags, a NumericNode is created if is_numeric is true
* In arrays, numbers are cast with (float) and matched by regexp

NumericNode also casts the value but does so by using an add-
zero trick which makes PHP do the casting based on string value,
and the input is always a string in the parser. This means that the
two different ways of passing a number will produce two different
types of variables given natural numbers as input. Passing floats
still causes the same type.

The solution is to apply the same method of casting in both cases.