### PR TITLE
[BUGFIX] Fix broken annotation of property (#476)

### DIFF
--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -30,7 +30,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
     protected $renderingContext;
 
     /**
-     * @var array()
+     * @var array
      */
     protected $localNamespaces = [];
 


### PR DESCRIPTION
The annotation of the property `NamespaceDetectionTemplateProcessor::$localNamespaces` is changed to being `@var array` to fix issues with the recent version of `phpdocumentor/reflection-docblock`.