### PR TITLE
[BUGFIX] Inconsistent return types in SwitchViewHelper

### DIFF
--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -92,7 +92,7 @@ class SwitchViewHelper extends AbstractViewHelper
         }
 
         $this->restoreSwitchState();
-        return $content;
+        return $content ?? '';
     }
 
     /**
@@ -184,8 +184,10 @@ class SwitchViewHelper extends AbstractViewHelper
     {
         $phpCode = 'call_user_func_array(function($arguments) use ($renderingContext, $self) {' . PHP_EOL .
             'switch ($arguments[\'expression\']) {' . PHP_EOL;
+        $hasDefaultCase = false;
         foreach ($node->getChildNodes() as $childNode) {
             if ($this->isDefaultCaseNode($childNode)) {
+                $hasDefaultCase = true;
                 $childrenClosure = $compiler->wrapChildNodesInClosure($childNode);
                 $phpCode .= sprintf('default: return call_user_func(%s);', $childrenClosure) . PHP_EOL;
             } elseif ($this->isCaseNode($childNode)) {
@@ -198,6 +200,10 @@ class SwitchViewHelper extends AbstractViewHelper
                     $childrenClosure
                 ) . PHP_EOL;
             }
+        }
+        if (!$hasDefaultCase) {
+            $phpCode .= 'default:' . PHP_EOL;
+            $phpCode .= 'return \'\';' . PHP_EOL;
         }
         $phpCode .= '}' . PHP_EOL;
         $phpCode .= sprintf('}, array(%s))', $argumentsName);

--- a/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
@@ -46,14 +46,13 @@ class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCase
         yield 'without cases' => [
             '<f:switch expression="{value}">bar</f:switch>',
             ['value' => 'foo'],
-            null,
+            '',
         ];
         yield 'with matching case' => [
             '<f:switch expression="{value}">' .
                 '<f:case value="option1">bar</f:case>' .
                 '<f:case value="option2">baz</f:case>' .
-                // @todo when next line is added, next case fails. Smells like a cache or state bug?
-                // '<f:defaultCase>default</f:defaultCase>' .
+                '<f:defaultCase>default</f:defaultCase>' .
             '</f:switch>',
             ['value' => 'option1'],
             'bar',
@@ -64,7 +63,7 @@ class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:case value="option2">baz</f:case>' .
             '</f:switch>',
             ['value' => 'anotherValue'],
-            null,
+            '',
         ];
         yield 'with matching default case' => [
             '<f:switch expression="{value}">' .


### PR DESCRIPTION
The SwitchViewHelper tends to return a mix of empty
string and null, which can be different when used
in non-compiled and compiled context and the existance
of a 'default' fallback.

The patch changes the VH slightly to return empty
string instead of null more often.