### PR TITLE
[BUGFIX] Fix ternary condition behaviors

### DIFF
--- a/examples/Resources/Private/Singles/Conditions.html
+++ b/examples/Resources/Private/Singles/Conditions.html
@@ -10,7 +10,12 @@ Conditions template from Singles.
 	<f:else>Not touched</f:else>
 </f:if>
 
-Ternary expression: {checkTernary ? ternaryTrue : ternaryFalse}
+Ternary expression without then case: {ternaryTrue ? : ternaryFalse}
+Negated ternary expression without then case: {!checkTernary ? : ternaryFalse}
+Standard ternary expression: {checkTernary ? ternaryTrue : ternaryFalse}
+Negated ternary expression: {!checkTernary ? ternaryTrue : ternaryFalse}
+Ternary expression with dotted variable paths: {asArray.nested.true ? asArray.nested.then : asArray.nested.else}
+Ternary expression with dotted variable paths without then case: {asArray.nested.then ? : asArray.nested.else}
 
 <f:if condition="0" else="0 === FALSE" />
 <f:if condition="1" then="1 === TRUE" />

--- a/examples/Resources/Private/Singles/Conditions.html
+++ b/examples/Resources/Private/Singles/Conditions.html
@@ -10,12 +10,12 @@ Conditions template from Singles.
 	<f:else>Not touched</f:else>
 </f:if>
 
-Ternary expression without then case: {ternaryTrue ? : ternaryFalse}
-Negated ternary expression without then case: {!checkTernary ? : ternaryFalse}
+Ternary expression without then case: {ternaryTrue ?: ternaryFalse}
+Negated ternary expression without then case: {!checkTernary ?: ternaryFalse}
 Standard ternary expression: {checkTernary ? ternaryTrue : ternaryFalse}
 Negated ternary expression: {!checkTernary ? ternaryTrue : ternaryFalse}
 Ternary expression with dotted variable paths: {asArray.nested.true ? asArray.nested.then : asArray.nested.else}
-Ternary expression with dotted variable paths without then case: {asArray.nested.then ? : asArray.nested.else}
+Ternary expression with dotted variable paths without then case: {asArray.nested.then ?: asArray.nested.else}
 
 <f:if condition="0" else="0 === FALSE" />
 <f:if condition="1" then="1 === TRUE" />

--- a/examples/example_conditions.php
+++ b/examples/example_conditions.php
@@ -20,6 +20,13 @@ $view->assign('vararray2', ['bar' => 'foo']);
 $view->assign('checkTernary', true);
 $view->assign('ternaryTrue', 'The ternary expression is TRUE');
 $view->assign('ternaryFalse', 'The ternary expression is FALSE');
+$view->assign('asArray', [
+    'nested' => [
+        'then' => 'Dotted variable TRUE',
+        'else' => 'Dotted variable FALSE',
+        'check' => true
+    ]
+]);
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -26,11 +26,11 @@ class TernaryExpressionNode extends AbstractExpressionNode
 		(
 			{                                                               # Start of shorthand syntax
 				(?:                                                         # Math expression is composed of...
-					[a-zA-Z0-9.\(\)\!\|\&\\\'\'\"\=\<\>\%\s\{\}\:\,]+       # Check variable side
-					[\s]+\?[\s]+
-					[a-zA-Z0-9.\s\'\"]+                                     # Then variable side
-					[\s]*:[\s]*
-					[a-zA-Z0-9.\s\'\"]+                                     # Else variable side
+					[\\!a-zA-Z0-9.\(\)\!\|\&\\\'\'\"\=\<\>\%\s\{\}\:\,]+    # Check variable side
+					[\s]?\?[\s]?
+					[a-zA-Z0-9.\s\'\"\\.]*                                  # Then variable side, optional
+					[\s]?:[\s]?
+					[a-zA-Z0-9.\s\'\"\\.]+                                  # Else variable side
 				)
 			}                                                               # End of shorthand syntax
 		)/x';
@@ -50,12 +50,18 @@ class TernaryExpressionNode extends AbstractExpressionNode
     {
         $parts = preg_split('/([\?:])/s', $expression);
         $parts = array_map([__CLASS__, 'trimPart'], $parts);
+        $negated = false;
         list ($check, $then, $else) = $parts;
+
+        if ($then === '') {
+            $then = $check{0} === '!' ? $else : $check;
+        }
 
         $context = static::gatherContext($renderingContext, $expression);
 
         $parser = new BooleanParser();
         $checkResult = $parser->evaluate($check, $context);
+
         if ($checkResult) {
             return static::getTemplateVariableOrValueItself($renderingContext->getTemplateParser()->unquoteString($then), $renderingContext);
         } else {

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -564,6 +564,9 @@ class TemplateParser
     public function unquoteString($quotedValue)
     {
         $value = $quotedValue;
+        if ($value === '') {
+            return $value;
+        }
         if ($quotedValue{0} === '"') {
             $value = str_replace('\\"', '"', preg_replace('/(^"|"$)/', '', $quotedValue));
         } elseif ($quotedValue{0} === '\'') {

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -80,6 +80,10 @@ class ExamplesTest extends BaseTestCase
             'example_conditions.php' => [
                 'example_conditions.php',
                 [
+                    'Standard ternary expression: The ternary expression is TRUE',
+                    'Negated ternary expression without then case: The ternary expression is FALSE',
+                    'Negated ternary expression: The ternary expression is FALSE',
+                    'Ternary expression without then case: The ternary expression is TRUE',
                     '1 === TRUE',
                     '(0) === FALSE',
                     '(1) === TRUE',


### PR DESCRIPTION
This patch corrects the following problems for
ternary conditions:

* Dotted paths were not detected correctly.
* The “then” part was mandatory
* Negating the condition did not work correctly

All three described cases are working now.

Fixes: #148