### PR TITLE
[FEATURE] Make render method optional

### DIFF
--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -102,15 +102,6 @@ interface ViewHelperInterface
      */
     public function validateAdditionalArguments(array $arguments);
 
-//	/**
-//	 * Render method you need to implement for your custom view helper.
-//	 * Note: This method is commented out in order to avoid conflicts with different method signatures in the implementation
-//	 *
-//	 * @return mixed usually the rendered string, depending on the view helper
-//	 * @api
-//	 */
-//	public function render();
-
     /**
      * Here follows a more detailed description of the arguments of this function:
      *

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -16,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeDefaultRenderStaticViewHelper;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -390,5 +392,31 @@ class AbstractViewHelperTest extends UnitTestCase
     {
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['dummy'], [], '', false);
         $this->assertNull($viewHelper->resetState());
+    }
+
+    /**
+     * @test
+     */
+    public function testCallRenderMethodCanRenderViewHelperWithoutRenderMethodAndCallsRenderStatic()
+    {
+        $subject = new RenderMethodFreeViewHelper();
+        $method = new \ReflectionMethod($subject, 'callRenderMethod');
+        $method->setAccessible(true);
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $result = $method->invoke($subject);
+        $this->assertSame('I was rendered', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testCallRenderMethodOnViewHelperWithoutRenderMethodWithDefaultRenderStaticMethodThrowsException()
+    {
+        $subject = new RenderMethodFreeDefaultRenderStaticViewHelper();
+        $method = new \ReflectionMethod($subject, 'callRenderMethod');
+        $method->setAccessible(true);
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $this->setExpectedException(Exception::class);
+        $method->invoke($subject);
     }
 }

--- a/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
@@ -1,0 +1,16 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+
+/**
+ * Fixture ViewHelper that will throw an exception if
+ * rendered, to test the infinite recursion prevention.
+ *
+ * See AbstractViewHelperTest->testCallRenderMethod* tests!
+ */
+class RenderMethodFreeDefaultRenderStaticViewHelper extends AbstractViewHelper implements ViewHelperInterface
+{
+}

--- a/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeViewHelper.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeViewHelper.php
@@ -1,0 +1,14 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+
+class RenderMethodFreeViewHelper extends AbstractViewHelper implements ViewHelperInterface
+{
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        return 'I was rendered';
+    }
+}


### PR DESCRIPTION
ViewHelpers are no longer required to, nor suggested to, implement a render() method.

If the method does not exist, `callRenderMethod` instead calls `renderStatic` if it is implemented on the class (i.e. not inherited from the base class). If the VH class does not implement render() and inherits renderStatic() an exception is thrown, informing the developer to implement one or the other (with preference for renderStatic that is declared on the interface).