### PR TITLE
[TASK] Allow phpunit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php": "^7.2 || ^8.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.5.21",
+		"phpunit/phpunit": "^8.5.26 || ^9.5",
 		"friendsofphp/php-cs-fixer": "^3.4"
 	},
 	"suggest": {


### PR DESCRIPTION
phpunit 8 needs to be kept for PHP 7.2.

composer req --dev phpunit/phpunit:"^8.5.26 || ^9.5"