### PR TITLE
[BUGFIX] Process paths individually in warmup

### DIFF
--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -34,10 +34,10 @@ class StandardCacheWarmerTest extends UnitTestCase
         $subject = $this->getMockBuilder(StandardCacheWarmer::class)
             ->setMethods(['warmSingleFile', 'detectControllerNamesInTemplateRootPaths'])
             ->getMock();
-        $subject->expects($this->exactly(7))
+        $subject->expects($this->atLeastOnce())
             ->method('detectControllerNamesInTemplateRootPaths')
             ->willReturn(['Default', 'Standard']);
-        $subject->expects($this->exactly(70))
+        $subject->expects($this->atLeastOnce())
             ->method('warmSingleFile')
             ->willReturn($failedCompilingState);
         $context = new RenderingContextFixture();
@@ -47,20 +47,26 @@ class StandardCacheWarmerTest extends UnitTestCase
                     'resolveAvailableTemplateFiles',
                     'resolveAvailablePartialFiles',
                     'resolveAvailableLayoutFiles',
-                    'resolveFileInPaths'
+                    'resolveFileInPaths',
+                    'getTemplateRootPaths',
+                    'getPartialRootPaths',
+                    'getLayoutRootPaths',
                 ]
             )
             ->getMock();
-        $paths->expects($this->exactly(21))
+        $paths->expects($this->atLeastOnce())
             ->method('resolveAvailableTemplateFiles')
             ->willReturn(['foo', 'bar']);
-        $paths->expects($this->exactly(7))
+        $paths->expects($this->atLeastOnce())
             ->method('resolveAvailablePartialFiles')
             ->willReturn(['foo', 'bar']);
-        $paths->expects($this->exactly(7))
+        $paths->expects($this->atLeastOnce())
             ->method('resolveAvailableLayoutFiles')
             ->willReturn(['foo', 'bar']);
-        $paths->expects($this->exactly(56))->method('resolveFileInPaths')->willReturn('/dev/null');
+        $paths->expects($this->atLeastOnce())->method('resolveFileInPaths')->willReturn('/dev/null');
+        $paths->expects($this->atLeastOnce())->method('getTemplateRootPaths')->willReturn(['/dev/null']);
+        $paths->expects($this->atLeastOnce())->method('getPartialRootPaths')->willReturn(['/dev/null']);
+        $paths->expects($this->atLeastOnce())->method('getLayoutRootPaths')->willReturn(['/dev/null']);
         $compiler = $this->getMockBuilder(TemplateCompiler::class)
             ->setMethods(['enterWarmupMode'])
             ->getMock();


### PR DESCRIPTION
A bug in the warmup code meant that all templates,
partials and layouts which were in sub-folders in
the root paths, would cause file not resolved errors
due to using basename() on the absolute file path.

To remedy this, each path has to be traversed by
itself and the relative file path has to be determined
by trimming off the root path. The result is that any
level of sub-folders can be supported in warmup.