### PR TITLE
[BUGFIX] Allow action-only templates to work

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -565,7 +565,7 @@ class TemplatePaths
             return 'source_' . sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $this->getFormat();
         }
         $templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action);
-        $prefix = $controller . '_action_' . $action;
+        $prefix = ltrim($controller . '_action_' . $action, '_');
         return $this->createIdentifierForFile($templatePathAndFilename, $prefix);
     }
 

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -258,9 +258,11 @@ class TemplatePaths
         $controller = str_replace('\\', '/', $controller);
         $action = ucfirst($action);
         $identifier = $controller . '/' . $action . '.' . $format;
+        $identifier = ltrim($identifier, '/');
         if (!array_key_exists($identifier, $this->resolvedFiles['templates'])) {
             $templateRootPaths = $this->getTemplateRootPaths();
             foreach ([$controller . '/' . $action, $action] as $possibleRelativePath) {
+                $possibleRelativePath = ltrim($possibleRelativePath, '/');
                 try {
                     return $this->resolvedFiles['templates'][$identifier] = $this->resolveFileInPaths($templateRootPaths, $possibleRelativePath, $format);
                 } catch (InvalidTemplateResourceException $error) {

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -257,8 +257,7 @@ class TemplatePaths
         $format = $format ?: $this->getFormat();
         $controller = str_replace('\\', '/', $controller);
         $action = ucfirst($action);
-        $identifier = $controller . '/' . $action . '.' . $format;
-        $identifier = ltrim($identifier, '/');
+        $identifier = ltrim($controller . '/' . $action . '.' . $format, '/');
         if (!array_key_exists($identifier, $this->resolvedFiles['templates'])) {
             $templateRootPaths = $this->getTemplateRootPaths();
             foreach ([$controller . '/' . $action, $action] as $possibleRelativePath) {

--- a/tests/Unit/View/Fixtures/ARandomController/TestTemplate.html
+++ b/tests/Unit/View/Fixtures/ARandomController/TestTemplate.html
@@ -1,0 +1,4 @@
+<f:if condition="{nothing}">
+    <f:then>Good</f:then>
+    <f:else>Bad</f:else>
+</f:if>

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -6,8 +6,6 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\View;
  * See LICENSE.txt that was shipped with this package.
  */
 
-use TYPO3Fluid\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3Fluid\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
@@ -280,5 +278,19 @@ class TemplatePathsTest extends BaseTestCase
         $instance = new $className();
         $instance->setTemplateSource('foobar');
         $this->assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+    }
+
+    /**
+     * @@test
+     */
+    public function testActionTemplateWithEmptyController(): void
+    {
+        $className = $this->getSubjectClassName();
+        $subject = new $className();
+        $subject->setTemplateRootPaths([__DIR__ . '/Fixtures']);
+        $foundFixture = $subject->resolveTemplateFileForControllerAndActionAndFormat('', 'UnparsedTemplateFixture');
+        self::assertStringContainsString('UnparsedTemplateFixture.html', $foundFixture);
+        $identifier = $subject->getTemplateIdentifier('', 'UnparsedTemplateFixture');
+        self::assertStringStartsWith('action_UnparsedTemplateFixture_', $identifier);
     }
 }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -283,13 +283,29 @@ class TemplatePathsTest extends BaseTestCase
     /**
      * @@test
      */
+    public function testActionTemplateWithControllerAndAction(): void
+    {
+        $className = $this->getSubjectClassName();
+        $subject = new $className();
+        $baseTemplatePath = __DIR__ . '/Fixtures';
+        $subject->setTemplateRootPaths([$baseTemplatePath]);
+        $foundFixture = $subject->resolveTemplateFileForControllerAndActionAndFormat('ARandomController', 'TestTemplate');
+        self::assertEquals($baseTemplatePath . '/ARandomController/TestTemplate.html', $foundFixture);
+        $identifier = $subject->getTemplateIdentifier('ARandomController', 'TestTemplate');
+        self::assertStringStartsWith('ARandomController_action_TestTemplate_', $identifier);
+    }
+
+    /**
+     * @@test
+     */
     public function testActionTemplateWithEmptyController(): void
     {
         $className = $this->getSubjectClassName();
         $subject = new $className();
-        $subject->setTemplateRootPaths([__DIR__ . '/Fixtures']);
+        $baseTemplatePath = __DIR__ . '/Fixtures';
+        $subject->setTemplateRootPaths([$baseTemplatePath]);
         $foundFixture = $subject->resolveTemplateFileForControllerAndActionAndFormat('', 'UnparsedTemplateFixture');
-        self::assertStringContainsString('UnparsedTemplateFixture.html', $foundFixture);
+        self::assertEquals($baseTemplatePath . '/UnparsedTemplateFixture.html', $foundFixture);
         $identifier = $subject->getTemplateIdentifier('', 'UnparsedTemplateFixture');
         self::assertStringStartsWith('action_UnparsedTemplateFixture_', $identifier);
     }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -281,7 +281,7 @@ class TemplatePathsTest extends BaseTestCase
     }
 
     /**
-     * @@test
+     * @test
      */
     public function testActionTemplateWithControllerAndAction(): void
     {
@@ -296,7 +296,7 @@ class TemplatePathsTest extends BaseTestCase
     }
 
     /**
-     * @@test
+     * @test
      */
     public function testActionTemplateWithEmptyController(): void
     {


### PR DESCRIPTION
The current templatePaths functionality is highly limited,
in order to run Fluid with an "ADR" approach where each
Action represents a single PHP class (single responsibility),
Fluid always expected a Controller in order to build the path.

This change addresses the issue when a TemplatePaths object
is built with an empty controller (""), to resolve the paths
correctly when trying to locate the proper file path.