### PR TITLE
[TASK] Remove dependency on View in RenderingContext

### DIFF
--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -26,7 +26,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
-use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
  * The rendering context that contains useful information during rendering time of a Fluid template
@@ -78,11 +77,6 @@ class RenderingContext implements RenderingContextInterface
     protected $controllerAction;
 
     /**
-     * @var ViewInterface
-     */
-    protected $view;
-
-    /**
      * @var TemplateParser
      */
     protected $templateParser;
@@ -126,9 +120,8 @@ class RenderingContext implements RenderingContextInterface
      * setRenderingContext() method (convention name) to provide the instance that is
      * created with an instance of the "parent" RenderingContext.
      */
-    public function __construct(ViewInterface $view)
+    public function __construct()
     {
-        $this->view = $view;
         $this->setTemplateParser(new TemplateParser());
         $this->setTemplateCompiler(new TemplateCompiler());
         $this->setTemplatePaths(new TemplatePaths());

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -25,7 +25,7 @@ class ViewHelperVariableContainer
     protected $objects = [];
 
     /**
-     * @var ViewInterface
+     * @var ViewInterface|null
      */
     protected $view;
 
@@ -154,7 +154,7 @@ class ViewHelperVariableContainer
      *
      * !!! This is NOT a public API and might still change!!!
      *
-     * @return ViewInterface The View
+     * @return ViewInterface|null The View
      */
     public function getView()
     {

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -57,7 +57,7 @@ abstract class AbstractTemplateView extends AbstractView
     public function __construct(RenderingContextInterface $context = null)
     {
         if (!$context) {
-            $context = new RenderingContext($this);
+            $context = new RenderingContext();
             $context->setControllerName('Default');
             $context->setControllerAction('Default');
         }

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
@@ -127,6 +128,15 @@ class RenderViewHelper extends AbstractViewHelper
         }
 
         $view = $renderingContext->getViewHelperVariableContainer()->getView();
+        if (!$view) {
+            throw new Exception(
+                'The f:render ViewHelper was used in a context where the ViewHelperVariableContainer does not contain ' .
+                'a reference to the View. Normally this is taken care of by the TemplateView, so most likely this ' .
+                'error is because you overrode AbstractTemplateView->initializeRenderingContext() and did not call ' .
+                '$renderingContext->getViewHelperVariableContainer()->setView($this) or parent::initializeRenderingContext. ' .
+                'This is an issue you must fix in your code as f:render is fully unable to render anything without a View.'
+            );
+        }
         $content = '';
         if ($renderable) {
             $content = $renderable->render($renderingContext);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -12,7 +12,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToArray;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class CastingExpressionNodeTest
@@ -30,8 +29,7 @@ class CastingExpressionNodeTest extends UnitTestCase
             ['dummy'],
             ['{test as string}', ['test as string']]
         );
-        $view = new TemplateView();
-        $context = new RenderingContext($view);
+        $context = new RenderingContext();
         $context->setVariableProvider(new StandardVariableProvider(['test' => 10]));
         $result = $subject->evaluate($context);
         $this->assertSame('10', $result);
@@ -42,11 +40,10 @@ class CastingExpressionNodeTest extends UnitTestCase
      */
     public function testEvaluateInvalidExpressionThrowsException()
     {
-        $view = new TemplateView();
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider(new StandardVariableProvider());
         $this->setExpectedException(ExpressionException::class);
-        $result = CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', []);
+        CastingExpressionNode::evaluateExpression($renderingContext, 'suchaninvalidexpression as 1', []);
     }
 
     /**
@@ -57,8 +54,7 @@ class CastingExpressionNodeTest extends UnitTestCase
      */
     public function testEvaluateExpression($expression, array $variables, $expected)
     {
-        $view = new TemplateView();
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
         $result = CastingExpressionNode::evaluateExpression($renderingContext, $expression, []);
         $this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -10,7 +10,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class MathExpressionNodeTest
@@ -26,8 +25,7 @@ class MathExpressionNodeTest extends UnitTestCase
      */
     public function testEvaluateExpression($expression, array $variables, $expected)
     {
-        $view = new TemplateView();
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
         $result = MathExpressionNode::evaluateExpression($renderingContext, $expression, []);
         $this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -10,7 +10,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class TernaryExpressionNodeTest
@@ -62,8 +61,7 @@ class TernaryExpressionNodeTest extends UnitTestCase
      */
     public function testEvaluateExpression($expression, array $variables, $expected)
     {
-        $view = new TemplateView();
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
         $result = TernaryExpressionNode::evaluateExpression($renderingContext, $expression, []);
         $this->assertEquals($expected, $result);

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -9,7 +9,6 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for RootNode
@@ -23,9 +22,8 @@ class RootNodeTest extends UnitTestCase
      */
     public function testEvaluateCallsEvaluateChildNodes()
     {
-        $view = new TemplateView();
         $subject = $this->getMock(RootNode::class, ['evaluateChildNodes']);
         $subject->expects($this->once())->method('evaluateChildNodes');
-        $subject->evaluate(new RenderingContext($view));
+        $subject->evaluate(new RenderingContext());
     }
 }

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -18,7 +18,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for ParsingState
@@ -44,8 +43,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function testGetter($property, $value)
     {
-        $view = new TemplateView();
-        $subject = $this->getAccessibleMock(RenderingContext::class, ['dummy'], [$view]);
+        $subject = $this->getAccessibleMock(RenderingContext::class, ['dummy']);
         $subject->_set($property, $value);
         $getter = 'get' . ucfirst($property);
         $this->assertSame($value, $subject->$getter());
@@ -58,8 +56,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function testSetter($property, $value)
     {
-        $view = new TemplateView();
-        $subject = new RenderingContext($view);
+        $subject = new RenderingContext();
         $setter = 'set' . ucfirst($property);
         $subject->$setter($value);
         $this->assertAttributeSame($value, $property, $subject);
@@ -110,7 +107,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function testIsCacheEnabled()
     {
-        $subject = new RenderingContext($this->getMock(TemplateView::class));
+        $subject = new RenderingContext();
         $this->assertFalse($subject->isCacheEnabled());
         $subject->setCache($this->getMock(SimpleFileCache::class));
         $this->assertTrue($subject->isCacheEnabled());

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -20,7 +20,6 @@ use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeDefault
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Testcase for AbstractViewHelper
@@ -246,8 +245,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $templateVariableContainer = $this->getMock(StandardVariableProvider::class);
         $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
 
-        $view = new TemplateView();
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider($templateVariableContainer);
         $renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);
 
@@ -374,8 +372,7 @@ class AbstractViewHelperTest extends UnitTestCase
      */
     public function testCompileReturnsAndAssignsExpectedPhpCode()
     {
-        $view = new TemplateView();
-        $context = new RenderingContext($view);
+        $context = new RenderingContext();
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['dummy'], [], '', false);
         $node = new ViewHelperNode($context, 'f', 'comment', [], new ParsingState());
         $init = '';

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -11,7 +11,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 /**
  * Class ViewHelperInvokerTest
@@ -29,10 +28,9 @@ class ViewHelperInvokerTest extends UnitTestCase
      */
     public function testInvokeViewHelper($viewHelperClassName, array $arguments, $expectedOutput, $expectedException)
     {
-        $view = new TemplateView();
         $resolver = new ViewHelperResolver();
         $invoker = new ViewHelperInvoker($resolver);
-        $renderingContext = new RenderingContext($view);
+        $renderingContext = new RenderingContext();
         if ($expectedException) {
             $this->setExpectedException($expectedException);
         }

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  */
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\ParsedTemplateImplementationFixture;
@@ -205,6 +206,23 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
         );
         $output = $this->subject->render();
         $this->assertEquals('default-foobar', $output);
+    }
+
+    public function testThrowsExceptionIfExecutedWithoutViewSetOnViewHelperVariableContainerRegardlessOfInvalidArguments()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $this->setExpectedException(Exception::class);
+        $arguments = [
+            'partial' => null,
+            'section' => null,
+            'delegate' => null,
+            'renderable' => null,
+            'arguments' => [],
+            'optional' => true,
+            'default' => null,
+            'contentAs' => null
+        ];
+        RenderViewHelper::renderStatic($arguments, function() {}, $renderingContext);
     }
 
     /**

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -13,7 +13,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
-use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\CaseViewHelper;
 use TYPO3Fluid\Fluid\ViewHelpers\DefaultCaseViewHelper;
 use TYPO3Fluid\Fluid\ViewHelpers\SwitchViewHelper;
@@ -171,7 +170,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
      */
     public function getCompileTestValues()
     {
-        $renderingContext = new RenderingContext($this->getMock(TemplateView::class), ['dummy'], [], '', false);
+        $renderingContext = new RenderingContext();
         $parsingState = new ParsingState();
         $emptySwitchNode = new ViewHelperNode(
             $renderingContext,


### PR DESCRIPTION
For a while there has been a near-circular dependency between
RenderingContext and View. The only component that truly
depends on the View is the ViewHelperVariableContainer, so
removing this interdependency is fairly painless.

A few key points:

* This remains compatible with method signatures in overridden
   RenderingContext classes that still require the view. Such classes
   can simply remove this constructor argument once the minimum
   fluid requirement is raised to a version with this patch included.
* The ViewHelperVariableContainer->getView method may now
   return NULL if a Fluid implementation overrides the normal View
   initialization logic (which sets the View in ViewHelperVariableContainer).
   This is not an issue since the method is already clearly annotated
   as "not public, may change" - and now it has changed. For a very
   limited set of ViewHelpers which actually use this internal API, this
   could be a breaking change.
* One such ViewHelper exists in Fluid - f:render. This patch changes
   that ViewHelper so it throws a ViewHelper Exception if detecting a
   ViewHelperVariableContainer without a View reference. This then
   reports a very precise cause and instructions for fixing.
* Tested and confirmed with TYPO3 dev-master, and third party app.

Close: #96