### PR TITLE
[BUGFIX] Support overloaded methods when extracting variables

### DIFF
--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -209,7 +209,7 @@ class VariableExtractor
         if (is_object($subject)) {
             $upperCasePropertyName = ucfirst($propertyName);
             $getter = 'get' . $upperCasePropertyName;
-            if (method_exists($subject, $getter)) {
+            if (is_callable([$subject, $getter])) {
                 return self::ACCESSOR_GETTER;
             }
             if ($this->isExtractableThroughAsserter($subject, $propertyName)) {

--- a/tests/Unit/Core/Fixtures/ClassWithMagicGetter.php
+++ b/tests/Unit/Core/Fixtures/ClassWithMagicGetter.php
@@ -1,0 +1,21 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Class ClassWithMagicGetter
+ */
+class ClassWithMagicGetter
+{
+    public function __call($name, $arguments)
+    {
+        if ($name === 'getTest') {
+            return 'test result';
+        }
+        return null;
+    }
+}

--- a/tests/Unit/Core/Fixtures/ClassWithProtectedGetter.php
+++ b/tests/Unit/Core/Fixtures/ClassWithProtectedGetter.php
@@ -1,0 +1,19 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Class ClassWithProtectedGetter
+ */
+class ClassWithProtectedGetter
+{
+
+    protected function getTest()
+    {
+        return 'test result';
+    }
+
+}

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -8,6 +8,8 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithMagicGetter;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithProtectedGetter;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -120,4 +122,25 @@ class VariableExtractorTest extends UnitTestCase
             [new \ArrayObject(['testProperty' => 'testValue']), 'testProperty', null, 'testValue'],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function testExtractCallsMagicMethodGetters()
+    {
+        $subject = new ClassWithMagicGetter();
+        $result = VariableExtractor::extract($subject, 'test');
+        $this->assertEquals('test result', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testExtractReturnsNullOnProtectedGetters()
+    {
+        $subject = new ClassWithProtectedGetter();
+        $result = VariableExtractor::extract($subject, 'test');
+        $this->assertEquals(null, $result);
+    }
+
 }


### PR DESCRIPTION
Value extraction will now support delegation of getter calls
via PHP‘s __call() magic method. Additionally, extracting a property
that results in a protected getter call will stop raising an error.

Solves #437 