### PR TITLE
[BUGFIX] Create child node copy on evaluation

### DIFF
--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -266,7 +266,9 @@ abstract class AbstractComponent implements ComponentInterface
             if ($childNode instanceof EmbeddedComponentInterface) {
                 continue;
             }
-            $evaluatedNodes[] = $childNode->evaluate($renderingContext);
+            $childNodeCopy = clone $childNode;
+            $childNodeCopy->setArguments(clone $childNodeCopy->getArguments());
+            $evaluatedNodes[] = $childNodeCopy->evaluate($renderingContext);
         }
         // Make decisions about what to actually return
         if (empty($evaluatedNodes)) {


### PR DESCRIPTION
When a child node is evaluated a copy of the node and
it's arguments must be used. If no copy is used things
like f:for viewhelper will not work as expected as the
nodes do always get the arguments of the first iteration.