### PR TITLE
[TASK] Replace method_exists by is_callable

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -344,7 +344,7 @@ class StandardVariableProvider implements VariableProviderInterface
         if (is_object($subject)) {
             $upperCasePropertyName = ucfirst($propertyName);
             $getter = 'get' . $upperCasePropertyName;
-            if (method_exists($subject, $getter)) {
+            if (is_callable([$subject, $getter])) {
                 return self::ACCESSOR_GETTER;
             }
             if ($this->isExtractableThroughAsserter($subject, $propertyName)) {


### PR DESCRIPTION
In the method detectAccessor of the class VariableExtractor is_callable is used, but in the method detectAccessor of the class StandardVariableProvider method_exits ist used. So when trying to use a magic call to access a dynamic generated method, the call fails. By using is_callable, the __call method is recognized and used