### PR TITLE
[TASK] Remove coveralls code coverage stats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
           extensions: mbstring, json
-          coverage: xdebug
 
       - name: Validate composer.json
         run: composer validate
@@ -38,9 +37,3 @@ jobs:
 
       - name: Run test suite
         run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
-
-      - name: Upload coverage results to Coveralls
-        if: ${{ matrix.php == '7.4'}}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: vendor/bin/php-coveralls

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ TYPO3.Fluid Rendering Engine
 ============================
 
 [![Build Status](https://github.com/TYPO3/Fluid/actions/workflows/build.yml/badge.svg)](https://github.com/TYPO3/Fluid/actions/workflows/build.yml)
-[![Coverage Status](https://coveralls.io/repos/github/TYPO3/Fluid/badge.svg?branch=master)](https://coveralls.io/github/TYPO3/Fluid?branch=master)
 
 TYPO3 community template engine - composer-enabled, Flow/CMS dependency-free PSR-4 edition.
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "^8.5.21",
 		"mikey179/vfsstream": "^1.6.10",
-		"squizlabs/php_codesniffer": "^2.7",
-		"php-coveralls/php-coveralls": "^2.1"
+		"squizlabs/php_codesniffer": "^2.7"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Coverage is a lie. With current configuration, it
does not really reflect actual test statistics and
"97%" is simply misleading since it ignores files
that are not loaded at all durnig tests.

As such, this statistic does not actively help us
in current development and should be dropped.

Naturally, patches that have parser impact need
proper test coverage and won't be accepted without.
A misleading coverage generator does not help
us here.