### PR TITLE
[BUGFIX] Guard against filemtime on missing file

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -622,7 +622,7 @@ class TemplatePaths
      */
     protected function createIdentifierForFile($pathAndFilename, $prefix)
     {
-        $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' ? filemtime($pathAndFilename) : 0;
+        $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' && file_exists($pathAndFilename) ? filemtime($pathAndFilename) : 0;
         return sprintf('%s_%s', $prefix, sha1($pathAndFilename . '|' . $templateModifiedTimestamp));
     }
 


### PR DESCRIPTION
Guard TemplatePaths->createIdentifierForFile against
attempts to use filemtime() on a file which does not
exist. Return a zero timestamp in this case.