### PR TITLE
[FEATURE] Introduce aria argument in AbstractTagBasedViewHelper

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -81,6 +81,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     {
         $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', false);
         $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.', false);
+        $this->registerArgument('aria', 'array', 'Additional aria-* attributes. They will each be added with a "aria-" prefix.', false);
     }
 
     /**
@@ -109,8 +110,14 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
             }
         }
 
+        if ($this->hasArgument('aria') && is_array($this->arguments['aria'])) {
+            foreach ($this->arguments['aria'] as $ariaAttributeKey => $ariaAttributeValue) {
+                $this->tag->addAttribute('aria-' . $ariaAttributeKey, $ariaAttributeValue);
+            }
+        }
+
         foreach ($this->additionalArguments as $argumentName => $argumentValue) {
-            if (strpos($argumentName, 'data-') === 0) {
+            if (strpos($argumentName, 'data-') === 0 || strpos($argumentName, 'aria-') === 0) {
                 $this->tag->addAttribute($argumentName, $argumentValue);
             }
         }

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -194,9 +194,11 @@ class TagBuilder
         if ($escapeSpecialCharacters) {
             $attributeName = htmlspecialchars($attributeName);
         }
-        if ($attributeName === 'data' && (is_array($attributeValue) || $attributeValue instanceof \Traversable)) {
+        if (($attributeName === 'data' || $attributeName === 'aria')
+            && (is_array($attributeValue) || $attributeValue instanceof \Traversable)
+        ) {
             foreach ($attributeValue as $name => $value) {
-                $this->addAttribute('data-' . $name, $value, $escapeSpecialCharacters);
+                $this->addAttribute($attributeName . '-' . $name, $value, $escapeSpecialCharacters);
             }
         } else {
             if (trim((string) $attributeValue) === '' && $this->ignoreEmptyAttributes) {

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -194,7 +194,7 @@ class TagBuilder
         if ($escapeSpecialCharacters) {
             $attributeName = htmlspecialchars($attributeName);
         }
-        if (($attributeName === 'data' || $attributeName === 'aria')
+        if (in_array($attributeName, ['data', 'aria'], true)
             && (is_array($attributeValue) || $attributeValue instanceof \Traversable)
         ) {
             foreach ($attributeValue as $name => $value) {

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -35,6 +35,19 @@ class TagBasedTest extends UnitTestCase
         $this->assertSame('<div data-foo="bar" />', $result);
     }
 
+    public function testTagBasedViewHelperWithAriaArray()
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $arguments = [
+            'aria' => [
+                'controls' => 'foo',
+            ],
+        ];
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div aria-controls="foo" />', $result);
+    }
+
     public function testTagBasedViewHelperWithDataPrefixedArgument()
     {
         $invoker = new ViewHelperInvoker();
@@ -44,6 +57,17 @@ class TagBasedTest extends UnitTestCase
         ];
         $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
         $this->assertSame('<div data-foo="bar" />', $result);
+    }
+
+    public function testTagBasedViewHelperWithAriaPrefixedArgument()
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $arguments = [
+            'aria-controls' => 'foo',
+        ];
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div aria-controls="foo" />', $result);
     }
 
     /**
@@ -73,6 +97,39 @@ class TagBasedTest extends UnitTestCase
                     'data-foo' => 'attribute',
                     'data' => [
                         'foo' => 'data',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider tagBasedViewHelperWithAriaArrayAndPrefixedArgumentProvider
+     */
+    public function testTagBasedViewHelperWithAriaArrayAndPrefixedArgument(array $arguments)
+    {
+        $invoker = new ViewHelperInvoker();
+        $viewHelper = new TagBasedTestViewHelper();
+        $result = $invoker->invoke($viewHelper, $arguments, new RenderingContextFixture());
+        $this->assertSame('<div aria-controls="attribute" />', $result);
+    }
+
+    public function tagBasedViewHelperWithAriaArrayAndPrefixedArgumentProvider(): array
+    {
+        return [
+            'aria before attribute' => [
+                [
+                    'aria' => [
+                        'controls' => 'aria',
+                    ],
+                    'aria-controls' => 'attribute',
+                ],
+            ],
+            'attribute before aria' => [
+                [
+                    'aria-controls' => 'attribute',
+                    'aria' => [
+                        'controls' => 'aria',
                     ],
                 ],
             ],

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -139,6 +139,21 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     /**
      * @test
      */
+    public function ariaAttributesAreRenderedCorrectly()
+    {
+        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
+        $mockTagBuilder->expects($this->at(0))->method('addAttribute')->with('aria-foo', 'bar');
+        $mockTagBuilder->expects($this->at(1))->method('addAttribute')->with('aria-baz', 'foos');
+        $this->viewHelper->setTagBuilder($mockTagBuilder);
+
+        $arguments = ['aria' => ['foo' => 'bar', 'baz' => 'foos']];
+        $this->viewHelper->setArguments($arguments);
+        $this->viewHelper->initialize();
+    }
+
+    /**
+     * @test
+     */
     public function testValidateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments()
     {
         $viewHelper = $this->getAccessibleMock(
@@ -171,6 +186,27 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $tagBuilder->expects($this->at(1))->method('addAttribute')->with('data-bar', 'bar');
         $viewHelper->setTagBuilder($tagBuilder);
         $viewHelper->handleAdditionalArguments(['data-foo' => 'foo', 'data-bar' => 'bar']);
+        $viewHelper->initializeArgumentsAndRender();
+    }
+
+    /**
+     * @test
+     */
+    public function testHandleAdditionalArgumentsSetsTagAttributesForAriaArguments()
+    {
+        $viewHelper = $this->getAccessibleMock(
+            AbstractTagBasedViewHelper::class,
+            ['dummy'],
+            [],
+            '',
+            false
+        );
+        $viewHelper->setRenderingContext(new RenderingContextFixture());
+        $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
+        $tagBuilder->expects($this->at(0))->method('addAttribute')->with('aria-foo', 'foo');
+        $tagBuilder->expects($this->at(1))->method('addAttribute')->with('aria-bar', 'bar');
+        $viewHelper->setTagBuilder($tagBuilder);
+        $viewHelper->handleAdditionalArguments(['aria-foo' => 'foo', 'aria-bar' => 'bar']);
         $viewHelper->initializeArgumentsAndRender();
     }
 


### PR DESCRIPTION
To support developers in building accessible applications,
the AbstractTagBasedViewHelper now provides a new
argument aria. It therefore can be used to add additional
aria attributes to the HTML element.