### PR TITLE
[BUGFIX] Prevent sprintf warning in cached ternary with modulo

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -133,7 +133,7 @@ class TernaryExpressionNode extends AbstractExpressionNode
         $functionName = $templateCompiler->variableName('ternaryExpression');
         $initializationPhpCode .= sprintf(
             '%s = function($context, $renderingContext) {
-				if (%s::convertToBoolean(' . $compiledExpression . ', $renderingContext) === TRUE) {
+				if (%s::convertToBoolean(%s, $renderingContext) === TRUE) {
 					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
 				} else {
 					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
@@ -141,6 +141,7 @@ class TernaryExpressionNode extends AbstractExpressionNode
 			};' . chr(10),
             $functionName,
             BooleanNode::class,
+            var_export($compiledExpression, true),
             static::class,
             var_export($then, true),
             static::class,

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -133,15 +133,17 @@ class TernaryExpressionNode extends AbstractExpressionNode
         $functionName = $templateCompiler->variableName('ternaryExpression');
         $initializationPhpCode .= sprintf(
             '%s = function($context, $renderingContext) {
-				if (%s::convertToBoolean(%s, $renderingContext) === TRUE) {
+                $candidate = %s::getTemplateVariableOrValueItself(%s, $renderingContext);
+				if (%s::convertToBoolean($candidate, $renderingContext)) {
 					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
 				} else {
 					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
 				}
 			};' . chr(10),
             $functionName,
-            BooleanNode::class,
+            static::class,
             var_export($compiledExpression, true),
+            BooleanNode::class,
             static::class,
             var_export($then, true),
             static::class,

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -134,12 +134,12 @@ class TernaryExpressionNode extends AbstractExpressionNode
         $initializationPhpCode .= sprintf(
             '%s = function($context, $renderingContext) {
                 $candidate = %s::getTemplateVariableOrValueItself(%s, $renderingContext);
-				if (%s::convertToBoolean($candidate, $renderingContext)) {
-					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
-				} else {
-					return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
-				}
-			};' . chr(10),
+                if (%s::convertToBoolean($candidate, $renderingContext)) {
+                    return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
+                } else {
+                    return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
+                }
+            };' . chr(10),
             $functionName,
             static::class,
             var_export($compiledExpression, true),

--- a/tests/Functional/BaseConditionalFunctionalTestCase.php
+++ b/tests/Functional/BaseConditionalFunctionalTestCase.php
@@ -2,6 +2,7 @@
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\View\ViewInterface;
@@ -20,7 +21,7 @@ abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
      */
     protected function getCache()
     {
-        return null;
+        return new SimpleFileCache(sys_get_temp_dir());
     }
 
     /**
@@ -116,7 +117,7 @@ abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
      * return a valid cache.
      *
      * @param string|resource $sourceOrStream
-     * @param boolean $expected
+     * @param boolean $expectation
      * @param array $variables
      * @test
      * @dataProvider getTemplateCodeFixturesAndExpectations
@@ -124,7 +125,8 @@ abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
     public function testTemplateCodeFixtureWithCache($sourceOrStream, $expectation, array $variables = [])
     {
         if ($this->getCache()) {
-            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, true);
+            $this->testTemplateCodeFixture($sourceOrStream, $expectation, $variables, true);
+            $this->testTemplateCodeFixture($sourceOrStream, $expectation, $variables, true);
         } else {
             $this->markTestSkipped('Cache-specific test skipped');
         }

--- a/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
@@ -19,117 +19,96 @@ class TernaryConditionsTest extends BaseFunctionalTestCase
         $someObject->someInt = 1337;
         $someObject->someFloat = 13.37;
         $someObject->someBoolean = true;
-        $someArray = [
-            'foo' => 'bar'
-        ];
         return [
-            [
+            'quoted string then/else' => [
                 '{true ? \'yes\' : \'no\'}',
                 [],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'unquoted integer then/else' => [
                 '{true ? 1 : 2}',
                 [],
-                [1],
-                [2]
+                1,
             ],
-            [
+            'unquoted then, quoted string else' => [
                 '{true ? foo : \'bar\'}',
                 ['foo' => 'bar'],
-                ['bar'],
-                ['foo']
+                'bar',
             ],
-            [
+            'single-item grouped condition true, quoted string then/else' => [
                 '{(true) ? \'yes\' : \'no\'}',
                 [],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'grouped or condition true, quoted string then/else' => [
                 '{(true || false) ? \'yes\' : \'no\'}',
                 [],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'grouped or condition false, quoted string then/else' => [
                 '{(false || false) ? \'yes\' : \'no\'}',
                 [],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'object accessor condition true, quoted string then/else' => [
                 '{foo ? \'yes\' : \'no\'}',
                 ['foo' => true],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'object accessor condition false, quoted string then/else' => [
                 '{foo ? \'yes\' : \'no\'}',
                 ['foo' => false],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'negated object accessor condition false, quoted string then/else' => [
                 '{!foo ? \'yes\' : \'no\'}',
                 ['foo' => false],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'grouped variable accessor or false condition true, quoted string then/else' => [
                 '{(foo || false) ? \'yes\' : \'no\'}',
                 ['foo' => true],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'grouped variable accessor or false condition false, quoted string then/else' => [
                 '{(foo || false) ? \'yes\' : \'no\'}',
                 ['foo' => false],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'grouped dotted variable accessor or false condition true, quoted string then/else' => [
                 '{(foo.bar || false) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => true]],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'grouped dotted variable accessor or false condition false, quoted string then/else' => [
                 '{(foo.bar && false) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => true]],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'dotted variable accessor greater than condition true, quoted string then/else' => [
                 '{(foo.bar > 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'dotted variable accessor less than condition true, quoted string then/else' => [
                 '{(foo.bar < 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'dotted variable accessor less than condition false, quoted string then/else' => [
                 '{(foo.bar < 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
-                ['no'],
-                ['yes']
+                'no',
             ],
-            [
+            'dotted variable accessor modulo condition true, quoted string then/else' => [
                 '{(foo.bar % 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
-                ['yes'],
-                ['no']
+                'yes',
             ],
-            [
+            'dotted variable accessor modulo condition false, quoted string then/else' => [
                 '{(foo.bar % 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 10]],
-                ['no'],
-                ['yes']
+                'no',
             ],
         ];
     }

--- a/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
+++ b/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
@@ -20,17 +20,6 @@ class NestedFluidTemplatesWithLayoutTest extends BaseFunctionalTestCase
     ];
 
     /**
-     * If your test case requires a cache, override this
-     * method and return an instance.
-     *
-     * @return FluidCacheInterface
-     */
-    protected function getCache()
-    {
-        return new SimpleFileCache(sys_get_temp_dir());
-    }
-
-    /**
      * @return array
      */
     public function getTemplateCodeFixturesAndExpectations()
@@ -53,21 +42,21 @@ class NestedFluidTemplatesWithLayoutTest extends BaseFunctionalTestCase
      *
      * @param string|resource $source
      * @param array $variables
-     * @param array $expected
-     * @param array $notExpected
+     * @param array|string $expected
+     * @param array|string|null $notExpected
      * @param string|NULL $expectedException
      * @param boolean $withCache
      * @test
      * @dataProvider getTemplateCodeFixturesAndExpectations
      */
-    public function testTemplateCodeFixture($source, array $variables, array $expected, array $notExpected, $expectedException = null, $withCache = false)
+    public function testTemplateCodeFixture($source, array $variables, $expected, $notExpected = null, $expectedException = null, $withCache = false)
     {
-        $view = $this->getView();
+        $view = $this->getView($withCache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
         $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
         $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
 
-        $innerView = $this->getView();
+        $innerView = $this->getView($withCache);
         $innerView->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
         $innerView->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/LayoutsOverride/Layouts/']);
         $innerView->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');

--- a/tests/Functional/Cases/SwitchTest.php
+++ b/tests/Functional/Cases/SwitchTest.php
@@ -9,18 +9,6 @@ use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
  */
 class SwitchTest extends BaseFunctionalTestCase
 {
-
-    /**
-     * If your test case requires a cache, override this
-     * method and return an instance.
-     *
-     * @return FluidCacheInterface
-     */
-    protected function getCache()
-    {
-        return new SimpleFileCache(sys_get_temp_dir());
-    }
-
     /**
      * @return array
      */

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -51,6 +51,7 @@ class TernaryExpressionNodeTest extends UnitTestCase
             ['{(true || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', true],
             ['{(foo || 1 && 1 && !(false) || (1 % 2) || (1 > 0) || (\'foo\' == \'bar\')) ? \'yes\' : \'no\'}', true],
             ['{{f:if(condition: 1, then: 1, else: 0)} ? \'yes\' : \'no\'}', true],
+            ['{zeroString ? zeroString : 123}', true],
         ];
     }
 
@@ -77,6 +78,8 @@ class TernaryExpressionNodeTest extends UnitTestCase
         return [
             ['1 ? 2 : 3', [], 2],
             ['0 ? 2 : 3', [], 3],
+            ['zeroString ? zeroString : 123', ['zeroString' => '0'], 123],
+            ['nested.zeroString ? nested.zeroString : 123', ['nested' => ['zeroString' => '0']], 123],
         ];
     }
 }


### PR DESCRIPTION
This patch primarily fixes a bug in TernaryExpressionNode
in which an expression that contains a modulo (%) would
be concatenated with the format string instead of inserted
as parameter, causing the parameter count for sprintf to
be incorrect. By adding the expression as format argument
the parameter count for sprintf will always be consistent.

Further, the patch also fixes a precursor problem that meant
functional tests did not test cached executions and adjusts
two other functional test to remove code duplication.

And allows functional tests to pass a string instead of an
array of expected strings, which makes the test match the
entire output instead of a substring, making the "not expected"
argument redundant when "expected" is a string. Cleans up
the ternary expression node test accordingly.