### PR TITLE
Add Argument viewhelper

### DIFF
--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -100,6 +100,8 @@ abstract class AbstractComponent implements ComponentInterface
             if ($lastNode) {
                 $lastNode->appendText($component->getText());
             }
+        } elseif ($component instanceof ArgumentViewHelper) {
+            $this->getArguments()[$component->getArguments()['name']] = $component;
         } else {
             $this->children[] = $component;
             $this->_lastAddedWasTextNode = $component instanceof TextNode;

--- a/src/ViewHelpers/ArgumentViewHelper.php
+++ b/src/ViewHelpers/ArgumentViewHelper.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+use TYPO3Fluid\Fluid\Component\EmbeddedComponentInterface;
+use TYPO3Fluid\Fluid\Component\SequencingComponentInterface;
+use TYPO3Fluid\Fluid\Core\Parser\Sequencer;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * Argument assigning ViewHelper
+ *
+ * Assigns an argument for a parent ViewHelper call when
+ * the parent ViewHelper supports it.
+ *
+ * Alternative to declaring an array to pass as "arguments".
+ *
+ * Usages:
+ *
+ *     <my:atom arg0="Foo">
+ *         <f:argument name="arg1">Value1</f:argument>
+ *         <f:argument name="arg2">Value2</f:argument>
+ *     </f:atom>
+ *
+ * Which is the equivalent of:
+ *
+ *     <my:atom arg0="Foo" arg1="Foo" arg2="Foo" />
+ *
+ * But has the benefit that writing ViewHelper expressions or
+ * other more complex syntax becomes much easier because you
+ * can use tag syntax (tag content becomes argument value).
+ *
+ */
+class ArgumentViewHelper extends AbstractViewHelper implements EmbeddedComponentInterface
+{
+    protected $escapeOutput = false;
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('name', 'string', 'Name of the parameter', true);
+    }
+
+    public function evaluate(RenderingContextInterface $renderingContext)
+    {
+        $arguments = $this->getArguments()->setRenderingContext($renderingContext)->getArrayCopy();
+        return $arguments['value'] ?? $this->evaluateChildNodes($renderingContext);
+    }
+}


### PR DESCRIPTION
Add a new `f:argument` viewhelper to be able to add
arguments to a node by using `f:argument` as child node.

Usage example:
```
<my:node>
	<f:argument name="content">Hello World</f:argument>
</my:node>
```

The sequencer does now put validation errors into a stack
so we are able to revalidate a node before it is closed but
children have been parsed. So we can still show the initial
problem if e.g. a required property was not defined.

Resolves #427