### PR TITLE
[TASK] Streamline license header once and for all

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -60,4 +60,10 @@ return (new PhpCsFixer\Config())
         'single_line_comment_style' => ['comment_types' => ['hash']],
         'single_trait_insert_per_statement' => true,
         'whitespace_after_comma_in_array' => true,
+        'header_comment' => [
+            'header' => 'This file belongs to the package "TYPO3 Fluid".' . chr(10) .
+                'See LICENSE.txt that was shipped with this package.',
+            'comment_type' => 'comment',
+            'location' => 'after_declare_strict',
+        ],
     ]);

--- a/src/Component/Argument/ArgumentCollection.php
+++ b/src/Component/Argument/ArgumentCollection.php
@@ -1,12 +1,13 @@
 <?php
 
 declare(strict_types=1);
-namespace TYPO3Fluid\Fluid\Component\Argument;
 
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Component\Argument;
 
 /**
  * STUB CLASS: ArgumentCollection

--- a/src/Component/ComponentInterface.php
+++ b/src/Component/ComponentInterface.php
@@ -1,12 +1,13 @@
 <?php
 
 declare(strict_types=1);
-namespace TYPO3Fluid\Fluid\Component;
 
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Component;
 
 /**
  * STUB CLASS: ComponentInterface

--- a/src/Core/Cache/FluidCacheInterface.php
+++ b/src/Core/Cache/FluidCacheInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Cache;
 
 /**
  * Interface FluidCacheInterface

--- a/src/Core/Cache/FluidCacheWarmerInterface.php
+++ b/src/Core/Cache/FluidCacheWarmerInterface.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Cache;
+
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**

--- a/src/Core/Cache/FluidCacheWarmupResult.php
+++ b/src/Core/Cache/FluidCacheWarmupResult.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;

--- a/src/Core/Cache/SimpleFileCache.php
+++ b/src/Core/Cache/SimpleFileCache.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Cache;
 
 /**
  * Class SimpleFileCache

--- a/src/Core/Cache/StandardCacheWarmer.php
+++ b/src/Core/Cache/StandardCacheWarmer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;

--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Compiler/FailedCompilingState.php
+++ b/src/Core/Compiler/FailedCompilingState.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;

--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;

--- a/src/Core/Compiler/StopCompilingChildrenException.php
+++ b/src/Core/Compiler/StopCompilingChildrenException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 /**
  * Exception thrown to stop the template compiling process

--- a/src/Core/Compiler/StopCompilingException.php
+++ b/src/Core/Compiler/StopCompilingException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 /**
  * Exception thrown to stop the template compiling process

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;

--- a/src/Core/Compiler/UncompilableTemplateInterface.php
+++ b/src/Core/Compiler/UncompilableTemplateInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 /**

--- a/src/Core/Compiler/ViewHelperCompiler.php
+++ b/src/Core/Compiler/ViewHelperCompiler.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;

--- a/src/Core/ErrorHandler/ErrorHandlerInterface.php
+++ b/src/Core/ErrorHandler/ErrorHandlerInterface.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
 
 interface ErrorHandlerInterface

--- a/src/Core/ErrorHandler/StandardErrorHandler.php
+++ b/src/Core/ErrorHandler/StandardErrorHandler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
 
 /**
  * Class StandardErrorHandler

--- a/src/Core/ErrorHandler/TolerantErrorHandler.php
+++ b/src/Core/ErrorHandler/TolerantErrorHandler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
 
 /**
  * Class TolerantErrorHandler

--- a/src/Core/Exception.php
+++ b/src/Core/Exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core;
 
 /**
  * A generic Fluid Core exception.

--- a/src/Core/Parser/BooleanParser.php
+++ b/src/Core/Parser/BooleanParser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * This BooleanParser helps to parse and evaluate boolean expressions.

--- a/src/Core/Parser/Configuration.php
+++ b/src/Core/Parser/Configuration.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * The parser configuration. Contains all configuration needed to configure

--- a/src/Core/Parser/Exception.php
+++ b/src/Core/Parser/Exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * A Parsing Exception

--- a/src/Core/Parser/Interceptor/Escape.php
+++ b/src/Core/Parser/Interceptor/Escape.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\Interceptor;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\Interceptor;
 
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;

--- a/src/Core/Parser/InterceptorInterface.php
+++ b/src/Core/Parser/InterceptorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;

--- a/src/Core/Parser/PassthroughSourceException.php
+++ b/src/Core/Parser/PassthroughSourceException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * Exception which when thrown causes the template rendering

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * Class Patterns

--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/SyntaxTree/ArrayNode.php
+++ b/src/Core/Parser/SyntaxTree/ArrayNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser;

--- a/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 /**
  * An ExpressionNode evaluation Exception

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;

--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/SyntaxTree/Expression/ParseTimeEvaluatedExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ParseTimeEvaluatedExpressionNodeInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 /**
  * Signaling interface used in Expression Node types which

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;

--- a/src/Core/Parser/SyntaxTree/NodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/NodeInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/SyntaxTree/NumericNode.php
+++ b/src/Core/Parser/SyntaxTree/NumericNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;

--- a/src/Core/Parser/SyntaxTree/RootNode.php
+++ b/src/Core/Parser/SyntaxTree/RootNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/SyntaxTree/TextNode.php
+++ b/src/Core/Parser/SyntaxTree/TextNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Compiler\UncompilableTemplateInterface;

--- a/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
@@ -1,16 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
-
 /*
- * This file is part of the Neos.FluidAdaptor package.
- *
- * (c) Contributors of the Neos Project - www.neos.io
- *
- * This package is Open Source Software. For the full copyright and license
- * information, please view the LICENSE file which was distributed with this
- * source code.
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\PassthroughSourceException;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;

--- a/src/Core/Parser/TemplateProcessorInterface.php
+++ b/src/Core/Parser/TemplateProcessorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 

--- a/src/Core/Parser/UnknownNamespaceException.php
+++ b/src/Core/Parser/UnknownNamespaceException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
 
 /**
  * A generic Fluid Core exception.

--- a/src/Core/Rendering/AbstractRenderable.php
+++ b/src/Core/Rendering/AbstractRenderable.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;

--- a/src/Core/Rendering/RenderableClosure.php
+++ b/src/Core/Rendering/RenderableClosure.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 /**
  * Class RenderableClosure

--- a/src/Core/Rendering/RenderableInterface.php
+++ b/src/Core/Rendering/RenderableInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/Core/Rendering/StandardRenderable.php
+++ b/src/Core/Rendering/StandardRenderable.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Rendering;
 
 /**
  * Class StandardRenderable

--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
  * Class ChainedVariableProvider

--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
  * Class JSONVariableProvider

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
  * Class StandardVariableProvider

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
  * Class VariableExtractor

--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
  * Interface VariableProviderInterface

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 /**
  * Tag based view helper.

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 /**
  * Argument definition of each view helper argument

--- a/src/Core/ViewHelper/Exception.php
+++ b/src/Core/ViewHelper/Exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 /**
  * A ViewHelper Exception

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 /**
  * Tag builder. Can be easily accessed in AbstractTagBasedViewHelper

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
+++ b/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\View\ViewInterface;
 

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid;
 
 /*

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;

--- a/src/View/AbstractView.php
+++ b/src/View/AbstractView.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 /**
  * An abstract View

--- a/src/View/Exception.php
+++ b/src/View/Exception.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 use TYPO3Fluid\Fluid;
 

--- a/src/View/Exception/InvalidSectionException.php
+++ b/src/View/Exception/InvalidSectionException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View\Exception;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View\Exception;
 
 use TYPO3Fluid\Fluid\View;
 

--- a/src/View/Exception/InvalidTemplateResourceException.php
+++ b/src/View/Exception/InvalidTemplateResourceException.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View\Exception;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View\Exception;
 
 use TYPO3Fluid\Fluid\View;
 

--- a/src/View/TemplateAwareViewInterface.php
+++ b/src/View/TemplateAwareViewInterface.php
@@ -1,12 +1,13 @@
 <?php
 
 declare(strict_types=1);
-namespace TYPO3Fluid\Fluid\View;
 
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 /**
  * Optional addition to ViewInterface if the view deals with template files.

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
+
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
 /**

--- a/src/View/TemplateView.php
+++ b/src/View/TemplateView.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 /**
  * The main template view. Should be used as view if you want Fluid Templating

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View;
 
 /**
  * Interface of a view

--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/src/ViewHelpers/Cache/DisableViewHelper.php
+++ b/src/ViewHelpers/Cache/DisableViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/Cache/StaticViewHelper.php
+++ b/src/ViewHelpers/Cache/StaticViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/ViewHelpers/Cache/WarmupViewHelper.php
+++ b/src/ViewHelpers/Cache/WarmupViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/src/ViewHelpers/CaseViewHelper.php
+++ b/src/ViewHelpers/CaseViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;

--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;

--- a/src/ViewHelpers/DefaultCaseViewHelper.php
+++ b/src/ViewHelpers/DefaultCaseViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/ElseViewHelper.php
+++ b/src/ViewHelpers/ElseViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;

--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderableInterface;

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;

--- a/src/ViewHelpers/ThenViewHelper.php
+++ b/src/ViewHelpers/ThenViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 class ExamplesTest extends AbstractFunctionalTestCase
 {

--- a/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/AbstractEscapingViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentInConstructorViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticFirstRegisteredOptionalArgumentAfterRequiredArgumentAsRenderChildrenViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticUseFirstRegisteredOptionalArgumentAsRenderChildrenViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 /**
  * Class EscapeChildrenDisabledAndEscapeOutputDisabledViewHelper

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 /**
  * Class EscapeChildrenDisabledAndEscapeOutputEnabledViewHelper

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 /**
  * Class EscapeChildrenEnabledAndEscapeOutputDisabledViewHelper

--- a/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper.php
@@ -1,19 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
-
 /*
- * This file is part of the TYPO3 CMS project.
- *
- * It is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License, either version 2
- * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
- *
- * The TYPO3 project - inspiring people to share!
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 /**
  * Class EscapeChildrenEnabledAndEscapeOutputEnabledViewHelper

--- a/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/TagBasedTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/TagBasedTestViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;

--- a/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolver.php
+++ b/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolver.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheWarmupResult;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheWarmupResult;
 use TYPO3Fluid\Fluid\Core\Cache\StandardCacheWarmer;

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Compiler\NodeConverter;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\NodeConverter;

--- a/tests/Unit/Core/Fixtures/ClassWithMagicGetter.php
+++ b/tests/Unit/Core/Fixtures/ClassWithMagicGetter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
 
 /**
  * Class ClassWithMagicGetter

--- a/tests/Unit/Core/Fixtures/ClassWithProtectedGetter.php
+++ b/tests/Unit/Core/Fixtures/ClassWithProtectedGetter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
 
 /**
  * Class ClassWithProtectedGetter

--- a/tests/Unit/Core/Fixtures/TestViewHelper.php
+++ b/tests/Unit/Core/Fixtures/TestViewHelper.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 

--- a/tests/Unit/Core/Fixtures/TestViewHelper2.php
+++ b/tests/Unit/Core/Fixtures/TestViewHelper2.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;

--- a/tests/Unit/Core/Parser/ConfigurationTest.php
+++ b/tests/Unit/Core/Parser/ConfigurationTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture01-shorthand-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture01-shorthand-split.php
@@ -1,4 +1,9 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 return ['
 a{f:base()}b'];

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture06-split.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 return [
     '{namespace foo=TYPO3Fluid\Fluid\ViewHelpers}',
     '<foo:format.nl2br>',

--- a/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture14-split.php
+++ b/tests/Unit/Core/Parser/Fixtures/TemplateParserTestFixture14-split.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 return [
     '<f:format.printf arguments="{number : 362525200}">',
     '%.3e',

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;

--- a/tests/Unit/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use TYPO3Fluid\Fluid\Core\Variables\ChainedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;

--- a/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;

--- a/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeViewHelper.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeViewHelper.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/tests/Unit/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;

--- a/tests/Unit/View/AbstractViewTest.php
+++ b/tests/Unit/View/AbstractViewTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\AbstractView;

--- a/tests/Unit/View/Fixtures/LegacyTemplatePathsFixture.php
+++ b/tests/Unit/View/Fixtures/LegacyTemplatePathsFixture.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
 namespace TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures;
 
 use TYPO3Fluid\Fluid\View\TemplatePaths;

--- a/tests/Unit/View/Fixtures/TransparentSyntaxTreeNode.php
+++ b/tests/Unit/View/Fixtures/TransparentSyntaxTreeNode.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\View\Fixture;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\View\Fixture;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;

--- a/tests/Unit/View/LegacyTemplatePathsTest.php
+++ b/tests/Unit/View/LegacyTemplatePathsTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\View;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\LegacyTemplatePathsFixture;
 

--- a/tests/Unit/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/AliasViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\ViewHelpers\AliasViewHelper;

--- a/tests/Unit/ViewHelpers/Cache/DisableViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/DisableViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/tests/Unit/ViewHelpers/Cache/StaticViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/StaticViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/tests/Unit/ViewHelpers/Cache/WarmupViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/Cache/WarmupViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Cache;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;

--- a/tests/Unit/ViewHelpers/ElseViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ElseViewHelperTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\ViewHelpers\ElseViewHelper;

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithToArray.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithToArray.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 
 /**
  * Dummy object to test Viewhelper behavior on objects with a toArray() method

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithToString.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithToString.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 
 /**
  * Dummy object to test Viewhelper behavior on objects with a __toString method

--- a/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
+++ b/tests/Unit/ViewHelpers/Fixtures/UserWithoutToString.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures;
 
 /**
  * Dummy object to test Viewhelper behavior on objects without a __toString method

--- a/tests/Unit/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ForViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers\Fixtures\ConstraintSyntaxTreeNode;

--- a/tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper;
 

--- a/tests/Unit/ViewHelpers/InlineViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/InlineViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;

--- a/tests/Unit/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/OrViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\ViewHelpers\OrViewHelper;

--- a/tests/Unit/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SectionViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;

--- a/tests/Unit/ViewHelpers/SpacelessViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/SpacelessViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\ViewHelpers\SpacelessViewHelper;

--- a/tests/Unit/ViewHelpers/ThenViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/ThenViewHelperTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
+
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\ViewHelpers\ThenViewHelper;

--- a/tests/Unit/ViewHelpers/VariableViewHelperTest.php
+++ b/tests/Unit/ViewHelpers/VariableViewHelperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace TYPO3Fluid\Fluid\Tests;
-
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
  */
+
+namespace TYPO3Fluid\Fluid\Tests;
 
 /**
  * Base test case for unit tests.


### PR DESCRIPTION
Have the license header in PHP files on top: After
declare(), but before namespace. Declare this in
php-cs-fixer config.