### PR TITLE
[BUGFIX] Switch incompatible use of DateTime format

### DIFF
--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -125,7 +125,7 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase
                 \DateTime::createFromFormat('U', '1468328915'),
                 ['typeOnly' => false, 'html' => false, 'levels' => 3],
                 'DateTime: ' . PHP_EOL . '  "class": string \'DateTime\'' . PHP_EOL .
-                '  "ISO8601": string \'2016-07-12T13:08:35+0000\'' . PHP_EOL . '  "UNIXTIME": integer 1468328915' . PHP_EOL
+                '  "ISO8601": string \'2016-07-12T13:08:35+00:00\'' . PHP_EOL . '  "UNIXTIME": integer 1468328915' . PHP_EOL
             ]
         ];
     }


### PR DESCRIPTION
The debug viewhelper use now DateTime::ATOM instead of DateTime::ISO8601.

This format is not compatible with ISO-8601, but is left this way for backward compatibility reasons. Use DateTime::ATOM or DATE_ATOM for compatibility with ISO-8601 instead.

Resolves: #374