### PR TITLE
[TASK] Remove stalled scrutinizer badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ TYPO3.Fluid Rendering Engine
 
 [![Build Status](https://github.com/TYPO3/Fluid/actions/workflows/build.yml/badge.svg)](https://github.com/TYPO3/Fluid/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/TYPO3/Fluid/badge.svg?branch=master)](https://coveralls.io/github/TYPO3/Fluid?branch=master)
-[![Scrutinizer](https://scrutinizer-ci.com/g/TYPO3/Fluid/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/TYPO3/Fluid/)
 
 TYPO3 community template engine - composer-enabled, Flow/CMS dependency-free PSR-4 edition.
 


### PR DESCRIPTION
scrutinizer is stalled / misconfigured for a long time
already. Remove it from the README.md badge list.