### PR TITLE
[BUGFIX] Correct throws annotation in ViewInterface

### DIFF
--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -49,7 +49,7 @@ interface ViewInterface
      * @param array $variables The variables to use
      * @param boolean $ignoreUnknown Ignore an unknown section and just return an empty string
      * @return string rendered template for the section
-     * @throws InvalidSectionException
+     * @throws Exception\InvalidSectionException
      */
     public function renderSection($sectionName, array $variables = [], $ignoreUnknown = false);
 


### PR DESCRIPTION
Fix the namespace to the actual position of the exception.