### PR TITLE
[FEATURE] Allow defining arguments for f:render with f:argument

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -40,6 +40,12 @@ Direct access of numeric prefixed variable: {123numericprefix}
 	}
 }"/>
 
+<!-- Passing arguments to a sections/partials using f:render in tag content -->
+<f:render section="Tertiary">
+    <f:argument name="arg1">First argument</f:argument>
+    <f:argument name="arg2">Second argument</f:argument>
+</f:render>
+
 </f:section>
 
 <f:section name="Secondary">
@@ -48,4 +54,9 @@ Received $array.printf with formatted string {array.printf -> f:format.printf(ar
 Received $array.baz with value {array.baz}
 Received $array.xyz.foobar with value {array.xyz.foobar}
 Received $myVariable with value {myVariable}
+</f:section>
+
+<f:section name="Tertiary">
+Input argument "arg1" was: {arg1}
+Input argument "arg2" was: {arg2}
 </f:section>

--- a/src/ViewHelpers/ArgumentViewHelper.php
+++ b/src/ViewHelpers/ArgumentViewHelper.php
@@ -1,0 +1,68 @@
+<?php
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Argument assigning ViewHelper
+ *
+ * Assigns an argument for a parent ViewHelper call when
+ * the parent ViewHelper supports it.
+ *
+ * Alternative to declaring an array to pass as "arguments".
+ *
+ * Usages:
+ *
+ *     <f:render partial="Foo">
+ *         <f:argument name="arg1">Value1</f:argument>
+ *         <f:argument name="arg2">Value2</f:argument>
+ *     </f:render>
+ *
+ * Which is the equivalent of:
+ *
+ *     <f:render partial="Foo" arguments="{arg1: 'Value1', arg2: 'Value2'}'" />
+ *
+ * But has the benefit that writing ViewHelper expressions or
+ * other more complex syntax becomes much easier because you
+ * can use tag syntax (tag content becomes argument value).
+ *
+ * @api
+ */
+class ArgumentViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('value', 'mixed', 'Value to assign. If not in arguments then taken from tag content');
+        $this->registerArgument('name', 'string', 'Name of variable to create', true);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return null
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $delegateVariableProvider = $renderingContext->getViewHelperVariableContainer()->getTopmostDelegateVariableProvider();
+        if ($delegateVariableProvider) {
+            $delegateVariableProvider->add($arguments['name'], $renderChildrenClosure());
+        }
+    }
+
+}

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -87,7 +87,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 class RenderViewHelper extends AbstractViewHelper
 {
     use CompileWithRenderStatic;
-    
+
     /**
      * @var boolean
      */
@@ -121,7 +121,20 @@ class RenderViewHelper extends AbstractViewHelper
         $delegate = $arguments['delegate'];
         /** @var RenderableInterface $renderable */
         $renderable = $arguments['renderable'];
+
+        // Prepare a delegate variable provider that will be possible to extract after rendering the child closure.
+        // Any variable defined therein gets used as argument and overrides any argument of the same name.
+        // Note: not using late static binding here is a conscious decision: if late static binding had been used
+        // then f:variable would not be able to reference this ViewHelper class' stack variable correctly.
+        $viewHelperVariableContainer = $renderingContext->getViewHelperVariableContainer();
+        $collector = $renderingContext->getVariableProvider()->getScopeCopy($variables);
+
+        $viewHelperVariableContainer->pushDelegateVariableProvider($collector);
+
         $tagContent = $renderChildrenClosure();
+
+        $variables = $viewHelperVariableContainer->popDelegateVariableProvider()->getAll();
+
         if ($arguments['contentAs']) {
             $variables[$arguments['contentAs']] = $tagContent;
         }

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -222,7 +222,9 @@ class ExamplesTest extends BaseTestCase
                     'Received $array.printf with formatted string Formatted string, value: formatted',
                     'Received $array.baz with value 42',
                     'Received $array.xyz.foobar with value Escaped sub-string',
-                    'Received $myVariable with value Nice string'
+                    'Received $myVariable with value Nice string',
+                    'Input argument "arg1" was: First argument',
+                    'Input argument "arg2" was: Second argument',
                 ]
             ],
             'example_variableprovider.php' => [


### PR DESCRIPTION
This patch allows you to define arguments that get passed to
f:render by using f:argument in the tag contents.

```xml
<f:render partial="Something">
   <f:argument name="arg1">Special value for arg1 variable</f:argument>
   <f:argument name="arg2">Special value for arg2 variable</f:argument>
</f:render>
```

Any argument specified with f:argument this way will override
the argument of the same name if it was passed in the “arguments”
array as well. The combined result will be used as variables for the
sub-rendering call.

References: #427