### PR TITLE
[BUGFIX] PHP 8.1 E_ALL compatibility

### DIFF
--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -130,6 +130,7 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param mixed $value The variable's value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($identifier, $value);
 
     /**
@@ -138,6 +139,7 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param string $identifier The identifier to remove
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($identifier);
 
     /**
@@ -146,6 +148,7 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param string $identifier
      * @return boolean TRUE if $identifier exists, FALSE otherwise
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($identifier);
 
     /**
@@ -154,5 +157,6 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param string $identifier
      * @return mixed The variable identified by $identifier
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($identifier);
 }


### PR DESCRIPTION
PHP 8.1 mumbles when internal (SPL) classes are
extended and their signature does not match. Some
of them can't be changed right now due to b/w
considerations and the availability of mixed
returns.

Attribute #[\ReturnTypeWillChange] can be used to
suppress E_DEPRECATED erros.