### PR TITLE
Escape single quotes in cache static viewhelper

### DIFF
--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -211,7 +211,7 @@ class NodeConverter
 
             $initializationPhpCode .= $argumentInitializationCode . $viewHelperInitializationPhpCode;
         } catch (StopCompilingChildrenException $stopCompilingChildrenException) {
-            $convertedViewHelperExecutionCode = '\'' . $stopCompilingChildrenException->getReplacementString() . '\'';
+            $convertedViewHelperExecutionCode = '\'' . str_replace("'", "\'", $stopCompilingChildrenException->getReplacementString()) . '\'';
         }
         $initializationArray = [
             'initialization' => $initializationPhpCode,


### PR DESCRIPTION
fixes: https://github.com/TYPO3/Fluid/issues/517