### PR TITLE
[FEATURE] Inline fluid ViewHelper

### DIFF
--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -1,0 +1,62 @@
+<?php
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Inline Fluid rendering ViewHelper
+ *
+ * Renders Fluid code stored in a variable, which you normally would
+ * have to render before assigning it to the view. Instead you can
+ * do the following (note, extremely simplified use case):
+ *
+ *      $view->assign('variable', 'value of my variable');
+ *      $view->assign('code', 'My variable: {variable}');
+ *
+ * And in the template:
+ *
+ *      {code -> f:inline()}
+ *
+ * Which outputs:
+ *
+ *      My variable: value of my variable
+ *
+ * You can use this to pass smaller and dynamic pieces of Fluid code
+ * to templates, as an alternative to creating new partial templates.
+ */
+class InlineViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    protected $escapeChildren = false;
+
+    protected $escapeOutput = false;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument(
+            'code',
+            'string',
+            'Fluid code to be rendered as if it were part of the template rendering it. Can be passed as inline argument or tag content'
+        );
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed|string
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        return $renderingContext->getTemplateParser()->parse($renderChildrenClosure())->render($renderingContext);
+    }
+}

--- a/tests/Unit/ViewHelpers/InlineViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/InlineViewHelperTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
+use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\ViewHelpers\InlineViewHelper;
+
+/**
+ * Class InlineViewHelperTest
+ */
+class InlineViewHelperTest extends ViewHelperBaseTestcase
+{
+    /**
+     * @test
+     */
+    public function testInitializeArguments()
+    {
+        $instance = $this->getMockBuilder(InlineViewHelper::class)->setMethods(['registerArgument'])->getMock();
+        $instance->expects($this->at(0))->method('registerArgument')->with('code', 'string', $this->anything());
+        $instance->initializeArguments();
+    }
+
+    /**
+     * @test
+     */
+    public function testCallsExpectedDelegationMethodFromRenderStatic()
+    {
+        $contextFixture = new RenderingContextFixture();
+
+        $parsedTemplateMock = $this->getMockBuilder(ParsedTemplateInterface::class)->getMock();
+        $parsedTemplateMock->expects($this->once())->method('render')->with($contextFixture)->willReturn('bar');
+
+        $parserMock = $this->getMockBuilder(TemplateParser::class)->setMethods(['parse'])->getMock();
+        $parserMock->expects($this->once())->method('parse')->with('foo')->willReturn($parsedTemplateMock);
+
+        $contextFixture->setTemplateParser($parserMock);
+
+        $result = InlineViewHelper::renderStatic([], function() { return 'foo'; }, $contextFixture);
+        $this->assertEquals('bar', $result);
+    }
+}


### PR DESCRIPTION
Allows rendering a variable containing Fluid code as
if the code contained in the variable were part of the
template invoking the ViewHelper.

    $view->assign('variable', 'value of my variable');
    $view->assign('code', 'My variable: {variable}');

And in the template:

    {code -> f:inline()}

Which outputs:

    My variable: value of my variable

You can use this to pass smaller and dynamic pieces of Fluid code
to templates, as an alternative to creating new partial templates.