### PR TITLE
[TASK] Canonicalize arrays before comparison

### DIFF
--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -219,13 +219,16 @@ class TemplatePathsTest extends BaseTestCase
             $instance,
             [['examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'], 'html']
         );
+        $expected = [
+            'examples/Resources/Private/Layouts/Default.html',
+            'examples/Resources/Private/Layouts/Dynamic.html',
+            'examples/Resources/Private/Templates/Default/Default.html',
+            'examples/Resources/Private/Templates/Default/Nested/Default.html',
+        ];
+        sort($result);
+        sort($expected);
         $this->assertEquals(
-            [
-                'examples/Resources/Private/Layouts/Default.html',
-                'examples/Resources/Private/Layouts/Dynamic.html',
-                'examples/Resources/Private/Templates/Default/Default.html',
-                'examples/Resources/Private/Templates/Default/Nested/Default.html',
-            ],
+            $expected,
             $result
         );
     }


### PR DESCRIPTION
Fixes a sometimes failing, sometimes succeeding unit
test which compares arrays of resolved files.

Sorts both arrays before comparison because at this
point in tests we don’t care about the order, which is
tested by other methods.

Unblocks #421