### PR TITLE
[BUGFIX] Respect $ignoreUnknown when rendering section/partial

### DIFF
--- a/examples/Resources/Private/Singles/ErrorHandling.html
+++ b/examples/Resources/Private/Singles/ErrorHandling.html
@@ -5,6 +5,7 @@
 <!-- View errors; rendering an asset that doesn't exist -->
 <f:render partial="DoesNotExist" />
 <f:render section="DoesNotExist" />
+<f:render section="DoesNotExist" partial="DoesNotExist" />
 
 <!-- ViewHelper errors; receiving arguments that were not registered -->
 <f:if notregistered="1" />

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -14,6 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
 
 /**
@@ -230,6 +231,16 @@ abstract class AbstractTemplateView extends AbstractView
             $parsedTemplate = $this->getCurrentParsedTemplate();
         } catch (PassthroughSourceException $error) {
             return $error->getSource();
+        } catch (InvalidTemplateResourceException $error) {
+            if (!$ignoreUnknown) {
+                return $renderingContext->getErrorHandler()->handleViewError($error);
+            }
+            return '';
+        } catch (InvalidSectionException $error) {
+            if (!$ignoreUnknown) {
+                return $renderingContext->getErrorHandler()->handleViewError($error);
+            }
+            return '';
         } catch (Exception $error) {
             return $renderingContext->getErrorHandler()->handleViewError($error);
         }
@@ -297,6 +308,16 @@ abstract class AbstractTemplateView extends AbstractView
             );
         } catch (PassthroughSourceException $error) {
             return $error->getSource();
+        } catch (InvalidTemplateResourceException $error) {
+            if (!$ignoreUnknown) {
+                return $renderingContext->getErrorHandler()->handleViewError($error);
+            }
+            return '';
+        } catch (InvalidSectionException $error) {
+            if (!$ignoreUnknown) {
+                return $renderingContext->getErrorHandler()->handleViewError($error);
+            }
+            return '';
         } catch (Exception $error) {
             return $renderingContext->getErrorHandler()->handleViewError($error);
         }


### PR DESCRIPTION
Somewhere, respect for $ignoreUnknown was lost. This patch
adds a check and only throws the exception if it is false.