### PR TITLE
[TASK] Raise phpunit min-versions to avoid prophecy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,7 @@ jobs:
           find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         run: composer update
-
-      - name: Install dependencies PHP 8.2
-        if: ${{ matrix.php > '8.1' }}
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        run: composer update --ignore-platform-req=php+
 
       - name: CGL check
         if: ${{ matrix.php == '7.2' }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "phpstan/phpstan": "^1.7",
         "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit": "^8.5.26 || ^9.5"
+        "phpunit/phpunit": "^8.5.29 || ^9.5.24"
     },
     "suggest": {
         "ext-json": "PHP JSON is needed when using JSONVariableProvider: A relatively rare use case"


### PR DESCRIPTION
With phpunit dropping prophecy dependency, we can avoid a CI PHP 8.2 related hack.

> composer req --dev "phpunit/phpunit":"^8.5.29 || ^9.5.24"