### PR TITLE
[TASK] Update deprecated license for Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "typo3fluid/fluid",
 	"description": "The TYPO3 Fluid template rendering engine",
-	"license": ["LGPL-3.0"],
+	"license": ["LGPL-3.0-or-later"],
 	"require": {
 		"php": ">=5.5.0"
 	},


### PR DESCRIPTION
Updates the composer manifest license value to the
current way of saying LGPL 3 or later.