### PR TITLE
[BUGFIX] Fix type annotation on TagBuilder->getAttribute()

### DIFF
--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -146,7 +146,7 @@ class TagBuilder
      * Get an attribute from the $attributes-collection
      *
      * @param string $attributeName name of the attribute
-     * @return string The attribute value or NULL if the attribute is not registered
+     * @return string|null The attribute value or NULL if the attribute is not registered
      * @api
      */
     public function getAttribute($attributeName)


### PR DESCRIPTION
The method can obviously return null.