### PR TITLE
[TASK] Avoid at() and assertFileNotExists()

### DIFF
--- a/tests/Functional/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Functional/Core/Cache/SimpleFileCacheTest.php
@@ -105,7 +105,12 @@ class SimpleFileCacheTest extends AbstractFunctionalTestCase
         $cache->set('test2', '<?php' . PHP_EOL . 'class MyOtherCachedClass {}' . PHP_EOL);
         $cache->flush('test');
         self::assertFileExists(self::$cachePath . '/' . 'test2.php');
-        self::assertFileNotExists(self::$cachePath . '/' . 'test.php');
+        if (method_exists($this, 'assertFileDoesNotExist')) {
+            self::assertFileDoesNotExist(self::$cachePath . '/' . 'test.php');
+        } else {
+            // @todo: Remove fallback when phpunit >= 9 is required.
+            self::assertFileNotExists(self::$cachePath . '/' . 'test.php');
+        }
     }
 
     /**

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -121,11 +121,18 @@ class TemplateCompilerTest extends UnitTestCase
             '',
             false
         );
-        $nodeConverter->expects(self::at(0))->method('convertListOfSubNodes')->with($foo)->willReturn([]);
-        $nodeConverter->expects(self::at(1))->method('convertListOfSubNodes')->with($bar)->willReturn([]);
+        $nodeConverter->expects(self::exactly(2))->method('convertListOfSubNodes')->withConsecutive(
+            [$foo],
+            [$bar]
+        )->willReturn([]);
         $instance = $this->getMock(TemplateCompiler::class, ['generateCodeForSection']);
-        $instance->expects(self::at(0))->method('generateCodeForSection')->with(self::anything())->willReturn('FOO');
-        $instance->expects(self::at(1))->method('generateCodeForSection')->with(self::anything())->willReturn('BAR');
+        $instance->expects(self::exactly(2))->method('generateCodeForSection')->withConsecutive(
+            [self::anything()],
+            [self::anything()]
+        )->willReturnOnConsecutiveCalls(
+            'FOO',
+            'BAR'
+        );
         $instance->setNodeConverter($nodeConverter);
         $method = new \ReflectionMethod($instance, 'generateSectionCodeFromParsingState');
         $method->setAccessible(true);

--- a/tests/Unit/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -28,12 +28,7 @@ class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
     {
         $renderingContext = new RenderingContextFixture();
         $viewHelperResolver = $this->getMockBuilder(ViewHelperResolver::class)->setMethods(['addNamespace'])->getMock();
-        foreach ($expectedNamespaces as $index => $expectedNamespace) {
-            list($expectedNamespaceAlias, $expectedNamespacePhp) = $expectedNamespace;
-            $viewHelperResolver->expects(self::at($index))
-                ->method('addNamespace')
-                ->with($expectedNamespaceAlias, $expectedNamespacePhp);
-        }
+        $viewHelperResolver->expects(self::exactly(count($expectedNamespaces)))->method('addNamespace')->withConsecutive(...$expectedNamespaces);
         $renderingContext->setViewHelperResolver($viewHelperResolver);
         $subject = new NamespaceDetectionTemplateProcessor();
         $subject->setRenderingContext($renderingContext);

--- a/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -202,8 +202,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function renderThenChildReturnsThenViewHelperChildIfConditionIsTrueAndThenViewHelperChildExists()
     {
         $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate'], [], '', false);
-        $mockThenViewHelperNode->expects(self::at(0))->method('getViewHelperClassName')->willReturn(ThenViewHelper::class);
-        $mockThenViewHelperNode->expects(self::at(1))->method('evaluate')->with($this->renderingContext)->willReturn('ThenViewHelperResults');
+        $mockThenViewHelperNode->expects(self::atLeastOnce())->method('getViewHelperClassName')->willReturn(ThenViewHelper::class);
+        $mockThenViewHelperNode->expects(self::atLeastOnce())->method('evaluate')->with($this->renderingContext)->willReturn('ThenViewHelperResults');
         $this->viewHelperNode->expects(self::any())->method('getChildNodes')->willReturn([$mockThenViewHelperNode]);
 
         $actualResult = $this->viewHelper->_call('renderThenChild');
@@ -253,8 +253,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function renderElseChildRendersElseViewHelperChildIfConditionIsFalseAndNoThenViewHelperChildExists()
     {
         $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'evaluate', 'setRenderingContext'], [], '', false);
-        $mockElseViewHelperNode->expects(self::at(0))->method('getViewHelperClassName')->willReturn(ElseViewHelper::class);
-        $mockElseViewHelperNode->expects(self::at(1))->method('evaluate')->with($this->renderingContext)->willReturn('ElseViewHelperResults');
+        $mockElseViewHelperNode->expects(self::atLeastOnce())->method('getViewHelperClassName')->willReturn(ElseViewHelper::class);
+        $mockElseViewHelperNode->expects(self::atLeastOnce())->method('evaluate')->with($this->renderingContext)->willReturn('ElseViewHelperResults');
         $this->viewHelperNode->expects(self::any())->method('getChildNodes')->willReturn([$mockElseViewHelperNode]);
 
         $actualResult = $this->viewHelper->_call('renderElseChild');
@@ -267,8 +267,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function renderElseChildReturnsEmptyStringIfConditionIsFalseAndElseViewHelperChildIfArgumentConditionIsFalseToo()
     {
         $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, ['getViewHelperClassName', 'getArguments', 'evaluate'], [], '', false);
-        $mockElseViewHelperNode->expects(self::at(0))->method('getViewHelperClassName')->willReturn(ElseViewHelper::class);
-        $mockElseViewHelperNode->expects(self::at(1))->method('getArguments')->willReturn(['if' => new BooleanNode(false)]);
+        $mockElseViewHelperNode->expects(self::atLeastOnce())->method('getViewHelperClassName')->willReturn(ElseViewHelper::class);
+        $mockElseViewHelperNode->expects(self::atLeastOnce())->method('getArguments')->willReturn(['if' => new BooleanNode(false)]);
         $mockElseViewHelperNode->expects(self::never())->method('evaluate');
 
         $this->viewHelperNode->expects(self::any())->method('getChildNodes')->willReturn([$mockElseViewHelperNode]);

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -86,8 +86,10 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
             '',
             false
         );
-        $viewHelper->expects(self::at(0))->method('registerArgument')->with('additionalAttributes');
-        $viewHelper->expects(self::at(1))->method('registerArgument')->with('data');
+        $viewHelper->expects(self::atLeastOnce())->method('registerArgument')->withConsecutive(
+            ['additionalAttributes'],
+            ['data']
+        );
         $viewHelper->initializeArguments();
     }
 
@@ -127,8 +129,10 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     public function dataAttributesAreRenderedCorrectly()
     {
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
-        $mockTagBuilder->expects(self::at(0))->method('addAttribute')->with('data-foo', 'bar');
-        $mockTagBuilder->expects(self::at(1))->method('addAttribute')->with('data-baz', 'foos');
+        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->withConsecutive(
+            ['data-foo', 'bar'],
+            ['data-baz', 'foos']
+        );
         $this->viewHelper->setTagBuilder($mockTagBuilder);
 
         $arguments = ['data' => ['foo' => 'bar', 'baz' => 'foos']];
@@ -142,8 +146,10 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     public function ariaAttributesAreRenderedCorrectly()
     {
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
-        $mockTagBuilder->expects(self::at(0))->method('addAttribute')->with('aria-foo', 'bar');
-        $mockTagBuilder->expects(self::at(1))->method('addAttribute')->with('aria-baz', 'foos');
+        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->withConsecutive(
+            ['aria-foo', 'bar'],
+            ['aria-baz', 'foos']
+        );
         $this->viewHelper->setTagBuilder($mockTagBuilder);
 
         $arguments = ['aria' => ['foo' => 'bar', 'baz' => 'foos']];
@@ -182,8 +188,10 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         );
         $viewHelper->setRenderingContext(new RenderingContextFixture());
         $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
-        $tagBuilder->expects(self::at(0))->method('addAttribute')->with('data-foo', 'foo');
-        $tagBuilder->expects(self::at(1))->method('addAttribute')->with('data-bar', 'bar');
+        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->withConsecutive(
+            ['data-foo', 'foo'],
+            ['data-bar', 'bar']
+        );
         $viewHelper->setTagBuilder($tagBuilder);
         $viewHelper->handleAdditionalArguments(['data-foo' => 'foo', 'data-bar' => 'bar']);
         $viewHelper->initializeArgumentsAndRender();
@@ -203,8 +211,10 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         );
         $viewHelper->setRenderingContext(new RenderingContextFixture());
         $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
-        $tagBuilder->expects(self::at(0))->method('addAttribute')->with('aria-foo', 'foo');
-        $tagBuilder->expects(self::at(1))->method('addAttribute')->with('aria-bar', 'bar');
+        $tagBuilder->expects(self::exactly(2))->method('addAttribute')->withConsecutive(
+            ['aria-foo', 'foo'],
+            ['aria-bar', 'bar']
+        );
         $viewHelper->setTagBuilder($tagBuilder);
         $viewHelper->handleAdditionalArguments(['aria-foo' => 'foo', 'aria-bar' => 'bar']);
         $viewHelper->initializeArgumentsAndRender();
@@ -216,14 +226,16 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     public function standardTagAttributesAreRegistered()
     {
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], '', false);
-        $mockTagBuilder->expects(self::at(0))->method('addAttribute')->with('class', 'classAttribute');
-        $mockTagBuilder->expects(self::at(1))->method('addAttribute')->with('dir', 'dirAttribute');
-        $mockTagBuilder->expects(self::at(2))->method('addAttribute')->with('id', 'idAttribute');
-        $mockTagBuilder->expects(self::at(3))->method('addAttribute')->with('lang', 'langAttribute');
-        $mockTagBuilder->expects(self::at(4))->method('addAttribute')->with('style', 'styleAttribute');
-        $mockTagBuilder->expects(self::at(5))->method('addAttribute')->with('title', 'titleAttribute');
-        $mockTagBuilder->expects(self::at(6))->method('addAttribute')->with('accesskey', 'accesskeyAttribute');
-        $mockTagBuilder->expects(self::at(7))->method('addAttribute')->with('tabindex', 'tabindexAttribute');
+        $mockTagBuilder->expects(self::exactly(8))->method('addAttribute')->withConsecutive(
+            ['class', 'classAttribute'],
+            ['dir', 'dirAttribute'],
+            ['id', 'idAttribute'],
+            ['lang', 'langAttribute'],
+            ['style', 'styleAttribute'],
+            ['title', 'titleAttribute'],
+            ['accesskey', 'accesskeyAttribute'],
+            ['tabindex', 'tabindexAttribute']
+        );
         $this->viewHelper->setTagBuilder($mockTagBuilder);
 
         $arguments = [

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -231,9 +231,9 @@ class AbstractViewHelperTest extends UnitTestCase
     public function initializeArgumentsAndRenderCallsTheCorrectSequenceOfMethods()
     {
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['validateArguments', 'initialize', 'callRenderMethod']);
-        $viewHelper->expects(self::at(0))->method('validateArguments');
-        $viewHelper->expects(self::at(1))->method('initialize');
-        $viewHelper->expects(self::at(2))->method('callRenderMethod')->willReturn('Output');
+        $viewHelper->expects(self::once())->method('validateArguments');
+        $viewHelper->expects(self::once())->method('initialize');
+        $viewHelper->expects(self::once())->method('callRenderMethod')->willReturn('Output');
 
         $expectedOutput = 'Output';
         $actualOutput = $viewHelper->initializeArgumentsAndRender(['argument1' => 'value1']);
@@ -292,8 +292,10 @@ class AbstractViewHelperTest extends UnitTestCase
             [$argument->getName() => $argument, 'second' => $argument]
         );
         $viewHelper->setArguments([$argument->getName() => $value, 'second' => $value]);
-        $viewHelper->expects(self::at(1))->method('hasArgument')->with($argument->getName())->willReturn(true);
-        $viewHelper->expects(self::at(2))->method('hasArgument')->with('second')->willReturn(true);
+        $viewHelper->expects(self::exactly(2))->method('hasArgument')->withConsecutive(
+            [$argument->getName()],
+            ['second']
+        )->willReturn(true);
         $viewHelper->validateArguments();
     }
 

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -83,9 +83,10 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignAddsValueToTemplateVariableContainer()
     {
-        $this->templateVariableContainer->expects(self::at(0))->method('add')->with('foo', 'FooValue');
-        $this->templateVariableContainer->expects(self::at(1))->method('add')->with('bar', 'BarValue');
-
+        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->withConsecutive(
+            ['foo', 'FooValue'],
+            ['bar', 'BarValue']
+        );
         $this->view
             ->assign('foo', 'FooValue')
             ->assign('bar', 'BarValue');
@@ -96,9 +97,10 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignCanOverridePreviouslyAssignedValues()
     {
-        $this->templateVariableContainer->expects(self::at(0))->method('add')->with('foo', 'FooValue');
-        $this->templateVariableContainer->expects(self::at(1))->method('add')->with('foo', 'FooValueOverridden');
-
+        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->withConsecutive(
+            ['foo', 'FooValue'],
+            ['foo', 'FooValueOverridden']
+        );
         $this->view->assign('foo', 'FooValue');
         $this->view->assign('foo', 'FooValueOverridden');
     }
@@ -108,10 +110,11 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignMultipleAddsValuesToTemplateVariableContainer()
     {
-        $this->templateVariableContainer->expects(self::at(0))->method('add')->with('foo', 'FooValue');
-        $this->templateVariableContainer->expects(self::at(1))->method('add')->with('bar', 'BarValue');
-        $this->templateVariableContainer->expects(self::at(2))->method('add')->with('baz', 'BazValue');
-
+        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->withConsecutive(
+            ['foo', 'FooValue'],
+            ['bar', 'BarValue'],
+            ['baz', 'BazValue']
+        );
         $this->view
             ->assignMultiple(['foo' => 'FooValue', 'bar' => 'BarValue'])
             ->assignMultiple(['baz' => 'BazValue']);
@@ -122,10 +125,11 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignMultipleCanOverridePreviouslyAssignedValues()
     {
-        $this->templateVariableContainer->expects(self::at(0))->method('add')->with('foo', 'FooValue');
-        $this->templateVariableContainer->expects(self::at(1))->method('add')->with('foo', 'FooValueOverridden');
-        $this->templateVariableContainer->expects(self::at(2))->method('add')->with('bar', 'BarValue');
-
+        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->withConsecutive(
+            ['foo', 'FooValue'],
+            ['foo', 'FooValueOverridden'],
+            ['bar', 'BarValue']
+        );
         $this->view->assign('foo', 'FooValue');
         $this->view->assignMultiple(['foo' => 'FooValueOverridden', 'bar' => 'BarValue']);
     }

--- a/tests/Unit/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/AliasViewHelperTest.php
@@ -22,7 +22,7 @@ class AliasViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArgumentsRegistersExpectedArguments()
     {
         $instance = $this->getMock(AliasViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('map', 'array', self::anything(), true);
+        $instance->expects(self::exactly(1))->method('registerArgument')->with('map', 'array', self::anything(), true);
         $instance->initializeArguments();
     }
 

--- a/tests/Unit/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/DebugViewHelperTest.php
@@ -22,7 +22,10 @@ class DebugViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArgumentsRegistersExpectedArguments()
     {
         $instance = $this->getMock(DebugViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('typeOnly', 'boolean', self::anything(), false, false);
+        $instance->expects(self::atLeastOnce())->method('registerArgument')->withConsecutive(
+            ['typeOnly', 'boolean', self::anything(), false, false],
+            ['levels', 'integer', self::anything(), false, 5, null]
+        );
         $instance->setRenderingContext(new RenderingContextFixture());
         $instance->initializeArguments();
     }

--- a/tests/Unit/ViewHelpers/ElseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ElseViewHelperTest.php
@@ -22,7 +22,7 @@ class ElseViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArgumentsRegistersExpectedArguments()
     {
         $instance = $this->getMock(ElseViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('if', 'boolean', self::anything());
+        $instance->expects(self::exactly(1))->method('registerArgument')->with('if', 'boolean', self::anything());
         $instance->initializeArguments();
     }
 

--- a/tests/Unit/ViewHelpers/InlineViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/InlineViewHelperTest.php
@@ -23,7 +23,7 @@ class InlineViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArguments()
     {
         $instance = $this->getMockBuilder(InlineViewHelper::class)->setMethods(['registerArgument'])->getMock();
-        $instance->expects(self::at(0))->method('registerArgument')->with('code', 'string', self::anything());
+        $instance->expects(self::exactly(1))->method('registerArgument')->with('code', 'string', self::anything());
         $instance->initializeArguments();
     }
 

--- a/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/LayoutViewHelperTest.php
@@ -26,7 +26,7 @@ class LayoutViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArgumentsRegistersExpectedArguments()
     {
         $instance = $this->getMock(LayoutViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('name', 'string', self::anything());
+        $instance->expects(self::exactly(1))->method('registerArgument')->with('name', 'string', self::anything());
         $instance->initializeArguments();
     }
 

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -22,9 +22,11 @@ class OrViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArguments()
     {
         $instance = $this->getMock(OrViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('content', 'mixed', self::anything(), false, '');
-        $instance->expects(self::at(1))->method('registerArgument')->with('alternative', 'mixed', self::anything(), false, '');
-        $instance->expects(self::at(2))->method('registerArgument')->with('arguments', 'array', self::anything());
+        $instance->expects(self::exactly(3))->method('registerArgument')->withConsecutive(
+            ['content', 'mixed', self::anything(), false, ''],
+            ['alternative', 'mixed', self::anything(), false, ''],
+            ['arguments', 'array', self::anything()]
+        );
         $instance->setRenderingContext(new RenderingContextFixture());
         $instance->initializeArguments();
     }

--- a/tests/Unit/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/RenderViewHelperTest.php
@@ -49,14 +49,16 @@ class RenderViewHelperTest extends ViewHelperBaseTestcase
     public function testInitializeArgumentsRegistersExpectedArguments()
     {
         $instance = $this->getMock(RenderViewHelper::class, ['registerArgument']);
-        $instance->expects(self::at(0))->method('registerArgument')->with('section', 'string', self::anything());
-        $instance->expects(self::at(1))->method('registerArgument')->with('partial', 'string', self::anything());
-        $instance->expects(self::at(2))->method('registerArgument')->with('delegate', 'string', self::anything());
-        $instance->expects(self::at(3))->method('registerArgument')->with('renderable', RenderableInterface::class, self::anything());
-        $instance->expects(self::at(4))->method('registerArgument')->with('arguments', 'array', self::anything(), false, []);
-        $instance->expects(self::at(5))->method('registerArgument')->with('optional', 'boolean', self::anything(), false, false);
-        $instance->expects(self::at(6))->method('registerArgument')->with('default', 'mixed', self::anything());
-        $instance->expects(self::at(7))->method('registerArgument')->with('contentAs', 'string', self::anything());
+        $instance->expects(self::exactly(8))->method('registerArgument')->withConsecutive(
+            ['section', 'string', self::anything()],
+            ['partial', 'string', self::anything()],
+            ['delegate', 'string', self::anything()],
+            ['renderable', RenderableInterface::class, self::anything()],
+            ['arguments', 'array', self::anything(), false, []],
+            ['optional', 'boolean', self::anything(), false, false],
+            ['default', 'mixed', self::anything()],
+            ['contentAs', 'string', self::anything()]
+        );
         $instance->initializeArguments();
     }
 


### PR DESCRIPTION
To prepare towards phpnunit 9, we avaid a couple
of deprecated things.