### PR TITLE
[BUGFIX] Sanitize htmlspecialchars(null) in TagBuilder

### DIFF
--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -184,7 +184,7 @@ class TagBuilder
      * Adds an attribute to the $attributes-collection
      *
      * @param string $attributeName name of the attribute to be added to the tag
-     * @param string $attributeValue attribute value
+     * @param string|\Traversable|array|null $attributeValue attribute value
      * @param boolean $escapeSpecialCharacters apply htmlspecialchars to attribute value
      * @return void
      * @api
@@ -205,7 +205,7 @@ class TagBuilder
                 return;
             }
             if ($escapeSpecialCharacters) {
-                $attributeValue = htmlspecialchars($attributeValue);
+                $attributeValue = htmlspecialchars((string)$attributeValue);
             }
             $this->attributes[$attributeName] = $attributeValue;
         }


### PR DESCRIPTION
Public TagBuilder->addAttribute() accepts null as
$attributeValue. htmlspecialchars(null) in non strict types
context raises a E_DEPRECATED level error since PHP 8.1.
The patch sanitizes the call using a string cast.