### PR TITLE
[TASK] Call getter instead of accessing property

### DIFF
--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -116,7 +116,7 @@ class ParsingState implements ParsedTemplateInterface
      */
     public function render(RenderingContextInterface $renderingContext)
     {
-        return $this->rootNode->evaluate($renderingContext);
+        return $this->getRootNode()->evaluate($renderingContext);
     }
 
     /**

--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -31,16 +31,17 @@ abstract class AbstractNode implements NodeInterface
      */
     public function evaluateChildNodes(RenderingContextInterface $renderingContext)
     {
-        $numberOfChildNodes = count($this->childNodes);
+        $childNodes = $this->getChildNodes();
+        $numberOfChildNodes = count($childNodes);
         if ($numberOfChildNodes === 0) {
             return null;
         }
         if ($numberOfChildNodes === 1) {
-            return $this->evaluateChildNode($this->childNodes[0], $renderingContext, false);
+            return $this->evaluateChildNode($childNodes[0], $renderingContext, false);
         }
         $output = '';
         /** @var $subNode NodeInterface */
-        foreach ($this->childNodes as $subNode) {
+        foreach ($childNodes as $subNode) {
             $output .= $this->evaluateChildNode($subNode, $renderingContext, true);
         }
         return $output;


### PR DESCRIPTION
Allows class overrides to only override getRootNode
on ParsingState in order to change which node gets
returned, instead of also having to override the
render() method. Does not affect behavior.