### PR TITLE
[BUGFIX] Prevent property spill-over to next call

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -88,6 +88,9 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     public function initialize()
     {
         parent::initialize();
+        $this->tag->reset();
+        $this->tag->setTagName($this->tagName);
+
         if ($this->hasArgument('additionalAttributes') && is_array($this->arguments['additionalAttributes'])) {
             $this->tag->addAttributes($this->arguments['additionalAttributes']);
         }


### PR DESCRIPTION
We have found an issue where consecutive viewhelpers take over properties from the previous one. 

This is the TYPO3 bug report: https://forge.typo3.org/issues/86890