### PR TITLE
[FEATURE] Allow setting keys of objects

### DIFF
--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -30,6 +30,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *     <f:variable name="myvariable">some value</f:variable>
  *     {oldvariable -> f:format.htmlspecialchars() -> f:variable(name: 'newvariable')}
  *     <f:variable name="myvariable"><f:format.htmlspecialchars>{oldvariable}</f:format.htmlspecialchars></f:variable>
+ *     {f:variable(name: 'myarray.mykey.mydeeperkey', value: 'some value')}
+ *     <f:variable name="myarray.mykey.mydeeperkey">some value</f:variable>
  *
  * @see \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper
  * @api
@@ -55,6 +57,29 @@ class VariableViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ) {
         $value = $renderChildrenClosure();
-        $renderingContext->getVariableProvider()->add($arguments['name'], $value);
+
+        if (!str_contains($arguments['name'], '.')) {
+            $renderingContext->getVariableProvider()->add($arguments['name'], $value);
+            return;
+        }
+
+        $seperated = explode('.', $arguments['name']);
+
+        $name = $seperated[0];
+        $keys = array_slice($seperated,1);
+
+        $object = $renderingContext->getVariableProvider()->get($name) ?: [];
+
+        $current = &$object;
+        foreach ($keys as $keySegment) {
+            if (!isset($current[$keySegment]) || !is_array($current[$keySegment])) {
+                $current[$keySegment] = [];
+            }
+            $current = &$current[$keySegment];
+        }
+        $current = $value;
+        unset($current);
+
+        $renderingContext->getVariableProvider()->add($name, $object);
     }
 }


### PR DESCRIPTION
Add an additional option to set the name to a period seperated path for modifying of inner values of arrays/objects for the ability to expand objects during fluid template validation

An example usecase for this would be when rendering a partial for a range input and allowing the passing of min and max as seperate parameters to additionalParameters to the f:render to then merge them inside the partial like this

Template.html
```html
<f:render partial="RangeInput" min="0" max="100" additionalAttributes="{data-target: "rangeinput"}"
```

RangeInput.html
```html
<f:variable name="additionalAttributes.min" value="{min}" />
<f:variable name="additionalAttributes.max" value="{max}" />
<f:form.textfield type="range" additionalAttributes="{additionalAttributes}"/>
```

This change allows for the parent to be null so in above example the additionalAttributes key is optional and if not passed the resulting additionalAttributes array would just look like ["min" => 0, "max" => 100]