### PR TITLE
[TASK] Stub ArgumentCollection from Fluid 3.0 API

### DIFF
--- a/src/Component/Argument/ArgumentCollection.php
+++ b/src/Component/Argument/ArgumentCollection.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\Component\Argument;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * STUB CLASS: ArgumentCollection
+ *
+ * Exists solely to allow static analysis of ViewHelper classes
+ * which implement new Fluid 3.x API to be technically valid.
+ */
+class ArgumentCollection
+{
+}


### PR DESCRIPTION
Creates a stub for the new ArgumentCollection class which
is added in Fluid 3.0. Allows Fluid 2.x implementations to
be technically valid when performing static analysis on
classes which implement API for both Fluid 2.x and 3.x.