### PR TITLE
[DOC] Remove wrong namespace registration examples

### DIFF
--- a/doc/FLUID_CREATING_VIEWHELPERS.md
+++ b/doc/FLUID_CREATING_VIEWHELPERS.md
@@ -11,14 +11,14 @@ ViewHelper to be usable in inline syntax - for example as value of the `each` ar
 And finally, we would like to be able to specify the "values" array also in the special inline syntax for tag content:
 
 ```xml
-<f:fluid xmlns:mypkg="Vendor\Package\ViewHelpers">
+<html xmlns:mypkg="Vendor\Package\ViewHelpers">
 <dl>
     <f:for each="{myValuesArray -> mypkg:combine(keys: myKeysArray)}" as="item" key="key">
         <dt>{key}</dt>
         <dd>{item}</dd>
     </f:for>
 <dl>
-</f:fluid>
+</html>
 ```
 
 To enable this usage we must then create a ViewHelper class:
@@ -66,10 +66,10 @@ And that's all this class requires to work in the described way.
 Note that in this example the ViewHelper's `render()` method returns an array which means you can't use it in tag mode:
 
 ```xml
-<f:fluid xmlns:mypkg="Vendor\Package\ViewHelpers">
+<html xmlns:mypkg="Vendor\Package\ViewHelpers">
 <!-- BAD USAGE. Will output string value "Array" -->
 <mypkg:combine keys="{myKeysArray}">{myValuesArray}</mypkg:combine>
-</f:fluid>
+</html>
 ```
 
 Naturally this implies that any ViewHelper which returns a string compatible value (including numbers and objects which have a

--- a/doc/FLUID_VIEWHELPERS.md
+++ b/doc/FLUID_VIEWHELPERS.md
@@ -21,23 +21,23 @@ $view->getRenderingContext()->getViewHelperResolver()->addNamespace('foo', 'Vend
 And the latter method which can be used in each template file that requires the ViewHelpers:
 
 ```xml
-<f:fluid xmlns:foo="Vendor\Foo\ViewHelpers">
+<html xmlns:foo="Vendor\Foo\ViewHelpers">
 <f:layout name="Default" />
 <f:section name="Main">
     <!-- ... --->
 </f:section>
-</f:fluid>
+</html>
 ```
 
 Or using the alternative `xmlns` approach:
 
 ```xml
-<f:fluid xmlns:foo="http://typo3.org/ns/Vendor/Foo/ViewHelpers">
+<html xmlns:foo="http://typo3.org/ns/Vendor/Foo/ViewHelpers">
 <f:layout name="Default" />
     <f:section name="Main">
         <!-- ... --->
     </f:section>
-</f:fluid>
+</html>
 ```
 
 Once you have registered/imported the ViewHelper collection (we call it a collection here even if it contains only one class) you


### PR DESCRIPTION
Avoids use of pseudo-ViewHelper "f:fluid" in favor
of traditional way using "html" tag.

Close: #448