### PR TITLE
[TASK] Allow mixed renderStatic() return types in compile traits

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -39,7 +39,7 @@ trait CompileWithContentArgumentAndRenderStatic
      * Default render method to render ViewHelper with
      * first defined optional argument as content.
      *
-     * @return string Rendered string
+     * @return mixed Rendered result
      * @api
      */
     public function render()

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -19,7 +19,7 @@ trait CompileWithRenderStatic
      * Default render method - simply calls renderStatic() with a
      * prepared set of arguments.
      *
-     * @return string Rendered string
+     * @return mixed Rendered result
      * @api
      */
     public function render()


### PR DESCRIPTION
A view helper might render the result into an array
and still use CompileWithRenderStatic to be compilable,
the return type annotations should reflect that.