### PR TITLE
Update IfViewHelper to reflect changes in string comparison

### DIFF
--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -39,8 +39,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  *   <f:if condition="{rank} == {k:bar()}">
  *     Checks if rank is equal to the result of the ViewHelper "k:bar"
  *   </f:if>
- *   <f:if condition="{foo.bar} == {'stringToCompare'}">
- *     Will result true if {foo.bar}'s represented value equals 'stringToCompare'.
+ *   <f:if condition="{foo.bar} == 'stringToCompare'">
+ *     Will result in true if {foo.bar}'s represented value equals 'stringToCompare'.
  *   </f:if>
  *
  * = Examples =

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -26,9 +26,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  * - Object Accessor
  * - Array
  * - a ViewHelper
- * Note: Strings at XX/YY are NOT allowed, however, for the time being,
- * a string comparison can be achieved with comparing arrays (see example
- * below).
+ * - string
+ *
  * ::
  *
  *   <f:if condition="{rank} > 100">
@@ -40,7 +39,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  *   <f:if condition="{rank} == {k:bar()}">
  *     Checks if rank is equal to the result of the ViewHelper "k:bar"
  *   </f:if>
- *   <f:if condition="{0: foo.bar} == {0: 'stringToCompare'}">
+ *   <f:if condition="{foo.bar} == {'stringToCompare'}">
  *     Will result true if {foo.bar}'s represented value equals 'stringToCompare'.
  *   </f:if>
  *


### PR DESCRIPTION
Comparing strings directly without using array comparison workaround is now possible.

Related: #442