### PR TITLE
[BUGFIX] Support overloaded methods in StandardVariableProvider

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -344,7 +344,7 @@ class StandardVariableProvider implements VariableProviderInterface
         if (is_object($subject)) {
             $upperCasePropertyName = ucfirst($propertyName);
             $getter = 'get' . $upperCasePropertyName;
-            if (method_exists($subject, $getter)) {
+            if (is_callable([$subject, $getter])) {
                 return self::ACCESSOR_GETTER;
             }
             if ($this->isExtractableThroughAsserter($subject, $propertyName)) {

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -7,7 +7,6 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
  */
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithMagicGetter;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithProtectedGetter;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString;

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -285,8 +285,8 @@ class StandardVariableProviderTest extends UnitTestCase
     public function testExtractCallsMagicMethodGetters()
     {
         $provider = new StandardVariableProvider();
-        $provider->setSource(new ClassWithMagicGetter());
-        $result = $provider->get('test');
+        $provider->setSource(['object' => new ClassWithMagicGetter()]);
+        $result = $provider->get('object.test');
         $this->assertEquals('test result', $result);
     }
 
@@ -296,8 +296,8 @@ class StandardVariableProviderTest extends UnitTestCase
     public function testExtractReturnsNullOnProtectedGetters()
     {
         $provider = new StandardVariableProvider();
-        $provider->setSource(new ClassWithProtectedGetter());
-        $result = $provider->get('test');
+        $provider->setSource(['object' => new ClassWithProtectedGetter()]);
+        $result = $provider->get('object.test');
         $this->assertEquals(null, $result);
     }
 }

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -7,6 +7,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
  */
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithMagicGetter;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithProtectedGetter;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\UserWithoutToString;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -275,5 +278,27 @@ class StandardVariableProviderTest extends UnitTestCase
             [['test' => 'test'], 'test', StandardVariableProvider::ACCESSOR_GETTER, 'test'],
             [['test' => 'test'], 'test', StandardVariableProvider::ACCESSOR_ASSERTER, 'test'],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function testExtractCallsMagicMethodGetters()
+    {
+        $provider = new StandardVariableProvider();
+        $provider->setSource(new ClassWithMagicGetter());
+        $result = $provider->get('test');
+        $this->assertEquals('test result', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testExtractReturnsNullOnProtectedGetters()
+    {
+        $provider = new StandardVariableProvider();
+        $provider->setSource(new ClassWithProtectedGetter());
+        $result = $provider->get('test');
+        $this->assertEquals(null, $result);
     }
 }


### PR DESCRIPTION
The bugfix/feature which was introduced in #438 where the function `is_callable` was used, is also necessary in StandardVariableProvider.