### PR TITLE
[TASK] Add Travis builds on osx and windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 
 language: php
 
+os:
+  - linux
+  - windows
+  - osx
+
 branches:
   only:
     - master


### PR DESCRIPTION
Adds the "osx" and "windows" environments to the Travis
build script to trigger building on these in addition to "linux".