### PR TITLE
[FEATURE] Allow variables assigned with dotted path

### DIFF
--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -96,7 +96,7 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
             } else {
                 $source = $this->source;
             }
-            $this->variables = json_decode($source, defined('JSON_OBJECT_AS_ARRAY') ? JSON_OBJECT_AS_ARRAY : 1);
+            parent::setSource(json_decode($source, defined('JSON_OBJECT_AS_ARRAY') ? JSON_OBJECT_AS_ARRAY : 1));
             $this->lastLoaded = time();
         }
     }

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
@@ -26,6 +26,14 @@ class UserWithoutToString
     }
 
     /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
      * @return string
      */
     public function getName()


### PR DESCRIPTION
Enables assignment of template variables with a dotted
path as name:

    $view->assign(‘parent.property’, ‘newValue’);

Each value in the path leading up to the final property
name is created as an array if it does not exist, and is
read by reference until a subject is identified. Then the
value is set on that subject.

If a path points to an object and the path to the property
contains one or more scalar values, assignment is
refused with an exception clearly stating why a subject
could not be resolved.

The feature is also enabled for the JsonVariableProvider
by making it call the StandardVariableProvider’s method.