### PR TITLE
[TASK] Correct annotation on ParsedTemplateInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -166,11 +166,6 @@ parameters:
 			path: src/ViewHelpers/RenderViewHelper.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Tests\\\\Functional\\\\Fixtures\\\\Various\\\\ParsedTemplateImplementationFixture\\:\\:getLayoutName\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with TYPO3Fluid\\\\Fluid\\\\Tests\\\\Functional\\\\Fixtures\\\\Various\\\\UserWithoutToString and string will always evaluate to false\\.$#"
 			count: 1
 			path: tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -48,7 +48,7 @@ interface ParsedTemplateInterface
      * This requires the current rendering context in order to be able to evaluate the layout name
      *
      * @param RenderingContextInterface $renderingContext
-     * @return string
+     * @return string|null
      */
     public function getLayoutName(RenderingContextInterface $renderingContext);
 

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -185,7 +185,7 @@ class ParsingState implements ParsedTemplateInterface
      * This requires the current rendering context in order to be able to evaluate the layout name
      *
      * @param RenderingContextInterface $renderingContext
-     * @return string
+     * @return string|null
      * @throws View\Exception
      */
     public function getLayoutName(RenderingContextInterface $renderingContext)

--- a/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
+++ b/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
@@ -37,7 +37,7 @@ class ParsedTemplateImplementationFixture implements ParsedTemplateInterface
 
     public function getLayoutName(RenderingContextInterface $renderingContext)
     {
-        // stub
+        return null;
     }
 
     public function addCompiledNamespaces(RenderingContextInterface $renderingContext)


### PR DESCRIPTION
ParsedTemplateInterface->getLayoutName() may return
string|null, but only string is reflected in the method
annotation. Adapt this.