### PR TITLE
[TASK] Add stub for ComponentInterface

### DIFF
--- a/src/Component/ComponentInterface.php
+++ b/src/Component/ComponentInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\Component;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * STUB CLASS: ComponentInterface
+ *
+ * Exists solely to allow static analysis of ViewHelper classes
+ * which implement new Fluid 3.x API to be technically valid.
+ */
+class ComponentInterface
+{
+}


### PR DESCRIPTION
Functionless stub for ComponentInterface to allow
ViewHelpers to implement API from Fluid 3.x and
still be technically valid in terms of static analysis.