### PR TITLE
[BUGFIX] Avoid deprecated rtrim(null) in ViewHelperResolver

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -325,7 +325,7 @@ class ViewHelperResolver
         $namespaces = (array) $this->namespaces[$namespaceIdentifier];
 
         do {
-            $name = rtrim(array_pop($namespaces), '\\') . '\\' . $className;
+            $name = rtrim((string)array_pop($namespaces), '\\') . '\\' . $className;
         } while (!class_exists($name) && count($namespaces));
 
         return $name;

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -79,7 +79,7 @@ class ViewHelperResolverTest extends UnitTestCase
     /**
      * @test
      */
-    public function testResolveViewHelperClassNameSupportsMultipleNamespaces()
+    public function testResolveViewHelperNameSupportsMultipleNamespaces()
     {
         $resolver = $this->getAccessibleMock(ViewHelperResolver::class, ['dummy']);
         $resolver->_set('namespaces', [
@@ -95,7 +95,23 @@ class ViewHelperResolverTest extends UnitTestCase
     /**
      * @test
      */
-    public function testResolveViewHelperClassNameTrimsBackslashSuffixFromNamespace()
+    public function testResolveViewHelperNameDoesNotChokeOnNullInMultipleNamespaces()
+    {
+        $resolver = $this->getAccessibleMock(ViewHelperResolver::class, ['dummy']);
+        $resolver->_set('namespaces', [
+            'f' => [
+                'TYPO3Fluid\\Fluid\\ViewHelpers',
+                null
+            ]
+        ]);
+        $result = $resolver->_call('resolveViewHelperName', 'f', 'render');
+        $this->assertEquals('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testResolveViewHelperNameTrimsBackslashSuffixFromNamespace()
     {
         $resolver = $this->getAccessibleMock(ViewHelperResolver::class, ['dummy']);
         $resolver->_set('namespaces', ['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers\\']]);


### PR DESCRIPTION
PHP 8.1 deprecated handing null as first argument to rtrim().
The patch sanitizes an occurrence in ViewHelperResolver.