### PR TITLE
[TASK] Fix tests using willReturnOnConsecutiveCalls()

### DIFF
--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * See LICENSE.txt that was shipped with this package.
  */
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
+namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
@@ -21,63 +21,73 @@ class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
         return [
             'does nothing with empty templates' => [
                 '',
-                [],
+                [
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                ],
                 ''
             ],
             'supports expression node style namespaces' => [
                 '{namespace x=X\\Y\\ViewHelpers}',
                 [
-                    ['x', 'X\\Y\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'x' => ['X\\Y\\ViewHelpers'],
                 ],
                 ''
             ],
             'ignores blank expression node style namespaces' => [
                 '{namespace z}',
                 [
-                    ['z', null]
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'z' => null,
                 ],
                 ''
             ],
             'ignores unknown namespaces' => [
                 '<html xmlns:unknown="http://not.from.here/ns/something" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
                 [
-                    ['unknown', null]
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'unknown' => null,
                 ],
                 PHP_EOL
             ],
             'supports xmlns detection, single' => [
                 '<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
                 [
-                    ['x', 'X\\Y\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'x' => ['X\\Y\\ViewHelpers'],
                 ],
                 PHP_EOL
             ],
             'supports xmlns detection, leave tag in place' => [
                 '<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers">' . PHP_EOL . '</html>',
                 [
-                    ['x', 'X\\Y\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'x' => ['X\\Y\\ViewHelpers'],
                 ],
                 '<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers">' . PHP_EOL . '</html>'
             ],
             'supports xmlns detection, multiple' => [
                 '<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers" xmlns:z="http://typo3.org/ns/X/Z/ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
                 [
-                    ['x', 'X\\Y\\ViewHelpers'],
-                    ['z', 'X\\Z\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'x' => ['X\\Y\\ViewHelpers'],
+                    'z' => ['X\\Z\\ViewHelpers'],
                 ],
                 PHP_EOL
             ],
             'supports expression style namespace detection, camelCase' => [
                 '{namespace camelCase=X\\Y\\ViewHelpers}',
                 [
-                    ['camelCase', 'X\\Y\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'camelCase' => ['X\\Y\\ViewHelpers'],
                 ],
                 ''
             ],
             'supports xmlns detection, camelCase' => [
                 '<html xmlns:camelCase="http://typo3.org/ns/X/Y/ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
                 [
-                    ['camelCase', 'X\\Y\\ViewHelpers']
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'camelCase' => ['X\\Y\\ViewHelpers'],
                 ],
                 PHP_EOL
             ],
@@ -90,13 +100,13 @@ class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
      */
     public function testExtractsExpectedNamespaces(string $templateSource, array $expectedNamespaces, string $expectedSource): void
     {
+        $viewHelperResolver = new ViewHelperResolver();
         $renderingContext = new RenderingContextFixture();
-        $viewHelperResolver = $this->getMockBuilder(ViewHelperResolver::class)->onlyMethods(['addNamespace'])->getMock();
-        $viewHelperResolver->expects(self::exactly(count($expectedNamespaces)))->method('addNamespace')->willReturnOnConsecutiveCalls(...$expectedNamespaces);
         $renderingContext->setViewHelperResolver($viewHelperResolver);
         $subject = new NamespaceDetectionTemplateProcessor();
         $subject->setRenderingContext($renderingContext);
         $result = $subject->preProcessSource($templateSource);
         self::assertSame($expectedSource, $result);
+        self::assertSame($expectedNamespaces, $viewHelperResolver->getNamespaces());
     }
 }

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -16,7 +16,6 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -94,42 +93,11 @@ class TemplateCompilerTest extends UnitTestCase
         $renderingContext = new RenderingContextFixture();
         $viewHelperNode = new ViewHelperNode($renderingContext, 'f', 'format.raw', $arguments, new ParsingState());
         $result = $instance->wrapViewHelperNodeArgumentEvaluationInClosure($viewHelperNode, 'value');
-        $serialized = serialize($arguments['value']);
         $expected = 'function() use ($renderingContext, $self) {' . chr(10);
         $expected .= chr(10);
         $expected .= 'return \'sometext\';' . chr(10);
         $expected .= '}';
         self::assertEquals($expected, $result);
-    }
-
-    /**
-     * @test
-     */
-    public function testGenerateSectionCodeFromParsingState(): void
-    {
-        $foo = new TextNode('foo');
-        $bar = new TextNode('bar');
-        $parsingState = new ParsingState();
-        $container = new StandardVariableProvider(['1457379500_sections' => [$foo, $bar]]);
-        $parsingState->setVariableProvider($container);
-        $nodeConverter = $this->getMock(NodeConverter::class, ['convertListOfSubNodes'], [], false, false);
-        $nodeConverter->expects(self::exactly(2))->method('convertListOfSubNodes')->willReturnOnConsecutiveCalls(
-            [$foo],
-            [$bar]
-        )->willReturn([]);
-        $instance = $this->getMock(TemplateCompiler::class, ['generateCodeForSection']);
-        $instance->expects(self::exactly(2))->method('generateCodeForSection')->willReturnOnConsecutiveCalls(
-            [self::anything()],
-            [self::anything()]
-        )->willReturnOnConsecutiveCalls(
-            'FOO',
-            'BAR'
-        );
-        $instance->setNodeConverter($nodeConverter);
-        $method = new \ReflectionMethod($instance, 'generateSectionCodeFromParsingState');
-        $method->setAccessible(true);
-        $result = $method->invokeArgs($instance, [$parsingState]);
-        self::assertEquals('FOOBAR', $result);
     }
 
     /**

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -52,19 +52,6 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     /**
      * @test
      */
-    public function testInitializeArgumentsRegistersExpectedArguments(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, ['registerArgument'], [], '', false);
-        $viewHelper->expects(self::atLeastOnce())->method('registerArgument')->willReturnOnConsecutiveCalls(
-            ['additionalAttributes'],
-            ['data']
-        );
-        $viewHelper->initializeArguments();
-    }
-
-    /**
-     * @test
-     */
     public function oneTagAttributeIsRenderedCorrectly(): void
     {
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
@@ -107,13 +94,18 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
-        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnOnConsecutiveCalls(
-            ['data-foo', 'bar'],
-            ['data-baz', 'foos']
-        );
+        $series = [
+            ['data-foo', 'fooValue'],
+            ['data-bar', 'barValue'],
+        ];
+        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $viewHelper->setTagBuilder($mockTagBuilder);
 
-        $arguments = ['data' => ['foo' => 'bar', 'baz' => 'foos']];
+        $arguments = ['data' => ['foo' => 'fooValue', 'bar' => 'barValue']];
         $viewHelper->setArguments($arguments);
         $viewHelper->initialize();
     }
@@ -127,13 +119,18 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
-        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnOnConsecutiveCalls(
-            ['aria-foo', 'bar'],
-            ['aria-baz', 'foos']
-        );
+        $series = [
+            ['aria-foo', 'fooValue'],
+            ['aria-bar', 'barValue'],
+        ];
+        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $viewHelper->setTagBuilder($mockTagBuilder);
 
-        $arguments = ['aria' => ['foo' => 'bar', 'baz' => 'foos']];
+        $arguments = ['aria' => ['foo' => 'fooValue', 'bar' => 'barValue']];
         $viewHelper->setArguments($arguments);
         $viewHelper->initialize();
     }
@@ -157,12 +154,17 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
         $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
-        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnOnConsecutiveCalls(
-            ['data-foo', 'foo'],
-            ['data-bar', 'bar']
-        );
+        $series = [
+            ['data-foo', 'fooValue'],
+            ['data-bar', 'barValue'],
+        ];
+        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $viewHelper->setTagBuilder($tagBuilder);
-        $viewHelper->handleAdditionalArguments(['data-foo' => 'foo', 'data-bar' => 'bar']);
+        $viewHelper->handleAdditionalArguments(['data-foo' => 'fooValue', 'data-bar' => 'barValue']);
         $viewHelper->initializeArgumentsAndRender();
     }
 
@@ -174,12 +176,17 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
         $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
-        $tagBuilder->expects(self::exactly(2))->method('addAttribute')->willReturnOnConsecutiveCalls(
-            ['aria-foo', 'foo'],
-            ['aria-bar', 'bar']
-        );
+        $series = [
+            ['aria-foo', 'fooValue'],
+            ['aria-bar', 'barValue'],
+        ];
+        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $viewHelper->setTagBuilder($tagBuilder);
-        $viewHelper->handleAdditionalArguments(['aria-foo' => 'foo', 'aria-bar' => 'bar']);
+        $viewHelper->handleAdditionalArguments(['aria-foo' => 'fooValue', 'aria-bar' => 'barValue']);
         $viewHelper->initializeArgumentsAndRender();
     }
 
@@ -192,7 +199,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
         $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
-        $mockTagBuilder->expects(self::exactly(8))->method('addAttribute')->willReturnOnConsecutiveCalls(
+        $series = [
             ['class', 'classAttribute'],
             ['dir', 'dirAttribute'],
             ['id', 'idAttribute'],
@@ -201,7 +208,12 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
             ['title', 'titleAttribute'],
             ['accesskey', 'accesskeyAttribute'],
             ['tabindex', 'tabindexAttribute']
-        );
+        ];
+        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $viewHelper->setTagBuilder($mockTagBuilder);
 
         $arguments = [

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -18,7 +18,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
-use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeDefaultRenderStaticViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeViewHelper;
@@ -215,46 +214,6 @@ class AbstractViewHelperTest extends UnitTestCase
         });
         $result = $viewHelper->renderChildren();
         self::assertEquals('foobar', $result);
-    }
-
-    public static function getValidateArgumentsTestValues(): array
-    {
-        return [
-            [new ArgumentDefinition('test', 'boolean', '', true, false), false],
-            [new ArgumentDefinition('test', 'boolean', '', true), true],
-            [new ArgumentDefinition('test', 'string', '', true), 'foobar'],
-            [new ArgumentDefinition('test', 'string', '', true), new UserWithToString('foobar')],
-            [new ArgumentDefinition('test', 'array', '', true), ['foobar']],
-            [new ArgumentDefinition('test', 'mixed', '', true), new \DateTime('now')],
-            [new ArgumentDefinition('test', 'DateTime[]', '', true), [new \DateTime('now'), 'test']],
-            [new ArgumentDefinition('test', 'string[]', '', true), []],
-            [new ArgumentDefinition('test', 'string[]', '', true), ['foobar']],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider getValidateArgumentsTestValues
-     * @param mixed $value
-     */
-    public function testValidateArguments(ArgumentDefinition $argument, $value): void
-    {
-        $viewHelper = $this->getAccessibleMock(
-            AbstractViewHelper::class,
-            ['hasArgument', 'prepareArguments'],
-            [],
-            '',
-            false
-        );
-        $viewHelper->expects(self::once())->method('prepareArguments')->willReturn(
-            [$argument->getName() => $argument, 'second' => $argument]
-        );
-        $viewHelper->setArguments([$argument->getName() => $value, 'second' => $value]);
-        $viewHelper->expects(self::exactly(2))->method('hasArgument')->willReturnOnConsecutiveCalls(
-            [$argument->getName()],
-            ['second']
-        )->willReturn(true);
-        $viewHelper->validateArguments();
     }
 
     public static function getValidateArgumentsErrorsTestValues(): array

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -74,10 +74,15 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignAddsValueToTemplateVariableContainer(): void
     {
-        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->willReturnOnConsecutiveCalls(
+        $series = [
             ['foo', 'FooValue'],
-            ['bar', 'BarValue']
-        );
+            ['bar', 'BarValue'],
+        ];
+        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $this->view
             ->assign('foo', 'FooValue')
             ->assign('bar', 'BarValue');
@@ -88,10 +93,15 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignCanOverridePreviouslyAssignedValues(): void
     {
-        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->willReturnOnConsecutiveCalls(
+        $series = [
             ['foo', 'FooValue'],
-            ['foo', 'FooValueOverridden']
-        );
+            ['foo', 'FooValueOverridden'],
+        ];
+        $this->templateVariableContainer->expects(self::exactly(2))->method('add')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $this->view->assign('foo', 'FooValue');
         $this->view->assign('foo', 'FooValueOverridden');
     }
@@ -101,14 +111,38 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function assignMultipleAddsValuesToTemplateVariableContainer(): void
     {
-        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->willReturnOnConsecutiveCalls(
+        $series = [
             ['foo', 'FooValue'],
             ['bar', 'BarValue'],
-            ['baz', 'BazValue']
-        );
+            ['baz', 'BazValue'],
+        ];
+        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
         $this->view
             ->assignMultiple(['foo' => 'FooValue', 'bar' => 'BarValue'])
             ->assignMultiple(['baz' => 'BazValue']);
+    }
+
+    /**
+     * @test
+     */
+    public function assignMultipleCanOverridePreviouslyAssignedValues(): void
+    {
+        $series = [
+            ['foo', 'FooValue'],
+            ['foo', 'FooValueOverridden'],
+            ['bar', 'BarValue']
+        ];
+        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->willReturnCallback(function (...$args) use (&$series): void {
+            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
+            self::assertSame($expectedArgOne, $args[0]);
+            self::assertSame($expectedArgTwo, $args[1]);
+        });
+        $this->view->assign('foo', 'FooValue');
+        $this->view->assignMultiple(['foo' => 'FooValueOverridden', 'bar' => 'BarValue']);
     }
 
     public static function getRenderSectionExceptionTestValues(): array
@@ -117,20 +151,6 @@ class AbstractTemplateViewTest extends UnitTestCase
             [true],
             [false]
         ];
-    }
-
-    /**
-     * @test
-     */
-    public function assignMultipleCanOverridePreviouslyAssignedValues(): void
-    {
-        $this->templateVariableContainer->expects(self::exactly(3))->method('add')->willReturnOnConsecutiveCalls(
-            ['foo', 'FooValue'],
-            ['foo', 'FooValueOverridden'],
-            ['bar', 'BarValue']
-        );
-        $this->view->assign('foo', 'FooValue');
-        $this->view->assignMultiple(['foo' => 'FooValueOverridden', 'bar' => 'BarValue']);
     }
 
     /**


### PR DESCRIPTION
We switched from withConsecutive() to
willReturnOnConsecutiveCalls() when adding
phpunit 10 support. This was partially broken
since various tests were designed to test the
input, which withConsecutive() does, but
willReturnOnConsecutiveCalls() does not.

Switch to a callback in some places, remove
a couple of heavily mocking tests altogether
and change some tests to functional tests.

In general, we should continue to avoid various
heavy mocking tests and various whitebox tests,
and substitute them with good functional tests.