### PR TITLE
[BUGFIX] Restore support for data- prefixed arguments

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -47,6 +47,14 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     protected $tagName = 'div';
 
     /**
+     * Arguments which are valid but do not have an ArgumentDefinition, e.g.
+     * data- prefixed arguments.
+     *
+     * @var array
+     */
+    protected $additionalArguments = [];
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -101,6 +109,12 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
             }
         }
 
+        foreach ($this->additionalArguments as $argumentName => $argumentValue) {
+            if (strpos($argumentName, 'data-') === 0) {
+                $this->tag->addAttribute($argumentName, $argumentValue);
+            }
+        }
+
         if (isset(self::$tagAttributes[get_class($this)])) {
             foreach (self::$tagAttributes[get_class($this)] as $attributeName) {
                 if ($this->hasArgument($attributeName) && $this->arguments[$attributeName] !== '') {
@@ -147,27 +161,10 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
         $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
     }
 
-    /**
-     * Handles additional arguments, sorting out any data-
-     * prefixed tag attributes and assigning them. Then passes
-     * the unassigned arguments to the parent class' method,
-     * which in the default implementation will throw an error
-     * about "undeclared argument used".
-     *
-     * @param array $arguments
-     * @return void
-     */
     public function handleAdditionalArguments(array $arguments)
     {
-        $unassigned = [];
-        foreach ($arguments as $argumentName => $argumentValue) {
-            if (strpos($argumentName, 'data-') === 0) {
-                $this->tag->addAttribute($argumentName, $argumentValue);
-            } else {
-                $unassigned[$argumentName] = $argumentValue;
-            }
-        }
-        parent::handleAdditionalArguments($unassigned);
+        $this->additionalArguments = $arguments;
+        parent::handleAdditionalArguments($arguments);
     }
 
     /**

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+
+class TagBasedTest extends UnitTestCase
+{
+    public function testTagBasedViewHelperWithAdditionalAttributesArray()
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $arguments = [
+            'additionalAttributes' => [
+                'foo' => 'bar',
+            ],
+        ];
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div foo="bar" />', $result);
+    }
+
+    public function testTagBasedViewHelperWithDataArray()
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $arguments = [
+            'data' => [
+                'foo' => 'bar',
+            ],
+        ];
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div data-foo="bar" />', $result);
+    }
+
+    public function testTagBasedViewHelperWithDataPrefixedArgument()
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $arguments = [
+            'data-foo' => 'bar',
+        ];
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div data-foo="bar" />', $result);
+    }
+}

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -45,4 +45,37 @@ class TagBasedTest extends UnitTestCase
         $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
         $this->assertSame('<div data-foo="bar" />', $result);
     }
+
+    /**
+     * @dataProvider tagBasedViewHelperWithDataArrayAndPrefixedArgumentProvider
+     */
+    public function testTagBasedViewHelperWithDataArrayAndPrefixedArgument(array $arguments)
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div data-foo="attribute" />', $result);
+    }
+
+    public function tagBasedViewHelperWithDataArrayAndPrefixedArgumentProvider(): array
+    {
+        return [
+            'data before attribute' => [
+                [
+                    'data' => [
+                        'foo' => 'data',
+                    ],
+                    'data-foo' => 'attribute',
+                ],
+            ],
+            'attribute before data' => [
+                [
+                    'data-foo' => 'attribute',
+                    'data' => [
+                        'foo' => 'data',
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -171,6 +171,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $tagBuilder->expects($this->at(1))->method('addAttribute')->with('data-bar', 'bar');
         $viewHelper->setTagBuilder($tagBuilder);
         $viewHelper->handleAdditionalArguments(['data-foo' => 'foo', 'data-bar' => 'bar']);
+        $viewHelper->initializeArgumentsAndRender();
     }
 
     /**


### PR DESCRIPTION
Due to a regression in https://github.com/TYPO3/Fluid/pull/419,
a TagBasedViewHelper which was called with one or more
data- prefixed arguments would discard the prefixed arguments
and the output would not contain the attribute.

This patch fixes that regression by moving the handling of
unregistered arguments to the initialize() function in order
to make sure the additional attributes are handled *after*
the reset() method has been called on TagBuilder.

References: #419