### PR TITLE
[TASK] Add TemplateAwareViewInterface

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -22,7 +22,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
  *
  * Contains the fundamental methods which any Fluid based template view needs.
  */
-abstract class AbstractTemplateView extends AbstractView
+abstract class AbstractTemplateView extends AbstractView implements TemplateAwareViewInterface
 {
 
     /**

--- a/src/View/TemplateAwareViewInterface.php
+++ b/src/View/TemplateAwareViewInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3Fluid\Fluid\View;
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+/**
+ * Optional addition to ViewInterface if the view deals with template files.
+ *
+ * @api
+ */
+interface TemplateAwareViewInterface
+{
+    /**
+     * @param string A template name to render, e.g. "Main/Index"
+     * @return string The rendered view
+     * @api
+     */
+    public function render(string $templateName = '');
+}


### PR DESCRIPTION
Method render() of AbstractTemplateView has an
optional argument to provide a template name.
This is not reflected in ViewInterface since
ViewInterface does not know about templates.

The patch adds an optional TemplateAwareViewInterface
to reflect this argument in 'template aware'
views like TemplateView.