### PR TITLE
Add tests for objects with countable-interface

### DIFF
--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -4,6 +4,15 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Conditions;
 use TYPO3Fluid\Fluid\Tests\Functional\BaseConditionalFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 
+
+class CanBeCounted implements \Countable
+{
+    public function count()
+    {
+        return 0;
+    }
+}
+
 /**
  * Class VariableConditionsTest
  */
@@ -25,6 +34,8 @@ class VariableConditionsTest extends BaseConditionalFunctionalTestCase
         $someArray = [
             'foo' => 'bar'
         ];
+
+        $emptyCountable = new \SplObjectStorage();
         return [
             // simple assignments
             ['{test}', true, ['test' => 1]],
@@ -70,7 +81,11 @@ class VariableConditionsTest extends BaseConditionalFunctionalTestCase
 
             // inline viewHelpers
             ['(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 1)', true],
-            ['(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 0)', false]
+            ['(TRUE && ({f:if(condition: \'TRUE\', then: \'1\')} == 0)', false],
+
+            //conditions with countable objects
+            ['{emptyCountable}', false, ['emptyCountable' => $emptyCountable]],
+            ['{emptyCountable} || false', false, ['emptyCountable' => $emptyCountable]]
         ];
     }
 }

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -5,14 +5,6 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseConditionalFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithToString;
 
 
-class CanBeCounted implements \Countable
-{
-    public function count()
-    {
-        return 0;
-    }
-}
-
 /**
  * Class VariableConditionsTest
  */

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -85,7 +85,9 @@ class VariableConditionsTest extends BaseConditionalFunctionalTestCase
 
             //conditions with countable objects
             ['{emptyCountable}', false, ['emptyCountable' => $emptyCountable]],
-            ['{emptyCountable} || false', false, ['emptyCountable' => $emptyCountable]]
+            ['{emptyCountable} || FALSE', false, ['emptyCountable' => $emptyCountable]],
+            // inline if-viewhelper condition with countable objects
+            ['{f:if(condition: \'{emptyCountable} || FALSE\', else: \'1\')} == 1)', true, ['emptyCountable' => $emptyCountable]]
         ];
     }
 }


### PR DESCRIPTION
While updating TYPO3 to 8.7.10 I came accross some errors in fluid. Seems it does not handle countable objects correctly when used in a conjunction (&& or ||). Also it seems to make a difference if the conditions is used within an inline stlye viewhelper or in a tag-style viewhelper.
TYPO3-Bug-Ticket: https://forge.typo3.org/issues/83812

I added 3 functional test, 2 of them are failing, which confirms the bug-report.