### PR TITLE
[TASK] Bump PHPUnit version to ^8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 vendor
 examples/cache/*.php
 .numerolog-token-90d266e4c7e3463a4266086282f608c1121c3d95
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,8 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.5
-  - 5.6
-  - 7
-  - 7.1
   - 7.2
+  - 7.3
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": ">=5.5.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.8",
+		"phpunit/phpunit": "^8.1",
 		"mikey179/vfsstream": "^1.6",
 		"squizlabs/php_codesniffer": "^2.7",
 		"php-coveralls/php-coveralls": "^2.1"

--- a/src/Core/Cache/FluidCacheWarmupResult.php
+++ b/src/Core/Cache/FluidCacheWarmupResult.php
@@ -58,7 +58,7 @@ class FluidCacheWarmupResult
         $currentlyCompiled = $state->isCompiled();
         $this->results[$templatePathAndFilename] = [
             static::RESULT_COMPILABLE => $currentlyCompiled || $state->isCompilable(),
-            static::RESULT_COMPILED => $state->isCompiled(),
+            static::RESULT_COMPILED => $currentlyCompiled,
             static::RESULT_HASLAYOUT => $state->hasLayout(),
             static::RESULT_COMPILEDCLASS => $state->getIdentifier()
         ];

--- a/tests/Functional/BaseConditionalFunctionalTestCase.php
+++ b/tests/Functional/BaseConditionalFunctionalTestCase.php
@@ -125,6 +125,8 @@ abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
     {
         if ($this->getCache()) {
             $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, true);
+        } else {
+            $this->markTestSkipped('Cache-specific test skipped');
         }
     }
 }

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -109,14 +109,14 @@ abstract class BaseFunctionalTestCase extends UnitTestCase
         }
         foreach ($expected as $expectedValue) {
             if (is_string($expectedValue) === true) {
-                $this->assertContains($expectedValue, $output);
+                $this->assertStringContainsString($expectedValue, $output);
             } else {
                 $this->assertEquals($expectedValue, $output);
             }
         }
         foreach ($notExpected as $notExpectedValue) {
             if (is_string($notExpectedValue) === true) {
-                $this->assertNotContains($notExpectedValue, $output);
+                $this->assertStringNotContainsString($notExpectedValue, $output);
             } else {
                 $this->assertNotEquals($notExpectedValue, $output);
             }
@@ -146,6 +146,8 @@ abstract class BaseFunctionalTestCase extends UnitTestCase
         if ($this->getCache()) {
             $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
             $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+        } else {
+            $this->markTestSkipped('Cache-specific test skipped');
         }
     }
 }

--- a/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
+++ b/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
@@ -79,14 +79,14 @@ class NestedFluidTemplatesWithLayoutTest extends BaseFunctionalTestCase
 
         foreach ($expected as $expectedValue) {
             if (is_string($expectedValue) === true) {
-                $this->assertContains($expectedValue, $output);
+                $this->assertStringContainsString($expectedValue, $output);
             } else {
                 $this->assertEquals($expectedValue, $output);
             }
         }
         foreach ($notExpected as $notExpectedValue) {
             if (is_string($notExpectedValue) === true) {
-                $this->assertNotContains($notExpectedValue, $output);
+                $this->assertStringNotContainsString($notExpectedValue, $output);
             } else {
                 $this->assertNotEquals($notExpectedValue, $output);
             }

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -18,7 +18,7 @@ class CommandTest extends BaseTestCase
     /**
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         vfsStream::setup('fakecache/');
     }
@@ -35,10 +35,10 @@ class CommandTest extends BaseTestCase
         $command = sprintf($argumentString, $bin);
         $output = shell_exec($command);
         foreach ($mustContain as $mustContainString) {
-            $this->assertContains($mustContainString, $output);
+            $this->assertStringContainsString($mustContainString, $output);
         }
         foreach ($mustNotContain as $mustNotContainString) {
-            $this->assertNotContains($mustNotContainString, $output);
+            $this->assertStringNotContainsString($mustNotContainString, $output);
         }
     }
 

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -18,7 +18,7 @@ class ExamplesTest extends BaseTestCase
     /**
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         vfsStream::setup('fakecache/');
     }

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -132,8 +132,8 @@ class ExamplesTest extends BaseTestCase
                 [
                     'Expression: $numberten % 4 = 2',
                     'Expression: 4 * $numberten = 40',
-                    'Expression: 4 / $numberten = 0.4',
-                    'Expression: $numberone / $numberten = 0.1',
+                    'Expression: 4 / $numberten = ' . (0.4), // NOTE: concat'ing a float + string LC-casts the float to localized comma/t-sep. Hence, let PHP also cast the expected value.
+                    'Expression: $numberone / $numberten = ' . (0.1), // NOTE: concat'ing a float + string LC-casts the float to localized comma/t-sep. Hence, let PHP also cast the expected value.
                     'Expression: 10 ^ $numberten = 10000000000'
                 ]
             ],

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -30,7 +30,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase
         $result2 = $this->getAccessibleMock(FluidCacheWarmupResult::class, ['dummy']);
         $result2->_set('results', array_pop($results));
         $result1->merge($result2);
-        $this->assertAttributeSame($expected, 'results', $result1);
+        $this->assertEquals($expected, $result1->getResults());
     }
 
     /**
@@ -51,7 +51,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase
     {
         $subject = $this->getAccessibleMock(FluidCacheWarmupResult::class, ['dummy']);
         $subject->_set('results', ['foo' => 'bar']);
-        $this->assertAttributeEquals(['foo' => 'bar'], 'results', $subject);
+        $this->assertEquals(['foo' => 'bar'], $subject->getResults());
     }
 
     /**
@@ -64,7 +64,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase
     {
         $result = new FluidCacheWarmupResult();
         $result->add($subject, 'foobar');
-        $this->assertAttributeEquals(['foobar' => $expected], 'results', $result);
+        $this->assertEquals(['foobar' => $expected], $result->getResults());
     }
 
     /**
@@ -77,7 +77,7 @@ class FluidCacheWarmupResultTest extends UnitTestCase
         )->setMethods(
             ['isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier']
         )->getMockForAbstractClass();
-        $subject1->expects($this->exactly(2))->method('isCompiled')->willReturn(false);
+        $subject1->expects($this->once())->method('isCompiled')->willReturn(false);
         $subject1->expects($this->once())->method('isCompilable')->willReturn(true);
         $subject1->expects($this->once())->method('hasLayout')->willReturn(false);
         $subject1->expects($this->once())->method('getIdentifier')->willReturn('subject1-identifier');
@@ -86,8 +86,8 @@ class FluidCacheWarmupResultTest extends UnitTestCase
         )->setMethods(
             ['isCompiled', 'isCompilable', 'hasLayout', 'getIdentifier', 'getFailureReason', 'getMitigations']
         )->getMockForAbstractClass();
-        $subject2->expects($this->exactly(2))->method('isCompiled')->willReturn(true);
-        $subject2->expects($this->once())->method('isCompilable')->willReturn(true);
+        $subject2->expects($this->once())->method('isCompiled')->willReturn(true);
+        $subject2->expects($this->never())->method('isCompilable');
         $subject2->expects($this->once())->method('hasLayout')->willReturn(true);
         $subject2->expects($this->once())->method('getIdentifier')->willReturn('subject2-identifier');
         $subject2->expects($this->once())->method('getFailureReason')->willReturn('failure-reason');

--- a/tests/Unit/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Unit/Core/Cache/SimpleFileCacheTest.php
@@ -26,7 +26,7 @@ class SimpleFileCacheTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->directory = vfsStream::setup('cache');
     }

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -40,8 +40,9 @@ class FailedCompilingStateTest extends UnitTestCase
         $subject = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
         $subject->_set($property, $value);
         $method = 'set' . ucfirst($property);
+        $getter = 'get' . ucfirst($property);
         $subject->$method($value);
-        $this->assertAttributeEquals($value, $property, $subject);
+        $this->assertEquals($value, $subject->$getter());
     }
 
     /**
@@ -52,7 +53,7 @@ class FailedCompilingStateTest extends UnitTestCase
         $subject = $this->getAccessibleMock(FailedCompilingState::class, ['dummy']);
         $subject->_set('mitigations', ['m1']);
         $subject->addMitigation('m2');
-        $this->assertAttributeEquals(['m1', 'm2'], 'mitigations', $subject);
+        $this->assertEquals(['m1', 'm2'], $subject->getMitigations());
     }
 
     /**

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -24,7 +24,7 @@ class BooleanParserTest extends UnitTestCase
     /**
      * Setup fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
     }

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -22,26 +22,26 @@ class EscapeTest extends UnitTestCase
 {
 
     /**
-     * @var Escape|\PHPUnit_Framework_MockObject_MockObject
+     * @var Escape|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $escapeInterceptor;
 
     /**
-     * @var AbstractViewHelper|\PHPUnit_Framework_MockObject_MockObject
+     * @var AbstractViewHelper|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mockViewHelper;
 
     /**
-     * @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewHelperNode|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mockNode;
 
     /**
-     * @var ParsingState|\PHPUnit_Framework_MockObject_MockObject
+     * @var ParsingState|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mockParsingState;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->escapeInterceptor = $this->getAccessibleMock(Escape::class, ['dummy']);
         $this->mockViewHelper = $this->getMockBuilder(AbstractViewHelper::class)->disableOriginalConstructor()->getMock();

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -40,7 +40,7 @@ class ParsingStateTest extends UnitTestCase
      */
     public function testSetIdentifierSetsProperty()
     {
-        $instance = $this->getMockForAbstractClass(ParsingState::class, [], '', false, ['dummy']);
+        $instance = $this->getMockForAbstractClass(ParsingState::class, [], '', false, false, false, ['dummy']);
         $instance->setIdentifier('test');
         $this->assertAttributeEquals('test', 'identifier', $instance);
     }
@@ -50,7 +50,7 @@ class ParsingStateTest extends UnitTestCase
      */
     public function testGetIdentifierReturnsProperty()
     {
-        $instance = $this->getAccessibleMockForAbstractClass(ParsingState::class, [], '', false, ['dummy']);
+        $instance = $this->getAccessibleMockForAbstractClass(ParsingState::class, [], '', false, false, false, ['dummy']);
         $instance->_set('identifier', 'test');
         $this->assertEquals('test', $instance->getIdentifier());
     }

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -25,12 +25,12 @@ class ParsingStateTest extends UnitTestCase
      */
     protected $parsingState;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->parsingState = new ParsingState();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->parsingState);
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -24,7 +24,7 @@ class AbstractNodeTest extends UnitTestCase
 
     protected $childNode;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = $this->getMock(RenderingContext::class, [], [], '', false);
 

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -40,7 +40,7 @@ class BooleanNodeTest extends UnitTestCase
     /**
      * Setup fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -23,7 +23,7 @@ class NumericNodeTest extends UnitTestCase
      */
     protected $renderingContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
     }
@@ -50,19 +50,20 @@ class NumericNodeTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
      */
     public function constructorThrowsExceptionIfNoNumericGiven()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\Parser\Exception::class);
         new NumericNode('foo');
     }
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
      */
     public function addChildNodeThrowsException()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\Parser\Exception::class);
+
         $node = new NumericNode('1');
         $node->addChildNode(clone $node);
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -29,10 +29,11 @@ class TextNodeTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
      */
     public function constructorThrowsExceptionIfNoStringGiven()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\Parser\Exception::class);
+
         new TextNode(123);
     }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -32,19 +32,19 @@ class ViewHelperNodeTest extends UnitTestCase
     protected $renderingContext;
 
     /**
-     * @var TemplateVariableContainer|\PHPUnit_Framework_MockObject_MockObject
+     * @var TemplateVariableContainer|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $templateVariableContainer;
 
     /**
-     * @var ViewHelperResolver|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewHelperResolver|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mockViewHelperResolver;
 
     /**
      * Setup fixture
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
         $this->mockViewHelperResolver = $this->getMock(ViewHelperResolver::class, ['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName', 'getArgumentDefinitionsForViewHelper']);
@@ -62,7 +62,7 @@ class ViewHelperNodeTest extends UnitTestCase
     public function constructorSetsViewHelperAndArguments()
     {
         $arguments = ['foo' => 'bar'];
-        /** @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject $viewHelperNode */
+        /** @var ViewHelperNode|\PHPUnit\Framework\MockObject\MockObject $viewHelperNode */
         $viewHelperNode = new ViewHelperNode($this->renderingContext, 'f', 'vh', $arguments, new ParsingState());
 
         $this->assertAttributeEquals($arguments, 'arguments', $viewHelperNode);
@@ -92,10 +92,11 @@ class ViewHelperNodeTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\Exception
      */
     public function abortIfRequiredArgumentsAreMissingThrowsException()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\Parser\Exception::class);
+
         $expected = [
             new ArgumentDefinition('firstArgument', 'string', '', false),
             new ArgumentDefinition('secondArgument', 'string', '', true)

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -149,10 +149,10 @@ class TemplateParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function parseThrowsExceptionWhenStringArgumentMissing()
     {
+        $this->expectException(\Exception::class);
         $templateParser = new TemplateParser();
         $templateParser->parse(123);
     }
@@ -281,10 +281,11 @@ class TemplateParserTest extends UnitTestCase
 
     /**
      * @__test
-     * @expectedException Exception
      */
     public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassDoesNotExisit()
     {
+        $this->expectException(\Exception::class);
+
         $mockState = $this->getMock(ParsingState::class);
 
         $templateParser = $this->getAccessibleMock(
@@ -301,10 +302,11 @@ class TemplateParserTest extends UnitTestCase
 
     /**
      * @__test
-     * @expectedException Exception
      */
     public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassNameIsWronglyCased()
     {
+        $this->expectException(\Exception::class);
+
         $mockState = $this->getMock(ParsingState::class);
 
         $templateParser = $this->getAccessibleMock(
@@ -344,10 +346,11 @@ class TemplateParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function closingViewHelperTagHandlerThrowsExceptionBecauseOfClosingTagWhichWasNeverOpened()
     {
+        $this->expectException(\Exception::class);
+
         $mockNodeOnStack = $this->getMock(NodeInterface::class, [], [], '', false);
         $mockState = $this->getMock(ParsingState::class);
         $mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));
@@ -360,10 +363,11 @@ class TemplateParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function closingViewHelperTagHandlerThrowsExceptionBecauseOfWrongTagNesting()
     {
+        $this->expectException(\Exception::class);
+
         $mockNodeOnStack = $this->getMock(ViewHelperNode::class, [], [], '', false);
         $mockState = $this->getMock(ParsingState::class);
         $mockState->expects($this->once())->method('popNodeFromStack')->will($this->returnValue($mockNodeOnStack));

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -36,7 +36,7 @@ class EscapingModifierTemplateProcessorTest extends UnitTestCase
         $context->setTemplateParser($parser);
         $subject->setRenderingContext($context);
         $processedSource = $subject->preProcessSource($templateSource);
-        $this->assertNotContains('{escaping', $processedSource);
+        $this->assertStringNotContainsString('{escaping', $processedSource);
     }
 
     /**

--- a/tests/Unit/Core/Rendering/RenderingContextFixture.php
+++ b/tests/Unit/Core/Rendering/RenderingContextFixture.php
@@ -6,6 +6,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use PHPUnit\Framework\MockObject\Generator;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\ErrorHandler\ErrorHandlerInterface;
@@ -100,7 +101,7 @@ class RenderingContextFixture implements RenderingContextInterface
      */
     public function __construct()
     {
-        $mockBuilder = new \PHPUnit_Framework_MockObject_Generator();
+        $mockBuilder = new Generator();
         $this->variableProvider = $mockBuilder->getMock(VariableProviderInterface::class);
         $this->viewHelperVariableContainer = $mockBuilder->getMock(ViewHelperVariableContainer::class, ['dummy']);
         $this->viewHelperResolver = $mockBuilder->getMock(ViewHelperResolver::class, ['dummy']);

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -32,7 +32,7 @@ class RenderingContextTest extends UnitTestCase
      */
     protected $renderingContext;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
     }

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -25,7 +25,7 @@ class JSONVariableProviderTest extends UnitTestCase
     /**
      * Constructor
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->jsonFile = new vfsStreamFile('test.json');
         $this->jsonFile->setContent('{"foo": "bar"}');
@@ -49,9 +49,6 @@ class JSONVariableProviderTest extends UnitTestCase
         }
     }
 
-    /**
-     * @test
-     */
     public function getOperabilityTestValues()
     {
         return [

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -23,14 +23,14 @@ class StandardVariableProviderTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->variableProvider = $this->getMock(StandardVariableProvider::class, ['dummy']);
     }
 
     /**
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->variableProvider);
     }
@@ -53,7 +53,7 @@ class StandardVariableProviderTest extends UnitTestCase
     }
 
     /**
-     * @test
+     * @return array
      */
     public function getOperabilityTestValues()
     {

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -24,16 +24,16 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
 {
 
     /**
-     * @var AbstractConditionViewHelper|\PHPUnit_Framework_MockObject_MockObject
+     * @var AbstractConditionViewHelper|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $viewHelper;
 
     /**
-     * @var ViewHelperNode|\PHPUnit_Framework_MockObject_MockObject
+     * @var ViewHelperNode|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $viewHelperNode;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['renderChildren', 'hasArgument']);

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 class AbstractTagBasedViewHelperTest extends UnitTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, ['dummy'], [], '', false);
         $this->viewHelper->setRenderingContext(new RenderingContextFixture());

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -108,10 +108,11 @@ class AbstractViewHelperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function registeringTheSameArgumentNameAgainThrowsException()
     {
+        $this->expectException(\Exception::class);
+
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
         $name = 'shortName';
@@ -145,10 +146,11 @@ class AbstractViewHelperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument()
     {
+        $this->expectException(\Exception::class);
+
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, null, [], '', false);
 
         $viewHelper->_call('overrideArgument', 'argumentName', 'string', 'description', true);
@@ -208,10 +210,11 @@ class AbstractViewHelperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['prepareArguments'], [], '', false);
 
         $viewHelper->setArguments(['test' => 'test']);

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -22,7 +22,7 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     protected $viewHelperVariableContainer;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->viewHelperVariableContainer = new ViewHelperVariableContainer();
     }

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -48,7 +48,7 @@ class AbstractTemplateViewTest extends UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->templateVariableContainer = $this->getMock(StandardVariableProvider::class);
         $this->viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class, ['setView']);

--- a/tests/Unit/ViewHelpers/CaseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CaseViewHelperTest.php
@@ -19,7 +19,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMock(CaseViewHelper::class, ['renderChildren']);
@@ -37,10 +37,11 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfSwitchExpressionIsNotSetInViewHelperVariableContainer()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception::class);
+
         $this->viewHelper->setArguments(['value' => 'foo']);
         $this->viewHelper->initializeArgumentsAndRender();
     }

--- a/tests/Unit/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CountViewHelperTest.php
@@ -20,7 +20,7 @@ class CountViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(CountViewHelper::class, ['renderChildren']);

--- a/tests/Unit/ViewHelpers/CycleViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/CycleViewHelperTest.php
@@ -19,7 +19,7 @@ class CycleViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMock(CycleViewHelper::class, ['renderChildren']);
@@ -34,15 +34,17 @@ class CycleViewHelperTest extends ViewHelperBaseTestcase
     {
         $values = ['bar', 'Fluid'];
         $this->viewHelper->setArguments(['values' => $values, 'as' => 'innerVariable']);
-        $this->viewHelper->render();
+        $output = $this->viewHelper->render();
+        $this->assertEquals('', $output);
     }
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionWhenPassingObjectsToValuesThatAreNotTraversable()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception::class);
+
         $object = new \stdClass();
         $this->viewHelper->setArguments(['values' => $object, 'as' => 'innerVariable']);
         $this->viewHelper->render();
@@ -75,8 +77,10 @@ class CycleViewHelperTest extends ViewHelperBaseTestcase
     {
         $traversableObject = new \ArrayObject(['key1' => 'value1', 'key2' => 'value2']);
         $this->viewHelper->setArguments(['values' => $traversableObject, 'as' => 'innerVariable']);
-        $this->viewHelper->render();
-        $this->viewHelper->render();
-        $this->viewHelper->render();
+        $o1 = $this->viewHelper->render();
+        $o2 = $this->viewHelper->render();
+        $o3 = $this->viewHelper->render();
+        $this->assertEquals($o1, $o2);
+        $this->assertEquals($o2, $o3);
     }
 }

--- a/tests/Unit/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ForViewHelperTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper;
 class ForViewHelperTest extends ViewHelperBaseTestcase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -25,7 +25,7 @@ class HtmlspecialcharsViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMock(HtmlspecialcharsViewHelper::class, ['renderChildren']);

--- a/tests/Unit/ViewHelpers/Format/PrintfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/PrintfViewHelperTest.php
@@ -20,7 +20,7 @@ class PrintfViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMock(PrintfViewHelper::class, ['renderChildren']);

--- a/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Format/RawViewHelperTest.php
@@ -21,7 +21,7 @@ class RawViewHelperTest extends UnitTestCase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->viewHelper = $this->getMock(RawViewHelper::class, ['renderChildren']);
         $this->viewHelper->setRenderingContext(new RenderingContextFixture());

--- a/tests/Unit/ViewHelpers/GroupedForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/GroupedForViewHelperTest.php
@@ -18,7 +18,7 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMock(GroupedForViewHelper::class, ['renderChildren']);
@@ -45,15 +45,17 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionWhenPassingObjectsToEachThatAreNotTraversable()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception::class);
+
         $object = new \stdClass();
         $this->viewHelper->setArguments(
             ['each' => $object, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => null]
         );
-        $this->viewHelper->render();
+        $output = $this->viewHelper->render();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -72,7 +74,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -91,7 +94,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -120,7 +124,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -151,7 +156,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $products, 'as' => 'products', 'groupBy' => 'license', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -174,7 +180,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -202,7 +209,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer.name', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -233,7 +241,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'customer', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -260,7 +269,8 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $invoices, 'as' => 'invoices', 'groupBy' => 'date', 'groupKey' => 'myGroupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -277,20 +287,23 @@ class GroupedForViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->setArguments(
             ['each' => $products, 'as' => 'innerKey', 'groupBy' => 'NonExistingKey', 'groupKey' => 'groupKey']
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionWhenPassingOneDimensionalArraysToEach()
     {
+        $this->expectException(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception::class);
+
         $values = ['some', 'simple', 'array'];
 
         $this->viewHelper->setArguments(
             ['each' => $values, 'as' => 'innerVariable', 'groupBy' => 'someKey', 'groupKey' => null]
         );
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 }

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -32,7 +32,7 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->subject = $this->getMock(RenderViewHelper::class, ['renderChildren']);
@@ -152,11 +152,11 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
     public function testRender(array $arguments, $expectedViewMethod)
     {
         if ($expectedViewMethod !== null) {
-            $this->view->expects($this->once())->method($expectedViewMethod)->willReturn('');
+            $this->view->expects($this->once())->method($expectedViewMethod)->willReturn(null);
         }
-        $this->subject->expects($this->any())->method('renderChildren')->willReturn(null);
         $this->subject->setArguments($arguments);
-        $this->subject->render();
+        $result = $this->subject->render();
+        $this->assertNull(null);
     }
 
     /**

--- a/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SwitchViewHelperTest.php
@@ -34,7 +34,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelperNode;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->viewHelperNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
@@ -49,8 +49,7 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperInitializesArguments()
     {
-        $this->viewHelper->initializeArguments();
-        $this->assertAttributeNotEmpty('argumentDefinitions', $this->viewHelper);
+        $this->assertNotEmpty($this->viewHelper->prepareArguments());
     }
 
     /**
@@ -60,7 +59,8 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
     {
         $switchExpression = new \stdClass();
         $this->viewHelper->setArguments(['expression' => $switchExpression]);
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**
@@ -69,7 +69,8 @@ class SwitchViewHelperTest extends ViewHelperBaseTestcase
     public function renderRemovesSwitchExpressionFromViewHelperVariableContainerAfterInvocation()
     {
         $this->viewHelper->setArguments(['expression' => 'switchExpression']);
-        $this->viewHelper->initializeArgumentsAndRender();
+        $output = $this->viewHelper->initializeArgumentsAndRender();
+        $this->assertEquals('', $output);
     }
 
     /**

--- a/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -60,7 +60,7 @@ abstract class ViewHelperBaseTestcase extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->viewHelperVariableContainer = new ViewHelperVariableContainer();
         $this->templateVariableContainer = new StandardVariableProvider();


### PR DESCRIPTION
Bump PHPUnit to most recent version, adapt tests and adjust
the Travis testing matrix to no longer test on PHP below 7.2,
in preparation for the up-coming minimum PHP requirement.