### PR TITLE
[FEATURE] Improve inline syntax for arguments and passing

### DIFF
--- a/examples/Resources/Private/Singles/Structures.html
+++ b/examples/Resources/Private/Singles/Structures.html
@@ -7,6 +7,33 @@ Fluid allows a handful of structures to render
 dynamic parts of templates. Each method is
 uniquely suited for precise use cases:
 
+* No difference between inline and tag argument syntax
+
+With the exception of using quotes, which must still be escaped, there is no difference between the following
+examples of syntax:
+
+	<f:render partial="Structures" section="ValidSection" />
+	{f:render(partial: 'Structures', section: 'ValidSection')}
+	{f:render(partial="Structures", section="ValidSection")}
+	{f:render(partial="Structures" section="ValidSection")}
+
+* Passing arguments in inline mode
+
+The following line:
+
+	Tag: "<f:format.raw>{dynamicSection}</f:format.raw>"
+
+Is identical in behavior to:
+
+	Pass: "{dynamicSection -> f:format.raw()}"
+
+Which can also be expressed as:
+
+	Pipe: "{dynamicSection | f:format.raw()}"
+	Pipe, multiple levels: "{dynamicSection | f:format.raw() | f:format.htmlspecialchars()}"
+
+In other words, tag contents can be passed also in inline mode, using either the combined "->" operator or standard pipe "|".
+
 * Loop
 
 You can loop through arrays in two ways; as standard

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -115,7 +115,7 @@ abstract class Patterns
 		(
 			{                                 # Start of shorthand syntax
 				(?:                           # Shorthand syntax is either composed of...
-					[a-zA-Z0-9\->_:,.()*+\^\/\%] # Various characters including math operations
+					[a-zA-Z0-9\|\->_:=,.()*+\^\/\%] # Various characters including math operations
 					|"(?:\\\"|[^"])*"         # Double-quoted strings
 					|\'(?:\\\\\'|[^\'])*\'    # Single-quoted strings
 					|(?R)                     # Other shorthand syntaxes inside, albeit not in a quoted string
@@ -136,7 +136,7 @@ abstract class Patterns
 		^{                                                  # Start of shorthand syntax
 			                                                # A shorthand syntax is either...
 			(?P<Object>[a-zA-Z0-9_\-\.\{\}]*)                 # ... an object accessor
-			\s*(?P<Delimiter>(?:->)?)\s*
+			\s*(?P<Delimiter>(?:->|\|)?)\s*
 
 			(?P<ViewHelper>                                 # ... a ViewHelper
 				[a-zA-Z0-9\\.]+                             # Namespace prefix of ViewHelper (as in $SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG)
@@ -146,7 +146,7 @@ abstract class Patterns
 					(?P<ViewHelperArguments>                # Start submatch for ViewHelper arguments. This is taken from $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
 						(?:
 							\s*[a-zA-Z0-9\-_]+              # The keys of the array
-							\s*:\s*                         # Key|Value delimiter :
+							\s*[:=]\s*                      # Key|Value delimiter : or =
 							(?:                             # Possible value options:
 								"(?:\\\"|[^"])*"            # Double qouoted string
 								|\'(?:\\\\\'|[^\'])*\'      # Single quoted string
@@ -160,7 +160,7 @@ abstract class Patterns
 			)?
 			(?P<AdditionalViewHelpers>                      # There can be more than one ViewHelper chained, by adding more -> and the ViewHelper (recursively)
 				(?:
-					\s*->\s*
+					\s*(?:->|\|)\s*
 					(?P>ViewHelper)
 				)*
 			)
@@ -179,7 +179,7 @@ abstract class Patterns
 			(?P<ViewHelperArguments>                # Start submatch for ViewHelper arguments. This is taken from $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
 				(?:
 					\s*[a-zA-Z0-9\-_]+              # The keys of the array
-					\s*:\s*                         # Key|Value delimiter :
+					\s*[:=]\s*                      # Key|Value delimiter : or =
 					(?:                             # Possible value options:
 						"(?:\\\"|[^"])*"            # Double qouoted string
 						|\'(?:\\\\\'|[^\'])*\'      # Single quoted string
@@ -210,7 +210,7 @@ abstract class Patterns
 							|"(?:\\\"|[^"])+"                      # Double quoted key, supporting more characters like dots and square brackets
 							|\'(?:\\\\\'|[^\'])+\'                 # Single quoted key, supporting more characters like dots and square brackets
 						)
-						\s*:\s*                                    # Key|Value delimiter :
+						\s*[:=]\s*                                 # Key|Value delimiter : or =
 						(?:                                        # Possible value options:
 							"(?:\\\"|[^"])*"                       # Double quoted string
 							|\'(?:\\\\\'|[^\'])*\'                 # Single quoted string
@@ -235,7 +235,7 @@ abstract class Patterns
 				|"(?:\\\\"|[^"])+"                                          # Double quoted
 				|\'(?:\\\\\'|[^\'])+\'                                      # Single quoted
 			)
-			\\s*:\\s*                                                       # Key|Value delimiter :
+			\\s*[:=]\\s*                                                    # Key|Value delimiter : or =
 			(?:                                                             # BEGIN Possible value options
 				(?P<QuotedString>                                           # Quoted string
 					 "(?:\\\\"|[^"])*"

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -187,6 +187,10 @@ class ExamplesTest extends BaseTestCase
             'example_structures.php' => [
                 'example_structures.php',
                 [
+                    'Tag: "Dynamic"',
+                    'Pass: "Dynamic"',
+                    'Pipe: "Dynamic"',
+                    'Pipe, multiple levels: "Dynamic"',
                     'This section exists and is rendered: Valid section',
                     'Expects no output because section name is invalid: ' . "\n",
                     'Dynamic section name: Dynamically suffixed section',


### PR DESCRIPTION
This patch improves the inline syntax of Fluid in the
following ways:

* The “pipe” character can be used instead of “->” to
  pass tag contents, e.g. {variable | f:format.raw()}. This
  is done to approach shell syntax and for easier picking
  up of Fluid syntax if you come from Twig.
* Arguments for inline VH calls can now be specified with
  tag attribute syntax. Commas were already optional which
  allowed syntax like “{v:h(foo: bar baz: 123)}”. This is now
  homogenised completely so you can use expressions like
  “{v:h(foo=“{bar}” baz=“123”)}” - which means that you
  can now migrate a tag-based usage to inline syntax
  without having to touch the arguments you provided as
  tag attributes.

All is achieved by adding two characters to the list that is
detected as inline syntax - “|” and “=“ - and by turning
the matching of “->” into a multiple match of either “->”
or the new “|”.

All legacy syntax is untouched. Tag syntax is untouched.

Full disclosure: a similar change was previously rejected
by myself: https://github.com/TYPO3/Fluid/pull/343. The
only arguments I can give for accepting this current patch
but rejecting #343, are:

* This patch modifies far less of the regular expressions
  and sticks to adding characters and converting a character
  match to a list of options.
* It is matching the current research I am doing on using a
  lexer to parse Fluid (a project which also tries to include
  the ES2015 style array syntax but can do so without any
  concerns about bloating of even overflowing the regexp).