### PR TITLE
[BUGFIX] Handle conflict with registered/ignored namespaces (#475)

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -210,8 +210,8 @@ class ViewHelperResolver
      */
     public function isNamespaceIgnored($namespaceIdentifier)
     {
-        if (array_key_exists($namespaceIdentifier, $this->namespaces) && $this->namespaces[$namespaceIdentifier] === null) {
-            return true;
+        if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
+            return $this->namespaces[$namespaceIdentifier] === null;
         }
         foreach (array_keys($this->namespaces) as $existingNamespaceIdentifier) {
             if (strpos($existingNamespaceIdentifier, '*') === false) {

--- a/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
+++ b/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
+
+/**
+ * Class NamespaceRegistrationTest
+ */
+class NamespaceRegistrationTest extends BaseFunctionalTestCase
+{
+
+    /**
+     * @var array
+     */
+    protected $variables = [];
+
+    /**
+     * @return array
+     */
+    public function getTemplateCodeFixturesAndExpectations()
+    {
+        return [
+            'Ignoring namespaces without conflict with registered namespace' => [
+                '{namespace z*}{namespace bar}<zoo:bar /><bar:foo></bar:foo><zoo.bar:baz /><f:format.raw>foobar</f:format.raw>',
+                $this->variables,
+                ['expected output' => '<zoo:bar /><bar:foo></bar:foo><zoo.bar:baz />'],
+                ['not expected in output' => '<f:format.raw>foobar</f:format.raw>'],
+            ],
+            'Ignoring namespaces with conflict with registered namespace gives registered namespace priority' => [
+                '{namespace f*}{namespace bar}<foo:bar /><bar:foo></bar:foo><foo.bar:baz /><f:format.raw>foobar</f:format.raw>',
+                $this->variables,
+                ['expected output' => '<foo:bar /><bar:foo></bar:foo><foo.bar:baz />'],
+                ['not expected in output' => '<f:format.raw>foobar</f:format.raw>'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Restores incorrect revert https://github.com/TYPO3/Fluid/commit/2b5ffd5ef66a557b4bf01fd74d65c2df6fec1587
which was unintentionally reverted as part of #489.

Fixes a regression in namespace resolving behavior,
wherein a conflicting ignored namespace (e.g. "f*")
incorrectly caused the registered namespace to be
ignored (e.g. "f:" would be ignored).

References: #451, #475, #489
References: https://github.com/neos/flow-development-collection/issues/1761