### PR TITLE
[TASK] Improve the type annotations for view helper arguments

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -64,7 +64,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed
@@ -92,7 +92,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * requires a different (or faster) decision then this method is the one
      * to override and implement.
      *
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      * @param RenderingContextInterface $renderingContext
      * @return bool
      */
@@ -115,7 +115,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * be a warning if someone considers changing this method signature!
      *
      * @deprecated Deprecated in favor of ClassName::verdict($arguments, renderingContext), will no longer be called in 3.0
-     * @param array|null $arguments
+     * @param array<string, mixed> $arguments
      * @return bool
      * @api
      */

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -45,14 +45,12 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     protected $viewHelperNode;
 
     /**
-     * Arguments array.
-     * @var array
+     * @var array<string, mixed>
      * @api
      */
     protected $arguments = [];
 
     /**
-     * Arguments array.
      * @var NodeInterface[] array
      * @api
      */
@@ -103,7 +101,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     protected $escapeOutput;
 
     /**
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function setArguments(array $arguments)
     {
@@ -449,7 +447,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * method must not be called, obviously.
      *
      * @throws Exception
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function handleAdditionalArguments(array $arguments)
     {
@@ -463,7 +461,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * method must not be called, obviously.
      *
      * @throws Exception
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function validateAdditionalArguments(array $arguments)
     {
@@ -506,7 +504,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * when compiled is able to render itself statically to increase performance. This
      * default implementation will simply delegate to the ViewHelperInvoker.
      *
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed
@@ -522,7 +520,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * called directly after the ViewHelper was built.
      *
      * @param ViewHelperNode $node
-     * @param TextNode[] $arguments
+     * @param array<string, TextNode> $arguments
      * @param VariableProviderInterface $variableContainer
      */
     public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer)

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -26,7 +26,7 @@ interface ViewHelperInterface
     public function prepareArguments();
 
     /**
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function setArguments(array $arguments);
 
@@ -80,7 +80,7 @@ interface ViewHelperInterface
      * the ability to allow additional, undeclared, dynamic etc. arguments for the
      * node in the template. Do not implement this unless you need it!
      *
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function handleAdditionalArguments(array $arguments);
 
@@ -89,7 +89,7 @@ interface ViewHelperInterface
      * the ability to allow additional, undeclared, dynamic etc. arguments for the
      * node in the template. Do not implement this unless you need it!
      *
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      */
     public function validateAdditionalArguments(array $arguments);
 
@@ -107,7 +107,7 @@ interface ViewHelperInterface
      * $renderingContext contains references to the VariableProvider and the
      * ViewHelperVariableContainer.
      *
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return string the resulting string which is directly shown

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -36,7 +36,7 @@ class ViewHelperInvoker
      * of which will already have been filled by the ViewHelperResolver.
      *
      * @param string|ViewHelperInterface $viewHelperClassNameOrInstance
-     * @param array $arguments
+     * @param array<string, mixed> $arguments
      * @param RenderingContextInterface $renderingContext
      * @param \Closure|null $renderChildrenClosure
      * @return string


### PR DESCRIPTION
This is required for extension with their own view helper to avoid PHPStan warnings about arrays without types.