### PR TITLE
[BUGFIX] Reset arguments when using cached templates

### DIFF
--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -293,4 +293,17 @@ abstract class AbstractComponent implements ComponentInterface
         }
         return (string) $value;
     }
+
+    public function __clone()
+    {
+        if ($this->arguments !== null) {
+            $this->arguments = clone $this->arguments;
+        }
+
+        if (0 < count($this->children)) {
+            $this->children = array_map(function ($child) {
+                return clone $child;
+            }, $this->children);
+        }
+    }
 }

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  * See LICENSE.txt that was shipped with this package.
  */
 
+use TYPO3Fluid\Fluid\Component\Argument\ArgumentCollection;
 use TYPO3Fluid\Fluid\Component\ComponentInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -55,9 +56,9 @@ class TemplateParser
         }
         static $cache = [];
         if (isset($cache[$hash])) {
-            return $cache[$hash];
+            return clone $cache[$hash];
         }
-        return $cache[$hash] = ($this->stack[$hash] ?? $this->parse($source));
+        return clone $cache[$hash] = ($this->stack[$hash] ?? $this->parse($source));
     }
 
     /**
@@ -109,7 +110,7 @@ class TemplateParser
         if (!isset($cache[$templateIdentifier])) {
             $cache[$templateIdentifier] = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure);
         }
-        return $cache[$templateIdentifier];
+        return clone $cache[$templateIdentifier];
     }
 
     /**


### PR DESCRIPTION
The TemplateParser creates a cache for parsed templates.
The arguemnts must be reset when using a cached verion
of a template.

Resolves #538