### PR TITLE
[TASK] Move testing forward until PHP8.1 testing with display_errors=1 and E_ALL testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
       - uses: actions/checkout@v2
@@ -40,6 +40,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
+        if: ${{ matrix.php != '8.0' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
-        if: ${{ matrix.php != '8.0' }}
+        if: ${{ matrix.php != '8.0' && matrix.php != '8.1' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": ">=5.5.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.1",
+		"phpunit/phpunit": "^8.5.21",
 		"mikey179/vfsstream": "^1.6.10",
 		"squizlabs/php_codesniffer": "^2.7",
 		"php-coveralls/php-coveralls": "^2.1"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.1",
-		"mikey179/vfsstream": "^1.6",
+		"mikey179/vfsstream": "^1.6.10",
 		"squizlabs/php_codesniffer": "^2.7",
 		"php-coveralls/php-coveralls": "^2.1"
 	},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,4 +28,8 @@
                         <directory>src/</directory>
                 </whitelist>
         </filter>
+
+        <php>
+                <ini name="display_errors" value="1" />
+        </php>        
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,5 +31,6 @@
 
         <php>
                 <ini name="display_errors" value="1" />
+                <ini name="error_reporting" value="E_ALL" />
         </php>        
 </phpunit>

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -300,7 +300,7 @@ EOD;
      */
     protected function sanitizeIdentifier($identifier)
     {
-        return preg_replace('([^a-zA-Z0-9_\x7f-\xff])', '_', $identifier);
+        return (string)preg_replace('([^a-zA-Z0-9_\x7f-\xff])', '_', $identifier);
     }
 
     /**

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -64,6 +64,7 @@ class TemplateCompilerTest extends UnitTestCase
         $renderingContext->cacheDisabled = true;
         $renderingContext->expects($this->never())->method('getCache');
         $instance->setRenderingContext($renderingContext);
+        $instance->expects($this->once())->method('sanitizeIdentifier')->willReturn('');
         $result = $instance->has('test');
         $this->assertFalse($result);
     }

--- a/tests/Unit/ViewHelpers/Fixtures/CountableIterator.php
+++ b/tests/Unit/ViewHelpers/Fixtures/CountableIterator.php
@@ -13,26 +13,32 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
  */
 class CountableIterator implements \Iterator, \Countable
 {
+    #[\ReturnTypeWillChange]
     public function current()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
     }


### PR DESCRIPTION
This pull-request contains multiple commits, which works to the point that github workflow testing is green with PHP 7.2, 7.3, 7.4, 8.0 and 8.1 with E_ALL error_reporting and display_errors = 1, or to say shortly tested as hard as possible.

To get there, some fixes have to be added, mainly fix inpropper testsetup (mock) or an
incompatible test fixture. 

Furthermore two packages will be raised for the minumum version as these are the needed
versions absolutly needed for PHP8.1 execution.

Note: There is one drawback, uploading coverage get disabled for PHP8.0 and PHP8.1 as
phpunit 8.5.x do not support creating corresponding file when run with PHP8.0 or 8.1.
As phpunit 9.x needs at least PHP7.3, I choosed to disable the uploading for now.

This has to be investigated further to find a solution having all under the same hood,
and solved in a dedicated pull-request / commit.
