### PR TITLE
[FEATURE] Deprecate evaluateCondition() in favor of verdict()

### DIFF
--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -81,19 +82,19 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IfViewHelper extends AbstractConditionViewHelper
 {
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
+    }
 
     /**
-     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
-     *
-     * @return string the rendered string
-     * @api
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @return bool
      */
-    public function render()
+    public static function verdict(array $arguments, RenderingContextInterface $renderingContext)
     {
-        if ($this->arguments['condition']) {
-            return $this->renderThenChild();
-        } else {
-            return $this->renderElseChild();
-        }
+        return (bool)$arguments['condition'];
     }
 }

--- a/tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -5,6 +5,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper;
 
 /**
@@ -12,34 +13,13 @@ use TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper;
  */
 class IfViewHelperTest extends ViewHelperBaseTestcase
 {
-
-    /**
-     * @var \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
-     */
-    protected $viewHelper;
-
-    /**
-     * @var \TYPO3Fluid\Fluid\Core\ViewHelper\Arguments
-     */
-    protected $mockArguments;
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->viewHelper = $this->getAccessibleMock(IfViewHelper::class, ['renderThenChild', 'renderElseChild']);
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $this->viewHelper->initializeArguments();
-    }
-
     /**
      * @test
      */
     public function viewHelperRendersThenChildIfConditionIsTrue()
     {
-        $this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('foo'));
-
-        $this->viewHelper->setArguments(['condition' => true]);
-        $actualResult = $this->viewHelper->render();
+        $context = $this->getMockBuilder(RenderingContextInterface::class)->getMockForAbstractClass();
+        $actualResult = IfViewHelper::renderStatic(['condition' => true, 'then' => 'foo'], function() {}, $context);
         $this->assertEquals('foo', $actualResult);
     }
 
@@ -48,10 +28,8 @@ class IfViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperRendersElseChildIfConditionIsFalse()
     {
-        $this->viewHelper->expects($this->at(0))->method('renderElseChild')->will($this->returnValue('foo'));
-
-        $this->viewHelper->setArguments(['condition' => false]);
-        $actualResult = $this->viewHelper->render();
+        $context = $this->getMockBuilder(RenderingContextInterface::class)->getMockForAbstractClass();
+        $actualResult = IfViewHelper::renderStatic(['condition' => false, 'else' => 'foo'], function() {}, $context);
         $this->assertEquals('foo', $actualResult);
     }
 }

--- a/tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -19,8 +19,8 @@ class IfViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperRendersThenChildIfConditionIsTrue()
     {
         $context = $this->getMockBuilder(RenderingContextInterface::class)->getMockForAbstractClass();
-        $actualResult = IfViewHelper::renderStatic(['condition' => true, 'then' => 'foo'], function() {}, $context);
-        $this->assertEquals('foo', $actualResult);
+        $actualResult = IfViewHelper::renderStatic(['condition' => true, 'then' => 'THEN', 'else' => 'ELSE'], function() {}, $context);
+        $this->assertEquals('THEN', $actualResult);
     }
 
     /**
@@ -29,7 +29,7 @@ class IfViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperRendersElseChildIfConditionIsFalse()
     {
         $context = $this->getMockBuilder(RenderingContextInterface::class)->getMockForAbstractClass();
-        $actualResult = IfViewHelper::renderStatic(['condition' => false, 'else' => 'foo'], function() {}, $context);
-        $this->assertEquals('foo', $actualResult);
+        $actualResult = IfViewHelper::renderStatic(['condition' => false, 'then' => 'THEN', 'else' => 'ELSE'], function() {}, $context);
+        $this->assertEquals('ELSE', $actualResult);
     }
 }


### PR DESCRIPTION
The AbstractConditionViewHelper method evaluateCondition
was less than ideal, in that it:

* Only received arguments and thus could not support context
  related conditions.
* Was protected which prevents a future refactoring to call the
  method to evaluate directly from the compiled code.
* Was not strictly requiring an array of arguments which meant
  technically unsafe code (static analysis would demand guard)

Instead of breaking the API, the old method is deprecated in
favor of a new method which strictly requires arguments as an
array and the current instance of the rendering context.

The new method is made public though it is still not being
called as such - this is in preparation for a future improvement
of the compiled code to clean up the current closure-based
solution for evaluating the if-elseif-else structure.

In addition, this patch:

* Refactors the condition ViewHelper so using the base class
  does not automatically register a “condition” argument.
* Refactors `f:if` to use the new API method.