### PR TITLE
[FEATURE] Add support for ES2015 style short array syntax

### DIFF
--- a/doc/FLUID_SYNTAX.md
+++ b/doc/FLUID_SYNTAX.md
@@ -118,3 +118,23 @@ fail if you receive unexpected types. To be able to cast a variable in this case
 
 ...and Fluid will be able to detect the **expression** you used, extract and cast the variable and finally remove the quotations
 and use the variable directly (although, semantically, the quotes mean you create a new TextNode that contains a type other than
+
+Array syntax
+------------
+
+Arrays can be written as non-associative and associative arrays. For associative arrays, there also exists a shorthand notation
+allows to very concisely write associative arrays that have the variable name as key.
+
+```xml
+<f:foo bar="{myVar, anotherVar, some: { yetAnotherVar }}"></f:foo>
+```
+
+will evaluate the same as if it was written as
+
+```xml
+<f:foo bar="{myVar: myVar, anotherVar: anotherVar, some: { yetAnotherVar: yetAnotherVar }}"></f:foo>
+```
+
+Note though, that this syntax is not possible for single element arrays, since the notation is ambiguous with the simple variable
+access syntax. This is an side effect of Fluid using curly brackets both for variable access and array declarations and therefore
+can not be worked around.

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -205,18 +205,21 @@ abstract class Patterns
 			{                                                      # Each array needs to start with {
 				(?P<Array>                                         # Start sub-match
 					(?:
-						\s*(
-							[a-zA-Z0-9\\-_]+                       # Unquoted key
-							|"(?:\\\"|[^"])+"                      # Double quoted key, supporting more characters like dots and square brackets
-							|\'(?:\\\\\'|[^\'])+\'                 # Single quoted key, supporting more characters like dots and square brackets
-						)
-						\s*:\s*                                    # Key|Value delimiter :
-						(?:                                        # Possible value options:
-							"(?:\\\"|[^"])*"                       # Double quoted string
-							|\'(?:\\\\\'|[^\'])*\'                 # Single quoted string
-							|[a-zA-Z0-9\-_.]+                      # variable identifiers
-							|(?P>Recursion)                        # Another sub-array
-						)                                          # END possible value options
+						\s*(?:                                     # key-value syntax
+							(                                      # Possible key options
+								[a-zA-Z0-9\\-_]+                   # Unquoted key
+								|"(?:\\\"|[^"])+"                  # Double quoted key, supporting more characters like dots and square brackets
+								|\'(?:\\\\\'|[^\'])+\'             # Single quoted key, supporting more characters like dots and square brackets
+							)                                      # END possible key options
+							\s*:\s*                                # Key|Value delimiter :
+							(?:                                    # Possible value options:
+								"(?:\\\"|[^"])*"                   # Double quoted string
+								|\'(?:\\\\\'|[^\'])*\'             # Single quoted string
+								|[a-zA-Z0-9\-_.]+                  # variable identifiers
+								|(?P>Recursion)                    # Another sub-array
+							)                                      # END possible value options
+						)                                          # END key-value syntax
+						|[a-zA-Z0-9\\-_]+                          # Single unquoted key matching short array syntax
 						\s*,?                                      # There might be a , to separate different parts of the array
 					)*                                             # The above cycle is repeated for all array elements
 				)                                                  # End array sub-match
@@ -248,6 +251,7 @@ abstract class Patterns
 				|(?P<Number>[0-9]+(?:\\.[0-9]+)?)                           # A hardcoded Number (also possibly with decimals)
 				|\\{\\s*(?P<Subarray>(?:(?P>ArrayPart)\\s*,?\\s*)+)\\s*\\}  # Another sub-array
 			)                                                               # END possible value options
+			|(?P<KeyValue>[a-zA-Z0-9_-]+)                                   # The arry key and value in short syntax
 		)\\s*(?=\\z|,|\\})                                                  # An array part sub-match ends with either a comma, a closing curly bracket or end of string
 	/x';
 }

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -195,7 +195,7 @@ abstract class Patterns
     /**
      * Pattern which detects the array/object syntax like in JavaScript, so it
      * detects strings like:
-     * {object: value, object2: {nested: array}, object3: "Some string"}
+     * {object: value, object2: {nested: array}, object3: "Some string", object4}
      *
      * THIS IS ALMOST THE SAME AS IN SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS
      *
@@ -205,22 +205,23 @@ abstract class Patterns
 			{                                                      # Each array needs to start with {
 				(?P<Array>                                         # Start sub-match
 					(?:
-						\s*(?:                                     # key-value syntax
+						\s*(?:
+						(?:                                        # key-value syntax
 							(                                      # Possible key options
 								[a-zA-Z0-9\\-_]+                   # Unquoted key
-								|"(?:\\\"|[^"])+"                  # Double quoted key, supporting more characters like dots and square brackets
+								|"(?:\\\\"|[^"])+"                 # Double quoted key, supporting more characters like dots and square brackets
 								|\'(?:\\\\\'|[^\'])+\'             # Single quoted key, supporting more characters like dots and square brackets
 							)                                      # END possible key options
 							\s*:\s*                                # Key|Value delimiter :
 							(?:                                    # Possible value options:
-								"(?:\\\"|[^"])*"                   # Double quoted string
+								"(?:\\\\"|[^"])*"                  # Double quoted string
 								|\'(?:\\\\\'|[^\'])*\'             # Single quoted string
-								|[a-zA-Z0-9\-_.]+                  # variable identifiers
+								|[a-zA-Z0-9\\-_.]+                 # variable identifiers
 								|(?P>Recursion)                    # Another sub-array
 							)                                      # END possible value options
 						)                                          # END key-value syntax
 						|[a-zA-Z0-9\\-_]+                          # Single unquoted key matching short array syntax
-						\s*,?                                      # There might be a , to separate different parts of the array
+						)\s*,?                                     # There might be a , to separate different parts of the array
 					)*                                             # The above cycle is repeated for all array elements
 				)                                                  # End array sub-match
 			}                                                      # Each array ends with }
@@ -232,26 +233,28 @@ abstract class Patterns
      * Note that this pattern can be used on strings with or without surrounding curly brackets.
      */
     static public $SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS = '/
-		(?P<ArrayPart>                                                      # Start sub-match of one key and value pair
-			(?P<Key>                                                        # The arry key
-				 [a-zA-Z0-9_-]+                                             # Unquoted
-				|"(?:\\\\"|[^"])+"                                          # Double quoted
-				|\'(?:\\\\\'|[^\'])+\'                                      # Single quoted
+		(?P<ArrayPart>
+			(?:                                                                 # Start sub-match of one key and value pair
+				(?P<Key>                                                        # The arry key
+					 [a-zA-Z0-9_-]+                                             # Unquoted
+					|"(?:\\\\"|[^"])+"                                          # Double quoted
+					|\'(?:\\\\\'|[^\'])+\'                                      # Single quoted
+				)
+				\\s*:\\s*                                                       # Key|Value delimiter :
+				(?:                                                             # BEGIN Possible value options
+					(?P<QuotedString>                                           # Quoted string
+						 "(?:\\\\"|[^"])*"
+						|\'(?:\\\\\'|[^\'])*\'
+					)
+					|(?P<VariableIdentifier>
+						(?:(?=[^,{}\.]*[a-zA-Z])[a-zA-Z0-9_-]*)                 # variable identifiers must contain letters (otherwise they are hardcoded numbers)
+						(?:\\.[a-zA-Z0-9_-]+)*                                  # but in sub key access only numbers are fine (foo.55)
+					)
+					|(?P<Number>[0-9]+(?:\\.[0-9]+)?)                           # A hardcoded Number (also possibly with decimals)
+					|\\{\\s*(?P<Subarray>(?:(?P>ArrayPart)\\s*,?\\s*)+)\\s*\\}  # Another sub-array
+				)                                                               # END possible value options
 			)
-			\\s*:\\s*                                                       # Key|Value delimiter :
-			(?:                                                             # BEGIN Possible value options
-				(?P<QuotedString>                                           # Quoted string
-					 "(?:\\\\"|[^"])*"
-					|\'(?:\\\\\'|[^\'])*\'
-				)
-				|(?P<VariableIdentifier>
-					(?:(?=[^,{}\.]*[a-zA-Z])[a-zA-Z0-9_-]*)                 # variable identifiers must contain letters (otherwise they are hardcoded numbers)
-					(?:\\.[a-zA-Z0-9_-]+)*                                  # but in sub key access only numbers are fine (foo.55)
-				)
-				|(?P<Number>[0-9]+(?:\\.[0-9]+)?)                           # A hardcoded Number (also possibly with decimals)
-				|\\{\\s*(?P<Subarray>(?:(?P>ArrayPart)\\s*,?\\s*)+)\\s*\\}  # Another sub-array
-			)                                                               # END possible value options
-			|(?P<KeyValue>[a-zA-Z0-9_-]+)                                   # The arry key and value in short syntax
-		)\\s*(?=\\z|,|\\})                                                  # An array part sub-match ends with either a comma, a closing curly bracket or end of string
+			|(?P<KeyValue>[a-zA-Z0-9_-]+)                                       # The arry key and value in short syntax
+		)\\s*(?=\\z|,|\\})                                                      # An array part sub-match ends with either a comma, a closing curly bracket or end of string
 	/x';
 }

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -678,6 +678,10 @@ class TemplateParser
         $arrayToBuild = [];
         if (preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS, $arrayText, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $singleMatch) {
+                if (!empty($singleMatch['KeyValue'])) {
+                    $arrayToBuild[$singleMatch['KeyValue']] = new ObjectAccessorNode($singleMatch['KeyValue']);
+                    continue;
+                }
                 $arrayKey = $this->unquoteString($singleMatch['Key']);
                 if (!empty($singleMatch['VariableIdentifier'])) {
                     $arrayToBuild[$arrayKey] = new ObjectAccessorNode($singleMatch['VariableIdentifier']);

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -339,7 +339,11 @@ class PatternsTest extends UnitTestCase
             ['string' => '{"a":{bla:{x:z}, b: a}}'],
             ['string' => '{a:{bla:{"x":z}, b: a}}'],
             ['string' => '{"@a": "bar"}'],
-            ['string' => '{\'_b\': "bar"}']
+            ['string' => '{\'_b\': "bar"}'],
+
+            // short syntax
+            ['string' => '{a, b, c:   {   d }}'],
+            ['string' => '{a:"foo", b, c: { e: \'bar\', g }}']
         ];
     }
 


### PR DESCRIPTION
This change introduces support for writing arrays in a short syntax that allows
specifying the variable names as key in a very concise way:

```
{ something, somethingElse, somethingWholeDifferent, andAlsoThis: WhichIsSomethingElse }
```

will be evaluated exactly as if it was written as

```
{ something: something, somethingElse: somethingElse, somethingWholeDifferent: somethingWholeDifferent, andAlsoThis: WhichIsSomethingElse }
```

Note though, that this currently will not work for single element arrays, since the
notation is then ambiguous with normal variable access/evaluation. Therefore, `{ foo }`
will just mean "the value of variable foo".

Resolves #336