### PR TITLE
[BUGFIX] Avoid further FILE_TEXT constant usages

### DIFF
--- a/src/Core/Cache/StandardCacheWarmer.php
+++ b/src/Core/Cache/StandardCacheWarmer.php
@@ -328,7 +328,7 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
     protected function createClosure($templatePathAndFilename)
     {
         return function(TemplateParser $parser, TemplatePaths $templatePaths) use ($templatePathAndFilename) {
-            return file_get_contents($templatePathAndFilename, FILE_TEXT);
+            return file_get_contents($templatePathAndFilename);
         };
     }
 }

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -546,7 +546,7 @@ class TemplatePaths
     public function getLayoutSource($layoutName = 'Default')
     {
         $layoutPathAndFilename = $this->getLayoutPathAndFilename($layoutName);
-        return file_get_contents($layoutPathAndFilename, FILE_TEXT);
+        return file_get_contents($layoutPathAndFilename);
     }
 
     /**
@@ -680,7 +680,7 @@ class TemplatePaths
     public function getPartialSource($partialName)
     {
         $partialPathAndFilename = $this->getPartialPathAndFilename($partialName);
-        return file_get_contents($partialPathAndFilename, FILE_TEXT);
+        return file_get_contents($partialPathAndFilename);
     }
 
     /**

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -242,7 +242,7 @@ class TemplateParserTest extends UnitTestCase
      */
     public function splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate($templateName)
     {
-        $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html', FILE_TEXT);
+        $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html');
         $expectedResult = require __DIR__ . '/Fixtures/' . $templateName . '-split.php';
         $templateParser = $this->getAccessibleMock(TemplateParser::class, ['dummy']);
         $this->assertSame($expectedResult, $templateParser->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);


### PR DESCRIPTION
constant FILE_TEXT is deprecated as of PHP 8.1. The
value is defined to 0.

The patch fixes remaining places: Given as second
argument to file_get_contents() makes it bool false,
which is default of second argument, so it can be
skipped altogether.