### PR TITLE
[TASK] Simplify ternary with null coalescence

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -123,7 +123,7 @@ class StandardVariableProvider implements VariableProviderInterface
     {
         $subject = $this->variables;
         foreach (explode('.', $this->resolveSubVariableReferences($path)) as $index => $pathSegment) {
-            $accessor = isset($accessors[$index]) ? $accessors[$index] : null;
+            $accessor = $accessors[$index] ?? null;
             $subject = $this->extractSingleValue($subject, $pathSegment, $accessor);
             if ($subject === null) {
                 break;


### PR DESCRIPTION
A line in StandardVariableProvider can be
simplified using the null coalescing operator.