### PR TITLE
[TASK] Avoid VariableExtractor in ChainedVariableProvider

### DIFF
--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -8,15 +8,12 @@
 namespace TYPO3Fluid\Fluid\Core\Variables;
 
 /**
- * Class ChainedVariableProvider
- *
- * Allows chainging any number of prioritised VariableProviders
+ * Allows chaining any number of prioritised VariableProviders
  * to be consulted whenever a variable is requested. First
  * VariableProvider to return a value "wins".
  */
 class ChainedVariableProvider extends StandardVariableProvider implements VariableProviderInterface
 {
-
     /**
      * @var VariableProviderInterface[]
      */
@@ -67,10 +64,33 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
      */
     public function getByPath($path, array $accessors = [])
     {
-        $value = VariableExtractor::extract($this->variables, $path, $accessors);
+        // First, see if we can resolve the value directly using "native" StandardVariableProvider.
+        // Even though this class extends StandardVariableProvider, we need to instantiate a new
+        // instance of StandardVariableProvider since getByPath() of parent calls itself recursive,
+        // and we must not become a victim of late-static binding here.
+        // @todo: It *might* be possible to simplify this, to:
+        //        $standardVariableProvider = new StandardVariableProvider($this->variables);
+        //        standardVariableProvider->getByPath($path, $accessors);
+        //        With current test coverage, this works. However, the old VariableExtractor
+        //        accepted mixed as variables, while StandardVariableProvider only accepts array.
+        //        We're currently unsure if this is a problem, it should be investigated further
+        //        to see if the given solution should be kept and this comment should be removed,
+        //        or if the code could be simplified.
+        // @todo: Also, this is unclear: The chained variable provider should most likely call
+        //        *only* variable resolving for attached single providers, and not use the
+        //        StandardVariableProvider as standard solution. As such, this default should
+        //        probably vanish altogether, to then rely on single variable provider implementations
+        //        instead, without this magic resolver?
+        // @todo: All in all, the entire VariableProvider construct feels over abstracted covering
+        //        very seldom use cases only. We may want to look at this again to see if we could
+        //        simplify the entire construct again.
+        $standardVariableProvider = new StandardVariableProvider();
+        $standardVariableProvider->setSource($this->variables);
+        $value = $standardVariableProvider->getByPath($path, $accessors);
         if ($value !== null) {
             return $value;
         }
+        // We did not resolve with native StandardVariableProvider. Let's try the chain.
         foreach ($this->variableProviders as $provider) {
             $value = $provider->getByPath($path, $accessors);
             if ($value !== null) {


### PR DESCRIPTION
VariableExtractor is deprecated for a long time,
use the methods from StandardVariableProvider
instead.