### PR TITLE
[BUGFIX] ParserRuntimeOnly trait compile() returns string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Core/Compiler/NodeConverter.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Core/Compiler/NodeConverter.php
-
-		-
 			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\Compiler\\\\TemplateCompiler\\:\\:get\\(\\) should return TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\ParsedTemplateInterface but returns TYPO3Fluid\\\\Fluid\\\\Core\\\\Compiler\\\\UncompilableTemplateInterface\\.$#"
 			count: 1
 			path: src/Core/Compiler/TemplateCompiler.php
@@ -171,11 +166,6 @@ parameters:
 			path: src/ViewHelpers/Cache/DisableViewHelper.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\ViewHelpers\\\\CommentViewHelper\\:\\:compile\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: src/ViewHelpers/CommentViewHelper.php
-
-		-
 			message: "#^Variable \\$iterationData might not be defined\\.$#"
 			count: 1
 			path: src/ViewHelpers/ForViewHelper.php
@@ -186,19 +176,9 @@ parameters:
 			path: src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\ViewHelpers\\\\LayoutViewHelper\\:\\:compile\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: src/ViewHelpers/LayoutViewHelper.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: src/ViewHelpers/RenderViewHelper.php
-
-		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\ViewHelpers\\\\SectionViewHelper\\:\\:compile\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: src/ViewHelpers/SectionViewHelper.php
 
 		-
 			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Tests\\\\Functional\\\\Fixtures\\\\Various\\\\ParsedTemplateImplementationFixture\\:\\:getLayoutName\\(\\) should return string but return statement is missing\\.$#"

--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -212,7 +212,9 @@ class NodeConverter
         }
         $initializationArray = [
             'initialization' => $initializationPhpCode,
-            'execution' => $convertedViewHelperExecutionCode === null ? 'NULL' : $convertedViewHelperExecutionCode
+            // @todo: compile() *should* return strings, but it's not enforced in the interface.
+            //        The string cast is here to stay compatible in case something still returns for instance null.
+            'execution' => (string)$convertedViewHelperExecutionCode === '' ? "''" : $convertedViewHelperExecutionCode
         ];
         return $initializationArray;
     }

--- a/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
+++ b/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
@@ -29,6 +29,6 @@ trait ParserRuntimeOnly
      */
     public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
     {
-        return null;
+        return '';
     }
 }

--- a/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
+++ b/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
@@ -24,8 +24,7 @@ trait ParserRuntimeOnly
      * @param string $argumentsName
      * @param string $closureName
      * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
+     * @return string
      */
     public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
     {

--- a/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
+++ b/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
@@ -36,7 +36,7 @@ class NestedFluidTemplatesWithLayoutTest extends AbstractFunctionalTestCase
         $output = $view->render();
         self::assertStringContainsString('DefaultLayoutLayoutOverride', $output);
 
-        // A second run with now compliled templates.
+        // A second run with now compiled templates.
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);

--- a/tests/Functional/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SectionViewHelperTest.php
@@ -16,13 +16,10 @@ class SectionViewHelperTest extends AbstractFunctionalTestCase
 {
     public function renderDataProvider(): \Generator
     {
-        /*
-         * @todo inconsistent, returns empty string when not cached, but null when cached
         yield 'section will not render itself' => [
             '<f:section name="foo">bar</f:section>',
             '',
         ];
-        */
         yield 'render section without arguments before section was defined' => [
             '<f:render section="foo" /><f:section name="foo">bar</f:section>',
             'bar',

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -38,6 +38,6 @@ class ParserRuntimeOnlyTest extends UnitTestCase
         $init = '';
         $viewHelperNodeMock = $this->getMock(ViewHelperNode::class, [], [], '', false);
         $result = $trait->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
-        self::assertNull($result);
+        self::assertSame('', $result);
     }
 }


### PR DESCRIPTION
ViewHelperInterface->compile() is annotated to return
string. ParserRuntimeOnly violates this and returns
null instead. This leads to different behavior in
consuming ViewHelpers between non-compiled and compiled
versions.

The change adapts ParserRuntimeOnly->compile() to
return an empty string and changes NodeConverter to
deal with it. A string cast is added to stay compatible
in case some other compile() method returns null as well.