### PR TITLE
[FEATURE] Make fluid PHP 7.4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 php:
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 before_install:
   - composer self-update

--- a/bin/fluid
+++ b/bin/fluid
@@ -128,7 +128,7 @@ class FluidCommandLine {
                 /** @var \TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface $variableProvider */
                 $variableProvider = new $variableProviderClassName();
                 $variableProvider->setSource($source);
-            } elseif (($variablesReference{0} === '{' && substr($variablesReference, -1) === '}')
+            } elseif (($variablesReference[0] === '{' && substr($variablesReference, -1) === '}')
                 || file_exists($variablesReference)
                 || strpos($variablesReference, ':/') !== FALSE
             ) {

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -54,7 +54,7 @@ class TernaryExpressionNode extends AbstractExpressionNode
         list ($check, $then, $else) = $parts;
 
         if ($then === '') {
-            $then = $check{0} === '!' ? $else : $check;
+            $then = $check[0] === '!' ? $else : $check;
         }
 
         $context = static::gatherContext($renderingContext, $expression);

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -573,9 +573,9 @@ class TemplateParser
         if ($value === '') {
             return $value;
         }
-        if ($quotedValue{0} === '"') {
+        if ($quotedValue[0] === '"') {
             $value = str_replace('\\"', '"', preg_replace('/(^"|"$)/', '', $quotedValue));
-        } elseif ($quotedValue{0} === '\'') {
+        } elseif ($quotedValue[0] === '\'') {
             $value = str_replace("\\'", "'", preg_replace('/(^\'|\'$)/', '', $quotedValue));
         }
         return str_replace('\\\\', '\\', $value);

--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -108,6 +108,6 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
     protected function isJSON($string)
     {
         $string = trim($string);
-        return ($string{0} === '{' && substr($string, -1) === '}');
+        return ($string[0] === '{' && substr($string, -1) === '}');
     }
 }

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -365,7 +365,7 @@ abstract class AbstractTemplateView extends AbstractView
     protected function getCurrentRenderingType()
     {
         $currentRendering = end($this->renderingStack);
-        return isset($currentRendering['type']) ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
+        return !empty($currentRendering['type']) ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
     }
 
     /**
@@ -377,7 +377,7 @@ abstract class AbstractTemplateView extends AbstractView
     {
         $currentRendering = end($this->renderingStack);
         $renderingContext = $this->getCurrentRenderingContext();
-        $parsedTemplate = isset($currentRendering['parsedTemplate']) ? $currentRendering['parsedTemplate'] : $renderingContext->getTemplateCompiler()->getCurrentlyProcessingState();
+        $parsedTemplate = !empty($currentRendering['parsedTemplate']) ? $currentRendering['parsedTemplate'] : $renderingContext->getTemplateCompiler()->getCurrentlyProcessingState();
         if ($parsedTemplate) {
             return $parsedTemplate;
         }
@@ -405,6 +405,6 @@ abstract class AbstractTemplateView extends AbstractView
     protected function getCurrentRenderingContext()
     {
         $currentRendering = end($this->renderingStack);
-        return isset($currentRendering['renderingContext']) ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
+        return !empty($currentRendering['renderingContext']) ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
     }
 }

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -365,7 +365,7 @@ abstract class AbstractTemplateView extends AbstractView
     protected function getCurrentRenderingType()
     {
         $currentRendering = end($this->renderingStack);
-        return $currentRendering['type'] ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
+        return isset($currentRendering['type']) ? $currentRendering['type'] : self::RENDERING_TEMPLATE;
     }
 
     /**
@@ -377,7 +377,7 @@ abstract class AbstractTemplateView extends AbstractView
     {
         $currentRendering = end($this->renderingStack);
         $renderingContext = $this->getCurrentRenderingContext();
-        $parsedTemplate = $currentRendering['parsedTemplate'] ? $currentRendering['parsedTemplate'] : $renderingContext->getTemplateCompiler()->getCurrentlyProcessingState();
+        $parsedTemplate = isset($currentRendering['parsedTemplate']) ? $currentRendering['parsedTemplate'] : $renderingContext->getTemplateCompiler()->getCurrentlyProcessingState();
         if ($parsedTemplate) {
             return $parsedTemplate;
         }
@@ -405,6 +405,6 @@ abstract class AbstractTemplateView extends AbstractView
     protected function getCurrentRenderingContext()
     {
         $currentRendering = end($this->renderingStack);
-        return $currentRendering['renderingContext'] ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
+        return isset($currentRendering['renderingContext']) ? $currentRendering['renderingContext'] : $this->baseRenderingContext;
     }
 }

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -444,7 +444,7 @@ class TemplatePaths
      */
     protected function ensureAbsolutePath($path)
     {
-        return ((!empty($path) && $path{0} !== '/' && $path{1} !== ':') ? $this->sanitizePath(realpath($path)) : $path);
+        return ((!empty($path) && $path[0] !== '/' && $path[1] !== ':') ? $this->sanitizePath(realpath($path)) : $path);
     }
 
     /**


### PR DESCRIPTION
Which is mainly not using curly braces to get characters
of a string and checking for valid arrays before accessing
them.

See https://wiki.php.net/rfc/notice-for-non-valid-array-container
for a further explanation.

To stay compatible with PHP 5 `isset` is used instead of a null
coalesce operator:

`isset($foo['bar']) ? $foo['bar'] : null;`

vs.

`$foo['bar'] ?? null;`