### PR TITLE
[TASK] Remove unused protected variable

### DIFF
--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -27,11 +27,6 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
     protected $renderingContext;
 
     /**
-     * @var array
-     */
-    protected $localNamespaces = [];
-
-    /**
      * @param RenderingContextInterface $renderingContext
      */
     public function setRenderingContext(RenderingContextInterface $renderingContext)


### PR DESCRIPTION
NamespaceDetectionTemplateProcessor->localNamespaces is protected and unused and can be removed without further impact.