### PR TITLE
[TASK] Stop exporting ViewHelperBaseTestcase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,3 @@ tests/Functional/ export-ignore
 tests/Unit/*/ export-ignore
 tests/Unit/ViewHelpers/ -export-ignore
 tests/Unit/ViewHelpers/* export-ignore
-tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php -export-ignore


### PR DESCRIPTION
The class is an abstract for unit testing VH's. Exporting
it does not make sense since it has a direct dependency to
RenderingContextFixture is setup(), which is not exported.

The patch excludes the file from packaging again, which
also allows Fluid to refactor internally without being
breaking.

Resolves #562