### PR TITLE
[FEATURE] Rename Fluid 3.0+ to typo3/fluid-engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,32 @@
 {
-	"name": "typo3fluid/fluid",
-	"description": "The TYPO3 Fluid template rendering engine",
-	"license": ["LGPL-3.0-or-later"],
-	"require": {
-		"php": ">=7.2.0"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "^8.1",
-		"mikey179/vfsstream": "^1.6",
-		"squizlabs/php_codesniffer": "^2.7",
-		"php-coveralls/php-coveralls": "^2.1"
-	},
-	"autoload": {
-		"psr-4": {
-			"TYPO3Fluid\\Fluid\\": "src/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"TYPO3Fluid\\Fluid\\Tests\\": "tests/"
-		}
-	},
-	"bin": [
-		"bin/fluid"
-	]
+    "name": "typo3/fluid-engine",
+    "description": "The TYPO3 Fluid template rendering engine",
+    "license": ["LGPL-3.0-or-later"],
+    "type": "library",
+    "require": {
+        "php": ">=7.2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.1",
+        "mikey179/vfsstream": "^1.6",
+        "squizlabs/php_codesniffer": "^2.7",
+        "php-coveralls/php-coveralls": "^2.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3Fluid\\Fluid\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "TYPO3Fluid\\Fluid\\Tests\\": "tests/"
+        }
+    },
+    "replace": {
+        "typo3fluid/fluid": ">=3.0.0"
+    },
+    "bin": [
+        "bin/fluid"
+    ]
 }
+


### PR DESCRIPTION
Renames the composer package and sets the “replace”
composer option so it only replaces Fluid 3.0 or above.