### PR TITLE
[BUGFIX] Support multiple references in variable names

### DIFF
--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -203,6 +203,7 @@ class StandardVariableProviderTest extends UnitTestCase
             [['foodynamicbar' => 'test', 'dyn' => 'dynamic'], 'foo{dyn}bar', 'test'],
             [['foo' => ['dynamic' => ['bar' => 'test']], 'dyn' => 'dynamic'], 'foo.{dyn}.bar', 'test'],
             [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar'], 'baz' => 'sub'], 'foo.{dynamic.{baz}}', 'test'],
+            [['foobardynamic' => 'test', 'foo' => 'bar', 'dyn' => 'dynamic'], 'foo{foo}{dyn}', 'test'],
             [['user' => $namedUser], 'user.hasAccessor', true],
             [['user' => $namedUser], 'user.isAccessor', true],
             [['user' => $unnamedUser], 'user.hasAccessor', false],


### PR DESCRIPTION
A small ajustement to the used regex and repeated matching calls make it possible to support multipe reference in variable names. This allowes to use for example `{foo}bar{baz}` as a variable name.

An exception is thrown if resolved variables would introduce new references. Otherwise variables would get resolved, that are not visible to the author of the template, which looks a bit off security-wise.