### PR TITLE
[TASK] Cache/DisableViewHelper->compile() returns string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: src/View/TemplatePaths.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\ViewHelpers\\\\Cache\\\\DisableViewHelper\\:\\:compile\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: src/ViewHelpers/Cache/DisableViewHelper.php
-
-		-
 			message: "#^Variable \\$iterationData might not be defined\\.$#"
 			count: 1
 			path: src/ViewHelpers/ForViewHelper.php

--- a/src/ViewHelpers/Cache/DisableViewHelper.php
+++ b/src/ViewHelpers/Cache/DisableViewHelper.php
@@ -84,16 +84,11 @@ class DisableViewHelper extends AbstractViewHelper
      * @param string $argumentsName
      * @param string $closureName
      * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
+     * @return string
      */
-    public function compile(
-        $argumentsName,
-        $closureName,
-        &$initializationPhpCode,
-        ViewHelperNode $node,
-        TemplateCompiler $compiler
-    ) {
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
         $compiler->disable();
+        return '';
     }
 }


### PR DESCRIPTION
compile() should return a string. Cache/DisableViewHelper
violates this. Let it return an empty string instead
of null.