### PR TITLE
[BUGFIX] Handle possibly-null view instance

### DIFF
--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -154,7 +154,7 @@ class ViewHelperVariableContainer
      *
      * !!! This is NOT a public API and might still change!!!
      *
-     * @return ViewInterface The View
+     * @return ViewInterface|null The View, or null if view was not set
      */
     public function getView()
     {

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -10,6 +10,7 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
@@ -147,6 +148,15 @@ class RenderViewHelper extends AbstractViewHelper
         }
 
         $view = $renderingContext->getViewHelperVariableContainer()->getView();
+        if (!$view) {
+            throw new Exception(
+                'The f:render ViewHelper was used in a context where the ViewHelperVariableContainer does not contain ' .
+                'a reference to the View. Normally this is taken care of by the TemplateView, so most likely this ' .
+                'error is because you overrode AbstractTemplateView->initializeRenderingContext() and did not call ' .
+                '$renderingContext->getViewHelperVariableContainer()->setView($this) or parent::initializeRenderingContext. ' .
+                'This is an issue you must fix in your code as f:render is fully unable to render anything without a View.'
+            );
+        }
         $content = '';
         if ($renderable) {
             $content = $renderable->render($renderingContext);

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -7,6 +7,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
  */
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\ParsedTemplateImplementationFixture;
@@ -59,6 +60,23 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
         $instance->expects($this->at(6))->method('registerArgument')->with('default', 'mixed', $this->anything());
         $instance->expects($this->at(7))->method('registerArgument')->with('contentAs', 'string', $this->anything());
         $instance->initializeArguments();
+    }
+
+    public function testThrowsExceptionIfExecutedWithoutViewSetOnViewHelperVariableContainerRegardlessOfInvalidArguments()
+    {
+        $renderingContext = new RenderingContextFixture();
+        $this->setExpectedException(Exception::class);
+        $arguments = [
+            'partial' => null,
+            'section' => null,
+            'delegate' => null,
+            'renderable' => null,
+            'arguments' => [],
+            'optional' => true,
+            'default' => null,
+            'contentAs' => null
+        ];
+        RenderViewHelper::renderStatic($arguments, function() {}, $renderingContext);
     }
 
     /**


### PR DESCRIPTION
This change corrects the signature of
ViewHelperVariableContainer->getView to reflect
that the return is possibly-null, and throws a
very specific exception in f:render if encountering
that case (indicating that a RenderingContext
override was incomplete or incorrect).