### PR TITLE
[!!!][TASK] Require PHP >=7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "The TYPO3 Fluid template rendering engine",
 	"license": ["LGPL-3.0-or-later"],
 	"require": {
-		"php": ">=5.5.0"
+		"php": "^7.2 || ^8.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5.21",


### PR DESCRIPTION
Current main-branch is de-facto PHP >=7.2 already since
we're not testing any lower PHP version for quite a while.

This patch requires a 2.8.0 as next release since we're
now forcing a higher minimum PHP version.

Resolves #405