### PR TITLE
[BUGFIX] Prevent binary characters in compiled templates

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -230,7 +230,7 @@ class TemplateCompiler
 %s {
 
 public function getLayoutName(\TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface \$renderingContext) {
-\$self = \$this; 
+\$self = \$this;
 %s;
 }
 public function hasLayout() {
@@ -364,17 +364,9 @@ EOD;
         $arguments = $node->getArguments();
         $argument = $arguments[$argumentName];
         $closure = 'function() use ($renderingContext, $self) {' . chr(10);
-        if ($node->getArgumentDefinition($argumentName)->getType() === 'boolean') {
-            // We treat boolean nodes by compiling a closure to evaluate the stack of the boolean argument
-            $compiledIfArgumentStack = $this->nodeConverter->convert(new ArrayNode($argument->getStack()));
-            $closure .= $compiledIfArgumentStack['initialization'] . chr(10);
-            $closure .= sprintf(
-                'return \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode::evaluateStack($renderingContext, %s);',
-                $compiledIfArgumentStack['execution']
-            ) . chr(10);
-        } else {
-            $closure .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', serialize($argument)) . chr(10);
-        }
+        $compiled = $this->nodeConverter->convert($argument);
+        $closure .= $compiled['initialization'] . chr(10);
+        $closure .= 'return ' . $compiled['execution'] . ';' . chr(10);
         $closure .= '}';
         return $closure;
     }

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -96,8 +96,9 @@ class TemplateCompilerTest extends UnitTestCase
         $result = $instance->wrapViewHelperNodeArgumentEvaluationInClosure($viewHelperNode, 'value');
         $serialized = serialize($arguments['value']);
         $expected = 'function() use ($renderingContext, $self) {' . chr(10);
-        $expected .= sprintf('$argument = unserialize(\'%s\'); return $argument->evaluate($renderingContext);', $serialized);
-        $expected .= chr(10) . '}';
+        $expected .= chr(10);
+        $expected .= 'return \'sometext\';' . chr(10);
+        $expected .= '}';
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -183,36 +183,37 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
         $withDefaultCaseOnly = clone $emptySwitchNode;
         $withDefaultCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'defaultCase', [], $parsingState));
         $withSingleCaseOnly = clone $emptySwitchNode;
-        $withSingleCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'case', ['value' => 'foo'], $parsingState));
+        $withSingleCaseOnly->addChildNode(new ViewHelperNode($renderingContext, 'f', 'case', ['value' => new TextNode('foo')], $parsingState));
         return [
             'Empty switch statement' => [
                 $emptySwitchNode,
-                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . chr(10) .
                 'switch ($arguments[\'expression\']) {' .
-                PHP_EOL . '}' . PHP_EOL .
+                chr(10) . '}' . chr(10) .
                 '}, array($arguments))',
                 ''
             ],
             'With default case only' => [
                 $withDefaultCaseOnly,
-                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-                'switch ($arguments[\'expression\']) {' . PHP_EOL .
-                'default: return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-                'return NULL;' . PHP_EOL .
-                '});' . PHP_EOL .
-                '}' . PHP_EOL . '}, array($arguments))',
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . chr(10) .
+                'switch ($arguments[\'expression\']) {' . chr(10) .
+                'default: return call_user_func(function() use ($renderingContext, $self) {' . chr(10) .
+                'return NULL;' . chr(10) .
+                '});' . chr(10) .
+                '}' . chr(10) . '}, array($arguments))',
                 ''
             ],
             'With single case only' => [
                 $withSingleCaseOnly,
-                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
-                'switch ($arguments[\'expression\']) {' . PHP_EOL .
-                'case call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-                '$argument = unserialize(\'s:3:"foo";\'); return $argument->evaluate($renderingContext);' . PHP_EOL .
-                '}): return call_user_func(function() use ($renderingContext, $self) {' . PHP_EOL .
-                'return NULL;' . PHP_EOL .
-                '});' . PHP_EOL .
-                '}' . PHP_EOL . '}, array($arguments))',
+                'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . chr(10) .
+                'switch ($arguments[\'expression\']) {' . chr(10) .
+                'case call_user_func(function() use ($renderingContext, $self) {' . chr(10) .
+                chr(10) .
+                'return \'foo\';' . chr(10) .
+                '}): return call_user_func(function() use ($renderingContext, $self) {' . chr(10) .
+                'return NULL;' . chr(10) .
+                '});' . chr(10) .
+                '}' . chr(10) . '}, array($arguments))',
                 ''
             ],
         ];


### PR DESCRIPTION
When compiled templates are retrieved from the cache and contain binary characters, arbitrary behavior may occur, usually a huge pile of Chinese-like characters is outputted and the template class cannot be loaded. Avoid this by delegating the generation of the compiled node state to the node converter.