### PR TITLE
[TASK] Functional tests extend BaseTestCase

### DIFF
--- a/tests/Functional/BaseConditionalFunctionalTestCase.php
+++ b/tests/Functional/BaseConditionalFunctionalTestCase.php
@@ -3,14 +3,11 @@
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
-/**
- * Class BaseFunctionalTestCase
- */
-abstract class BaseConditionalFunctionalTestCase extends UnitTestCase
+abstract class BaseConditionalFunctionalTestCase extends BaseTestCase
 {
 
     /**

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -3,14 +3,11 @@
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
-/**
- * Class BaseFunctionalTestCase
- */
-abstract class BaseFunctionalTestCase extends UnitTestCase
+abstract class BaseFunctionalTestCase extends BaseTestCase
 {
 
     /**

--- a/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
@@ -141,12 +141,8 @@ class CompileWithContentArgumentAndRenderStaticTest extends BaseFunctionalTestCa
      */
     public function testTemplateCodeFixtureWithCache($sourceOrStream, array $variables, array $expected, array $notExpected, $expectedException = null)
     {
-        if ($this->getCache()) {
-            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
-            $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
-        } else {
-            self::markTestSkipped('Cache-specific test skipped');
-        }
+        $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
+        $this->testTemplateCodeFixture($sourceOrStream, $variables, $expected, $notExpected, $expectedException, true);
     }
 
     /**

--- a/tests/Functional/Cases/Rendering/DataAccessorTest.php
+++ b/tests/Functional/Cases/Rendering/DataAccessorTest.php
@@ -4,11 +4,11 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
+use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering\Fixtures\Objects;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class DataAccessorTest extends UnitTestCase
+class DataAccessorTest extends BaseTestCase
 {
     /**
      * @return array

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -3,11 +3,11 @@
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
+use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class TagBasedTest extends UnitTestCase
+class TagBasedTest extends BaseTestCase
 {
     public function testTagBasedViewHelperWithAdditionalAttributesArray()
     {

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -10,9 +10,6 @@ namespace TYPO3Fluid\Fluid\Tests\Functional;
 use org\bovigo\vfs\vfsStream;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 
-/**
- * Class CommandTest
- */
 class CommandTest extends BaseTestCase
 {
     public static function setUpBeforeClass(): void

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -10,9 +10,6 @@ namespace TYPO3Fluid\Fluid\Tests\Functional;
 use org\bovigo\vfs\vfsStream;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 
-/**
- * Class ExamplesTest
- */
 class ExamplesTest extends BaseTestCase
 {
     public static function setUpBeforeClass(): void


### PR DESCRIPTION
First patch to improve test class inheritance: Functional
tests no longer extend (empty) UnitTestCase, but BaseTestCase
instead.