### PR TITLE
[TASK] Change property docblock of $contentArgumentName how to set it

### DIFF
--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -25,11 +25,31 @@ trait CompileWithContentArgumentAndRenderStatic
      * registered in `initializeArguments` of the ViewHelper
      * will be used.
      *
-     * Note: it is significantly better practice to define
+     * Note: it is significantly better practice defining
      * this property in your ViewHelper class and so fix it
      * to one particular argument instead of resolving,
      * especially when your ViewHelper is called multiple
      * times within an uncompiled template!
+     *
+     * This property cannot be directly set in consuming
+     * ViewHelper, instead set the property in ViewHelper
+     * constructor '__construct()', for example with
+     * $this->contentArgumentName = 'explicitlyToUseArgumentName';
+     *
+     * Another possible way would be to override the method
+     * 'resolveContentArgumentName()' and return the name.
+     *
+     * public function resolveContentArgumentName()
+     * {
+     *     return 'explicitlyToUseArgumentName';
+     * }
+     *
+     * Note: Setting this through 'initializeArguments()' will
+     *       not work as expected, and other methods should be
+     *       avoided to override this.
+     *
+     * Following test ViewHelpers are tested and demonstrates
+     * that the setting posibillities works.
      *
      * @var string
      */
@@ -66,7 +86,7 @@ trait CompileWithContentArgumentAndRenderStatic
         ViewHelperNode $node,
         TemplateCompiler $compiler
     ) {
-        list ($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
+        list($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
             $this,
             $argumentsName,
             $closureName,
@@ -128,7 +148,7 @@ trait CompileWithContentArgumentAndRenderStatic
             }
             throw new Exception(
                 sprintf('Attempting to compile %s failed. Chosen compile method requires that ViewHelper has ' .
-                'at least one registered and optional argument', __CLASS__)
+                    'at least one registered and optional argument', __CLASS__)
             );
         }
         return $this->contentArgumentName;

--- a/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
+
+use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
+use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
+use TYPO3Fluid\Fluid\Tests\Functional\BaseFunctionalTestCase;
+
+class CompileWithContentArgumentAndRenderStaticTest extends BaseFunctionalTestCase
+{
+    /**
+     * If your test case requires a cache, override this
+     * method and return an instance.
+     *
+     * @return FluidCacheInterface
+     */
+    protected function getCache()
+    {
+        return new SimpleFileCache(sys_get_temp_dir());
+    }
+
+    public function getTemplateCodeFixturesAndExpectations(): array
+    {
+        return [
+            // with trait but without contentArgumentProperty set in viewhelper and having optional argument
+            'children content but no argument value' => [
+                '<test:compileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildren>mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildren>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": null',
+                    '"renderChildrenClosure": "mustBeRenderingChildrenClosure"',
+                ],
+                [],
+                null,
+                true
+            ],
+            'children content and argument value' => [
+                '<test:compileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildren firstOptionalArgument="firstOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildren>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": "firstOptionalArgument"',
+                    '"renderChildrenClosure": "firstOptionalArgument"',
+                ],
+                [],
+                null,
+                true
+            ],
+            // with trait but without contentArgumentProperty set in viewhelper and having first optional argument as second argument
+            'children content but no argument value [optional is second argument]' => [
+                '<test:compileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildren requiredArgument="dummy">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildren>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": null',
+                    '"renderChildrenClosure": "mustBeRenderingChildrenClosure"',
+                ],
+                [],
+                null,
+                true
+            ],
+            'children content and argument value [optional is second argument]' => [
+                '<test:compileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildren requiredArgument="dummy" firstOptionalArgument="firstOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildren>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": "firstOptionalArgument"',
+                    '"renderChildrenClosure": "firstOptionalArgument"',
+                ],
+                [],
+                null,
+                true
+            ],
+            // now the hard cases - setting the contentArgumentName property which the trait uses to disable the magic
+            'children content but no argument value [use second optional argument]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent >mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": null',
+                    '"arguments[secondOptionalArgument]": null',
+                    '"renderChildrenClosure": "mustBeRenderingChildrenClosure"',
+                ],
+                [],
+                null,
+                true
+            ],
+            'children content and argument value [use second optional argument]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent firstOptionalArgument="firstOptionalArgument" secondOptionalArgument="secondOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": "firstOptionalArgument"',
+                    '"arguments[secondOptionalArgument]": "secondOptionalArgument"',
+                    '"renderChildrenClosure": "secondOptionalArgument"',
+                ],
+                [],
+                null,
+                true
+            ],
+        ];
+    }
+
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * Same as testTemplateCodeFixture() but includes a cache
+     * in the tests. Silently skipped if the test case does not
+     * return a valid cache.
+     *
+     * @param string|resource $sourceOrStream
+     * @param array $variables
+     * @param array $expected
+     * @param array $notExpected
+     * @param string|NULL $expectedException
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixtureWithCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = null)
+    {
+        if ($this->getCache()) {
+            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+        } else {
+            $this->markTestSkipped('Cache-specific test skipped');
+        }
+    }
+
+    /**
+     * Perform a standard test on the source or stream provided,
+     * rendering it with $variables assigned and checking the
+     * output for presense of $expected values and confirming
+     * that none of the $notExpected values are present.
+     *
+     * Same as testTemplateCodeFixture() but includes a cache
+     * in the tests. Silently skipped if the test case does not
+     * return a valid cache.
+     *
+     * @param string|resource $sourceOrStream
+     * @param array $variables
+     * @param array $expected
+     * @param array $notExpected
+     * @param string|NULL $expectedException
+     * @test
+     * @dataProvider getTemplateCodeFixturesAndExpectations
+     */
+    public function testTemplateCodeFixtureWithoutCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = null)
+    {
+        $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, false);
+        $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, false);
+    }
+}

--- a/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
@@ -68,9 +68,9 @@ class CompileWithContentArgumentAndRenderStaticTest extends BaseFunctionalTestCa
                 null,
                 true
             ],
-            // now the hard cases - setting the contentArgumentName property which the trait uses to disable the magic
-            'children content but no argument value [use second optional argument]' => [
-                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent >mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent>',
+            // now the hard cases - setting the contentArgumentName property through the constructor
+            'children content but no argument value [use second optional argument][explicit set in __construct]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructor>mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructor>',
                 [],
                 [
                     '"arguments[firstOptionalArgument]": null',
@@ -81,8 +81,33 @@ class CompileWithContentArgumentAndRenderStaticTest extends BaseFunctionalTestCa
                 null,
                 true
             ],
-            'children content and argument value [use second optional argument]' => [
-                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent firstOptionalArgument="firstOptionalArgument" secondOptionalArgument="secondOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent>',
+            'children content and argument value [use second optional argument][explicit set in __construct]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructor firstOptionalArgument="firstOptionalArgument" secondOptionalArgument="secondOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructor>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": "firstOptionalArgument"',
+                    '"arguments[secondOptionalArgument]": "secondOptionalArgument"',
+                    '"renderChildrenClosure": "secondOptionalArgument"',
+                ],
+                [],
+                null,
+                true
+            ],
+            // now the hard cases - setting the contentArgumentName property through overriding resolveContentArgumentName
+            'children content but no argument value [use second optional argument][explicit set in overriden resolveContentArgumentName]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethod>mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethod>',
+                [],
+                [
+                    '"arguments[firstOptionalArgument]": null',
+                    '"arguments[secondOptionalArgument]": null',
+                    '"renderChildrenClosure": "mustBeRenderingChildrenClosure"',
+                ],
+                [],
+                null,
+                true
+            ],
+            'children content and argument value [use second optional argument][explicit set in overriden resolveContentArgumentName]' => [
+                '<test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethod firstOptionalArgument="firstOptionalArgument" secondOptionalArgument="secondOptionalArgument">mustBeRenderingChildrenClosure</test:compileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethod>',
                 [],
                 [
                     '"arguments[firstOptionalArgument]": "firstOptionalArgument"',

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper
+ */
+class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper extends AbstractViewHelper
+{
+    // ViewHelper tests this trait functionalities.
+    use CompileWithContentArgumentAndRenderStatic;
+
+    // set to false because of json response, not test relevant
+    protected $escapeOutput = false;
+    // set to false because of json response, not test relevant
+    protected $escapeChildren = false;
+
+    public function __construct()
+    {
+        // Set argument name to be used as content 'renderChildrenClosure()' if provided, otherwise render children.
+        $this->contentArgumentName = 'secondOptionalArgument';
+    }
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('firstOptionalArgument', 'string', 'First optional argument which is used as render children.');
+        $this->registerArgument('secondOptionalArgument', 'string', 'Second optional argument which is used as render children.');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        return json_encode(
+            [
+                'arguments[firstOptionalArgument]' => $arguments['firstOptionalArgument'],
+                'arguments[secondOptionalArgument]' => $arguments['secondOptionalArgument'],
+                'renderChildrenClosure' => $renderChildrenClosure(),
+            ],
+            JSON_PRETTY_PRINT
+        );
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
@@ -20,25 +20,22 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
 
 /**
- * Class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper
+ * Class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper *
  */
-class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper extends AbstractViewHelper
+class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper extends AbstractViewHelper
 {
     // ViewHelper tests this trait functionalities.
     use CompileWithContentArgumentAndRenderStatic;
-
-    /**
-     * Explicit set name of content argument which disable the magic determination of the first optional argument
-     * provided by the 'CompileWithContentArgumentAndRenderStatic' trait.
-     *
-     * @var string
-     */
-    protected $contentArgumentName = 'secondOptionalArgument';
 
     // set to false because of json response, not test relevant
     protected $escapeOutput = false;
     // set to false because of json response, not test relevant
     protected $escapeChildren = false;
+
+    public function __construct()
+    {
+
+    }
 
     public function initializeArguments(): void
     {
@@ -57,5 +54,14 @@ class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent
             ],
             JSON_PRETTY_PRINT
         );
+    }
+
+    /**
+     * @return string
+     */
+    public function resolveContentArgumentName()
+    {
+        // Use argument name to be used as content 'renderChildrenClosure()' if provided, otherwise render children.
+        return 'secondOptionalArgument';
     }
 }

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper
+ */
+class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentViewHelper extends AbstractViewHelper
+{
+    // ViewHelper tests this trait functionalities.
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * Explicit set name of content argument which disable the magic determination of the first optional argument
+     * provided by the 'CompileWithContentArgumentAndRenderStatic' trait.
+     *
+     * @var string
+     */
+    protected $contentArgumentName = 'secondOptionalArgument';
+
+    // set to false because of json response, not test relevant
+    protected $escapeOutput = false;
+    // set to false because of json response, not test relevant
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('firstOptionalArgument', 'string', 'First optional argument which is used as render children.');
+        $this->registerArgument('secondOptionalArgument', 'string', 'Second optional argument which is used as render children.');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        return json_encode(
+            [
+                'arguments[firstOptionalArgument]' => $arguments['firstOptionalArgument'],
+                'arguments[secondOptionalArgument]' => $arguments['secondOptionalArgument'],
+                'renderChildrenClosure' => $renderChildrenClosure(),
+            ],
+            JSON_PRETTY_PRINT
+        );
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Class CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper
+ */
+class CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper extends AbstractViewHelper
+{
+    // ViewHelper tests this trait functionalities.
+    use CompileWithContentArgumentAndRenderStatic;
+
+    // set to false because of json response, not test relevant
+    protected $escapeOutput = false;
+    // set to false because of json response, not test relevant
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('requiredArgument', 'string', 'demo required argument before optional argument', true);
+        $this->registerArgument('firstOptionalArgument', 'string', 'First optional argument which is used as render children.');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        return json_encode(
+            [
+                'arguments[firstOptionalArgument]' => $arguments['firstOptionalArgument'],
+                'renderChildrenClosure' => $renderChildrenClosure(),
+            ],
+            JSON_PRETTY_PRINT
+        );
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Class CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper
+ */
+class CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper extends AbstractViewHelper
+{
+    // ViewHelper tests this trait functionalities.
+    use CompileWithContentArgumentAndRenderStatic;
+
+    // set to false because of json response, not test relevant
+    protected $escapeOutput = false;
+    // set to false because of json response, not test relevant
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('firstOptionalArgument', 'string', 'First optional argument which is used as render children.');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        return json_encode(
+            [
+                'arguments[firstOptionalArgument]' => $arguments['firstOptionalArgument'],
+                'renderChildrenClosure' => $renderChildrenClosure(),
+            ],
+            JSON_PRETTY_PRINT
+        );
+    }
+}


### PR DESCRIPTION
This pull-request contains two commits:

- Adding tests to cover this trait and show that implementation is broken
- Provide the change to document how to set this property correctly

As this is needed for changes in the Typo3 core, it would be nice if
a new patchlevel release could be done after approving and merging this,
so a pending core change can be reviewed and processed:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/73014

Fixes: #582