### PR TITLE
[DOCS] Add anchors to chapters

### DIFF
--- a/Documentation/Development/CreatingViewHelpers.rst
+++ b/Documentation/Development/CreatingViewHelpers.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _creating-viewhelpers:
+
 ====================
 Creating ViewHelpers
 ====================

--- a/Documentation/Development/Decisions.rst
+++ b/Documentation/Development/Decisions.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _decisions:
+
 ======================================
 Decoupling decisions and compatibility
 ======================================

--- a/Documentation/Development/Expressions.rst
+++ b/Documentation/Development/Expressions.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _creating-expressionnodes:
+
 ========================
 Creating ExpressionNodes
 ========================

--- a/Documentation/Development/Implementation.rst
+++ b/Documentation/Development/Implementation.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _implementations:
+
 ==================
 Implementing Fluid
 ==================

--- a/Documentation/Development/Index.rst
+++ b/Documentation/Development/Index.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _development:
+
 ===========
 Development
 ===========

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -32,7 +32,7 @@ output in the TYPO3 CMS. However, it is not dependent on TYPO3 and can be used
 in any PHP project.
 
 If using Fluid in combination with TYPO3 CMS, a look at the documentation of
-:doc:`ext:fsc:Index` can be worth a look.
+:doc:`ext_fsc:Index` can be worth a look.
 
 ----
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _installation:
+
 ============
 Installation
 ============

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _usage:
+
 =====
 Usage
 =====

--- a/Documentation/Usage/RunningExamples.rst
+++ b/Documentation/Usage/RunningExamples.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _running-examples:
+
 ================
 Running Examples
 ================

--- a/Documentation/Usage/Structure.rst
+++ b/Documentation/Usage/Structure.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _template-file-structure:
+
 =============================
 Fluid Template File Structure
 =============================

--- a/Documentation/Usage/Syntax.rst
+++ b/Documentation/Usage/Syntax.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _fluid-syntax:
+
 ================
 The Fluid Syntax
 ================

--- a/Documentation/Usage/ViewHelpers.rst
+++ b/Documentation/Usage/ViewHelpers.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _what-are-viewhelpers:
+
 =====================
 What Are ViewHelpers?
 =====================


### PR DESCRIPTION
This way, the topic can be linked from other manuals without referencing
a concrete page.

Additionally, a wrong link to Fluid Styled Content manual was fixed.