### PR TITLE
[FEATURE] Allow content argument on ViewHelpers without trait

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -15,104 +15,11 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
  * an argument value must be checked and used instead of
  * the normal render children closure, if that named
  * argument is specified and not empty.
+ *
+ * @deprecated Trait no longer required, content argument supported by any VH via base class.
  */
 trait CompileWithContentArgumentAndRenderStatic
 {
-    /**
-     * Name of variable that contains the value to use
-     * instead of render children closure, if specified.
-     * If no name is provided here, the first variable
-     * registered in `initializeArguments` of the ViewHelper
-     * will be used.
-     *
-     * Note: it is significantly better practice to define
-     * this property in your ViewHelper class and so fix it
-     * to one particular argument instead of resolving,
-     * especially when your ViewHelper is called multiple
-     * times within an uncompiled template!
-     *
-     * @var string
-     */
-    protected $contentArgumentName;
-
-    /**
-     * Default render method to render ViewHelper with
-     * first defined optional argument as content.
-     *
-     * @return string Rendered string
-     * @api
-     */
-    public function render()
-    {
-        return static::renderStatic(
-            $this->arguments,
-            $this->buildRenderChildrenClosure(),
-            $this->renderingContext
-        );
-    }
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile(
-        $argumentsName,
-        $closureName,
-        &$initializationPhpCode,
-        ViewHelperNode $node,
-        TemplateCompiler $compiler
-    ) {
-        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
-            $this,
-            $argumentsName,
-            $closureName,
-            ViewHelperCompiler::RENDER_STATIC,
-            static::class
-        );
-        $contentArgumentName = $this->resolveContentArgumentName();
-        $initializationPhpCode .= sprintf(
-            '%s = (%s[\'%s\'] !== null) ? function() use (%s) { return %s[\'%s\']; } : %s;',
-            $closureName,
-            $argumentsName,
-            $contentArgumentName,
-            $argumentsName,
-            $argumentsName,
-            $contentArgumentName,
-            $closureName
-        );
-        $initializationPhpCode .= $initialization;
-        return $execution;
-    }
-
-    /**
-     * Helper which is mostly needed when calling renderStatic() from within
-     * render().
-     *
-     * No public API yet.
-     *
-     * @return \Closure
-     */
-    protected function buildRenderChildrenClosure()
-    {
-        $argumentName = $this->resolveContentArgumentName();
-        $arguments = $this->arguments;
-        if (!empty($argumentName) && isset($arguments[$argumentName])) {
-            $renderChildrenClosure = function () use ($arguments, $argumentName) {
-                return $arguments[$argumentName];
-            };
-        } else {
-            $self = clone $this;
-            $renderChildrenClosure = function () use ($self) {
-                return $self->renderChildren();
-            };
-        }
-        return $renderChildrenClosure;
-    }
-
     /**
      * @return string
      */

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -34,8 +34,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CountViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
-
     /**
      * @var boolean
      */
@@ -45,6 +43,11 @@ class CountViewHelper extends AbstractViewHelper
      * @var boolean
      */
     protected $escapeOutput = false;
+
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'subject';
 
     /**
      * @return void

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -34,9 +34,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class DebugViewHelper extends AbstractViewHelper
 {
-
-    use CompileWithRenderStatic;
-
     /**
      * @var boolean
      */
@@ -48,6 +45,11 @@ class DebugViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
+
+    /**
      * @return void
      */
     public function initializeArguments()
@@ -56,6 +58,7 @@ class DebugViewHelper extends AbstractViewHelper
         $this->registerArgument('typeOnly', 'boolean', 'If TRUE, debugs only the type of variables', false, false);
         $this->registerArgument('levels', 'integer', 'Levels to render when rendering nested objects/arrays', false, 5);
         $this->registerArgument('html', 'boolean', 'Render HTML. If FALSE, output is indented plaintext', false, false);
+        $this->registerArgument('value', 'mixed', 'The value to be debugged. Can also be passed as tag content or as inline pass.');
     }
 
     /**

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -43,9 +43,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CdataViewHelper extends AbstractViewHelper
 {
-
-    use CompileWithContentArgumentAndRenderStatic;
-
     /**
      * @var boolean
      */
@@ -55,6 +52,11 @@ class CdataViewHelper extends AbstractViewHelper
      * @var boolean
      */
     protected $escapeOutput = false;
+
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
 
     /**
      * @return void

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -49,6 +49,11 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
+
+    /**
      * @return void
      */
     public function initializeArguments()
@@ -69,13 +74,10 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-        $value = $this->arguments['value'];
+        $value = $this->renderChildren();
         $keepQuotes = $this->arguments['keepQuotes'];
         $encoding = $this->arguments['encoding'];
         $doubleEncode = $this->arguments['doubleEncode'];
-        if ($value === null) {
-            $value = $this->renderChildren();
-        }
 
         if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
             return $value;

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -49,8 +49,10 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class PrintfViewHelper extends AbstractViewHelper
 {
-
-    use CompileWithContentArgumentAndRenderStatic;
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
 
     /**
      * @return void

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -46,9 +46,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class RawViewHelper extends AbstractViewHelper
 {
-
-    use CompileWithContentArgumentAndRenderStatic;
-
     /**
      * @var boolean
      */
@@ -58,6 +55,11 @@ class RawViewHelper extends AbstractViewHelper
      * @var boolean
      */
     protected $escapeOutput = false;
+
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
 
     /**
      * @return void

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -15,8 +15,10 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class OrViewHelper extends AbstractViewHelper
 {
-
-    use CompileWithContentArgumentAndRenderStatic;
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'content';
 
     /**
      * Initialize

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -33,7 +33,10 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class VariableViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    /**
+     * @var string
+     */
+    protected $contentArgumentName = 'value';
 
     /**
      * @return void

--- a/tests/Unit/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CountViewHelperTest.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\ViewHelpers\CountViewHelper;
 
@@ -27,70 +28,32 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
     }
 
     /**
-     * @test
+     * @param mixed $subject
+     * @param int $expectedResult
+     * @dataProvider getCountTestValues
      */
-    public function renderReturnsNumberOfElementsInAnArray()
+    public function testCountOperation($subject, $expectedResult)
     {
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $expectedResult = 3;
-        $this->arguments = ['subject' => ['foo', 'bar', 'Baz']];
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
+        $actualResult = CountViewHelper::renderStatic(['subject' => $subject], function() use ($subject) { return $subject; }, $this->renderingContext);
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    /**
-     * @test
-     */
-    public function renderReturnsNumberOfElementsInAnArrayObject()
+    public function getCountTestValues()
     {
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $expectedResult = 2;
-        $this->arguments = ['subject' => new \ArrayObject(['foo', 'bar'])];
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
-        $this->assertSame($expectedResult, $actualResult);
-    }
-
-    /**
-     * @test
-     */
-    public function renderReturnsZeroIfGivenArrayIsEmpty()
-    {
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $expectedResult = 0;
-        $this->arguments = ['subject' => []];
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
-    }
-
-    /**
-     * @test
-     */
-    public function renderUsesChildrenAsSubjectIfGivenSubjectIsNull()
-    {
-        $this->viewHelper->expects($this->once())->method('renderChildren')
-            ->will($this->returnValue(['foo', 'baz', 'bar']));
-        $expectedResult = 3;
-        $this->arguments = ['subject' => null];
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
-        $this->assertSame($expectedResult, $actualResult);
-    }
-
-    /**
-     * @test
-     */
-    public function renderReturnsZeroIfGivenSubjectIsNullAndRenderChildrenReturnsNull()
-    {
-        $this->viewHelper->expects($this->once())->method('renderChildren')
-            ->will($this->returnValue(null));
-        $this->viewHelper->setArguments(['subject' => null]);
-        $this->injectDependenciesIntoViewHelper($this->viewHelper);
-        $expectedResult = 0;
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
-        $this->assertSame($expectedResult, $actualResult);
+        return [
+            [
+                ['foo', 'bar', 'Baz'],
+                3,
+            ],
+            [
+                new \ArrayObject(['foo', 'bar']),
+                2,
+            ],
+            [
+                [],
+                0,
+            ]
+        ];
     }
 
     /**
@@ -98,11 +61,7 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderThrowsExceptionIfGivenSubjectIsNotCountable()
     {
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $this->viewHelper->setRenderingContext(new RenderingContextFixture());
-        $object = new \stdClass();
-        $this->viewHelper->setArguments(['subject' => $object]);
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $this->viewHelper->initializeArgumentsAndRender();
+        $this->setExpectedException(Exception::class);
+        CountViewHelper::renderStatic([], function() { return new \stdClass(); }, $this->renderingContext);
     }
 }

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -34,11 +34,8 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRender($value, array $arguments, $expected = null)
     {
-        $instance = $this->getMock(DebugViewHelper::class, ['renderChildren']);
-        $instance->expects($this->once())->method('renderChildren')->willReturn($value);
-        $instance->setArguments($arguments);
-        $instance->setRenderingContext(new RenderingContextFixture());
-        $result = $instance->render();
+        $closure = function() use ($value) { return $value; };
+        $result = DebugViewHelper::renderStatic($arguments, $closure, new RenderingContextFixture());
         if ($expected) {
             $this->assertEquals($expected, $result);
         }

--- a/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -49,29 +49,6 @@ class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase
         $this->assertFalse($this->viewHelper->isOutputEscapingEnabled());
     }
 
-    /**
-     * @test
-     */
-    public function renderUsesValueAsSourceIfSpecified()
-    {
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $this->viewHelper->setArguments(
-            ['value' => 'Some string', 'keepQuotes' => false, 'encoding' => 'UTF-8', 'doubleEncode' => false]
-        );
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
-        $this->assertEquals('Some string', $actualResult);
-    }
-
-    /**
-     * test
-     */
-    public function renderUsesChildNodesAsSourceIfSpecified()
-    {
-        $this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Some string'));
-        $actualResult = $this->viewHelper->initializeArgumentsAndRender();
-        $this->assertEquals('Some string', $actualResult);
-    }
-
     public function dataProvider()
     {
         return [

--- a/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
@@ -38,23 +38,10 @@ class RawViewHelperTest extends UnitTestCase
     /**
      * @test
      */
-    public function renderReturnsUnmodifiedValueIfSpecified()
+    public function renderReturnsUnmodifiedValue()
     {
         $value = 'input value " & äöüß@';
-        $this->viewHelper->expects($this->never())->method('renderChildren');
-        $this->viewHelper->setArguments(['value' => $value]);
-        $actualResult = $this->viewHelper->render();
+        $actualResult = RawViewHelper::renderStatic(['value' => $value], function() use ($value) { return $value; }, new RenderingContextFixture());
         $this->assertEquals($value, $actualResult);
-    }
-
-    /**
-     * @test
-     */
-    public function renderReturnsUnmodifiedChildNodesIfNoValueIsSpecified()
-    {
-        $childNodes = 'input value " & äöüß@';
-        $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue($childNodes));
-        $actualResult = $this->viewHelper->render();
-        $this->assertEquals($childNodes, $actualResult);
     }
 }

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -36,11 +36,7 @@ class OrViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRender($arguments, $expected)
     {
-        $instance = $this->getMock(OrViewHelper::class, ['renderChildren']);
-        $instance->expects($this->exactly((integer) empty($arguments['content'])))->method('renderChildren')->willReturn($arguments['content']);
-        $instance->setArguments($arguments);
-        $instance->setRenderingContext(new RenderingContextFixture());
-        $result = $instance->render();
+        $result = OrViewHelper::renderStatic($arguments, function() use ($arguments) { return $arguments['content']; }, new RenderingContextFixture());
         $this->assertEquals($expected, $result);
     }
 
@@ -63,12 +59,8 @@ class OrViewHelperTest extends ViewHelperBaseTestcase
      */
     public function testRenderAlternative($arguments, $expected)
     {
-        $instance = $this->getMock(OrViewHelper::class, ['renderChildren']);
-        $instance->expects($this->once())->method('renderChildren')->willReturn(null);
         $arguments['content'] = null;
-        $instance->setArguments($arguments);
-        $instance->setRenderingContext(new RenderingContextFixture());
-        $result = $instance->render();
+        $result = OrViewHelper::renderStatic($arguments, function() { return null; }, new RenderingContextFixture());
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
This change deprecates CompileWithContentArgumentAndRenderStatic
in favor of a similar, but explicit, solution on AbstractViewHelper.

Content argument is possible on any ViewHelper after this
change but must explicitly be opted-in by one of two methods:

* Set `protected $contentArgumentName` to name of argument.
* Override `resolveContentArgumentName` and return name.

The latter of the two methods is implemented so ViewHelpers
can be plug-and-play compatible even with the trait hollowed
out and deprecated.

A couple of ViewHelpers and related tests have additionally
been refactored to not assume that render() is implemented
(the method is now optional), instead using static calling. This
allowed removing the deprecated trait from those ViewHelpers.

Close: #400