### PR TITLE
[TASK] Change expected values to match used php version behaviour

### DIFF
--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -19,11 +19,14 @@ class BasicConditionsTest extends BaseConditionalFunctionalTestCase
             ['1 != 2', true],
             ['1 == 2', false],
             ['1 === 1', true],
-            ['\'foo\' == 0', true],
-            ['1.1 >= \'foo\'', true],
+            // expected value based on php versions behaviour
+            ['\'foo\' == 0', (PHP_VERSION_ID < 80000 ? true : false)],
+            // expected value based on php versions behaviour
+            ['1.1 >= \'foo\'', (PHP_VERSION_ID < 80000 ? true : false)],
             ['\'String containing word \"false\" in text\'', true],
             ['\'  FALSE  \'', true],
-            ['\'foo\' > 0', false],
+            // expected value based on php versions behaviour
+            ['\'foo\' > 0', (PHP_VERSION_ID < 80000 ? false : true)],
             ['FALSE', false],
             ['(FALSE || (FALSE || 1)', true],
             ['(FALSE || (FALSE || 1)', true],

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -128,9 +128,10 @@ class BooleanParserTest extends UnitTestCase
             ['0 OR 1', true],
 
             // edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
-            ['\'foo\' == 0', true],
-            ['1.1 >= foo', true],
-            ['\'foo\' > 0', false],
+            // expected value based on php versions behaviour
+            ['\'foo\' == 0', (PHP_VERSION_ID < 80000 ? true : false)],
+            ['1.1 >= foo', (PHP_VERSION_ID < 80000 ? true : false)],
+            ['\'foo\' > 0', (PHP_VERSION_ID < 80000 ? false : true)],
 
             ['{foo}', true, ['foo' => true]],
             ['{foo} == FALSE', true, ['foo' => false]],

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -585,9 +585,12 @@ class BooleanNodeTest extends UnitTestCase
      */
     public function equalsReturnsTrueIfComparingStringWithZero()
     {
+        // expected value based on php versions behaviour
+        $expected = (PHP_VERSION_ID < 80000 ? true : false);
+
         $rootNode = new RootNode();
         $rootNode->addChildNode(new TextNode('\'stringA\' == 0'));
-        $this->assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
+        $this->assertSame($expected, BooleanNode::createFromNodeAndEvaluate($rootNode, $this->renderingContext));
     }
 
     /**


### PR DESCRIPTION
Some tests has been expecting results on how php <8.0
behaves. These expectations were hard coded. These tests
had further tested raw php execution as a second match.

This patch sets the hardcoded expected values to values
based on the current php version used to run the
testsuite.

Testes with php8.0 enabled build, which demonstrates that
tests working with it. Still have issue with clover file
as current phpunit version do not support it.

See: https://github.com/sbuerk/Fluid/runs/3979490519?check_suite_focus=true

Fixes: #566