### PR TITLE
[BUGFIX] Avoid preg_replace('', '', null) in SpacelessViewHelper

### DIFF
--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -57,6 +57,6 @@ class SpacelessViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $childClosure, RenderingContextInterface $renderingContext)
     {
-        return trim(preg_replace('/\\>\\s+\\</', '><', $childClosure()));
+        return trim(preg_replace('/\\>\\s+\\</', '><', (string)$childClosure()));
     }
 }


### PR DESCRIPTION
Invoking $childClosure() may return null. Feeding null as third
argument to preg_replace raises a E_DEPRECATED level error in
PHP 8.1 in non strict types context.
Sanitize that call.