### PR TITLE
[TASK] Add two missing test cases

### DIFF
--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -206,6 +206,7 @@ class StandardVariableProviderTest extends UnitTestCase
             [['user' => $namedUser], 'user.invalid', null],
             [['foodynamicbar' => 'test', 'dyn' => 'dynamic'], 'foo{dyn}bar', 'test'],
             [['foo' => ['dynamic' => ['bar' => 'test']], 'dyn' => 'dynamic'], 'foo.{dyn}.bar', 'test'],
+            [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar'], 'baz' => 'sub'], 'foo.{dynamic.{baz}}', 'test'],
             [['user' => $namedUser], 'user.hasAccessor', true],
             [['user' => $namedUser], 'user.isAccessor', true],
             [['user' => $unnamedUser], 'user.hasAccessor', false],

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -50,6 +50,7 @@ class VariableExtractorTest extends UnitTestCase
             [['user' => $namedUser], 'user.invalid', null],
             [['foodynamicbar' => 'test', 'dyn' => 'dynamic'], 'foo{dyn}bar', 'test'],
             [['foo' => ['dynamic' => ['bar' => 'test']], 'dyn' => 'dynamic'], 'foo.{dyn}.bar', 'test'],
+            [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar'], 'baz' => 'sub'], 'foo.{dynamic.{baz}}', 'test'],
             [['user' => $namedUser], 'user.hasAccessor', true],
             [['user' => $namedUser], 'user.isAccessor', true],
             [['user' => $unnamedUser], 'user.hasAccessor', false],


### PR DESCRIPTION
This patch adds two missing test cases for VariableExtractor
and StandardVariableProvider. The absence of these tests
has caused two pull requests to be rejected even though the
patches' tests ran successfully.

To prevent future pitfalls, the test case that would fail if a
developer attempts to make multiple same-level sub-variable
references work, are added in the appropriate places.

References: #509, #472