### PR TITLE
fix: Match mathematical expressions containing multiple whitespace chars

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -26,7 +26,7 @@ class MathExpressionNode extends AbstractExpressionNode
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
-					[_a-zA-Z0-9\.]+(?:[\s]?[*+\^\/\%\-]{1}[\s]?[_a-zA-Z0-9\.]+)+   # Various math expressions left and right sides with any spaces
+					[_a-zA-Z0-9\.]+(?:[\s]*[*+\^\/\%\-]{1}[\s]*[_a-zA-Z0-9\.]+)+   # Various math expressions left and right sides with any spaces
 					|(?R)                    # Other expressions inside
 				)+
 			}                                # End of shorthand syntax

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -42,6 +42,8 @@ class MathExpressionNodeTest extends UnitTestCase
         return [
             ['1 gabbagabbahey 1', [], 0],
             ['1 + 1', [], 2],
+            ['1 +
+                   1', [], 2],
             ['2 - 1', [], 1],
             ['2 % 4', [], 2],
             ['2 * 4', [], 8],


### PR DESCRIPTION
Fixes #673

Allows multiple spaces as well as newline, tab etc. in between operator and operand.

This can be the case when formatting projects with, e.g. `prettier`:

Formatteres break maths expressions onto multiple lines, if they contain long variable names, such as:

```
  <f:variable name="proportionalWidth"
    ><f:format.number decimals="2" thousandsSeparator=""
      >{data.tx_someextensionlongname_and_even_some_more_field_name /
      100}</f:format.number
    ></f:variable
  >
```

This example fails before this PR, and succeeds after this PR.

---

Side note - rather independent of this PR:

It actualy fails quite miserably, with 
- the math expression node printing itself as `{data.tx_someextensionlongname_and_even_some_more_field_name / 100}`, 
- and the number formatting view helper printing an unexpected `0.00`! 

Arguably, `f:format.number` should at least fail by also bailing and printing the invalid input string, rather than **hiding the error** by returning `"0.00"`