### PR TITLE
[TASK] Improve performance of uncompilable templates

### DIFF
--- a/src/Core/Compiler/UncompilableTemplateInterface.php
+++ b/src/Core/Compiler/UncompilableTemplateInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace TYPO3Fluid\Fluid\Core\Compiler;
+
+/**
+ * Interface UncompilableTemplateInterface
+ *
+ * Implemented in compiled templates when the syntax tree could
+ * not be fully compiled. Prevents continuous attempts to compile
+ * the same template by allowing the template compiler to store
+ * a class so the compiled identifier appears to exist, but return
+ * nothing when asked to get() the identifier.
+ *
+ * The result is that the template parser will always parse the
+ * original template.
+ */
+interface UncompilableTemplateInterface
+{
+}

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -165,14 +165,14 @@ class TemplateCompilerTest extends UnitTestCase
     /**
      * @test
      */
-    public function testStoreWhenDisabledFlushesCache()
+    public function testStoreSavesUncompilableState()
     {
-        $cacheMock = $this->getMockBuilder(SimpleFileCache::class)->setMethods(['flush'])->getMock();
-        $cacheMock->expects($this->once())->method('flush');
-        $renderingContext = $this->getMockBuilder(RenderingContextFixture::class)->setMethods(['isCacheEnabled', 'getCache'])->getMock();
-        $renderingContext->expects($this->once())->method('isCacheEnabled')->willReturn(false);
-        $renderingContext->expects($this->once())->method('getCache')->willReturn($cacheMock);
+        $cacheMock = $this->getMockBuilder(SimpleFileCache::class)->setMethods(['set'])->getMock();
+        $cacheMock->expects($this->once())->method('set')->with('fakeidentifier', $this->anything());
+        $renderingContext = new RenderingContextFixture();
+        $renderingContext->setCache($cacheMock);
         $state = new ParsingState();
+        $state->setCompilable(false);
         $instance = new TemplateCompiler();
         $instance->setRenderingContext($renderingContext);
         $instance->store('fakeidentifier', $state);


### PR DESCRIPTION
Problem briefly described:

Uncompilable templates are both parsed and attempted compiled
on each initial rendering (once per request/context). Because no
result is stored if a template is not compilable, the compiler does
not know that it should not attempt to compile the template.

This patch introduces a few measures to create a compiled stub
class which informs the template parser and compiler that the
template was attempted compiled but determined uncompilable,
so the compiler should not attempt to compile it by converting
the syntax tree to PHP code.

The stub template is achieved by allowing the template compiler
to also "compile" ParsedTemplateInterface implementations which
have the "compilable" flag set to false. When this is the case, the
compiler creates a stub class which skips compiling when the
template is requested again.