### PR TITLE
[BUGFIX] Correct cached ternary expressions

### DIFF
--- a/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/TernaryConditionsTest.php
@@ -50,40 +50,26 @@ class TernaryConditionsTest extends AbstractFunctionalTestCase
                 ['foo' => true],
                 'yes',
             ],
-            // @todo: This fails for compiled / cached templates: The data set above has the same source,
-            //        but a different variable assignment and thus triggers a cached access for this run
-            //        already. It seems variables are then not taken into account properly?!
-            //        Other tests below show this as well for 'new unique' source with two runs:
-            //        First uncached, second one cached. *Might* be a broken test setup, too, though.
-            //        Needs investigation.
-            /*
             [
                 '{foo ? \'yes\' : \'no\'}',
                 ['foo' => false],
                 'no',
             ],
-            */
-            // @todo: Similar fail scenario for 'cached' templates as above.
-            /*
             [
                 '{!foo ? \'yes\' : \'no\'}',
                 ['foo' => false],
                 'yes',
             ],
-            */
             [
                 '{(foo || false) ? \'yes\' : \'no\'}',
                 ['foo' => true],
                 'yes',
             ],
-            // @todo: Similar fail scenario for 'cached' templates as above.
-            /*
             [
                 '{(foo || false) ? \'yes\' : \'no\'}',
                 ['foo' => false],
                 'no',
             ],
-            */
             [
                 '{(foo.bar || false) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => true]],
@@ -94,46 +80,31 @@ class TernaryConditionsTest extends AbstractFunctionalTestCase
                 ['foo' => ['bar' => true]],
                 'no',
             ],
-            // @todo: This fails with php <= 8.0 with compiled templates.
-            /*
             [
                 '{(foo.bar > 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
                 'yes',
             ],
-            */
-            // @todo: This fails with php <= 8.0 with compiled templates.
-            /*
             [
                 '{(foo.bar < 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
                 'no',
             ],
-            */
-            // @todo: Similar fail scenario for 'cached' templates as above.
-            /*
             [
                 '{(foo.bar < 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
                 'no',
             ],
-            */
-            // @todo: Similar fail scenario for 'cached' templates as above.
-            /*
             [
                 '{(foo.bar % 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 11]],
-                ['yes'],
+                'yes',
             ],
-            */
-            // @todo: Similar fail scenario for 'cached' templates as above.
-            /*
             [
                 '{(foo.bar % 10) ? \'yes\' : \'no\'}',
                 ['foo' => ['bar' => 10]],
                 'no',
             ],
-            */
         ];
     }
 


### PR DESCRIPTION
Ternary expressions are broken with cached templates.
Even with simple things like this:

$view->assign('myVariable', false);
{myVariable ? 'yes' : 'no'}

This evaluates correctly to 'no' on first call with cold
caches, but to 'yes' when a cached template is used
on subsequent calls.

This came up when the functional tests have recently been
fixed to correctly test cached behavior.

The fix is to evaluate() the "left" / "check" side just
like the non-cached variant does.