### PR TITLE
[TASK] Simplify usages of StandardVariableProvider

### DIFF
--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -170,8 +170,9 @@ class DebugViewHelper extends AbstractViewHelper
         $output = [];
         foreach ($properties as $property) {
             $propertyName = $property->getName();
-            $standardVariableProvider = new StandardVariableProvider(['subject' => $variable]);
-            $output[$propertyName] = $standardVariableProvider->getByPath('subject.' . $propertyName);
+            $standardVariableProvider = new StandardVariableProvider();
+            $standardVariableProvider->setSource($variable);
+            $output[$propertyName] = $standardVariableProvider->getByPath($propertyName);
         }
         return $output;
     }

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -153,8 +153,9 @@ class GroupedForViewHelper extends AbstractViewHelper
         $groups = ['keys' => [], 'values' => []];
         foreach ($elements as $key => $value) {
             if (is_array($value) || is_object($value)) {
-                $extractor = new StandardVariableProvider(['subject' => $value]);
-                $currentGroupIndex = $extractor->getByPath('subject.' . $groupBy);
+                $extractor = new StandardVariableProvider();
+                $extractor->setSource($value);
+                $currentGroupIndex = $extractor->getByPath($groupBy);
             } else {
                 throw new ViewHelper\Exception('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
             }


### PR DESCRIPTION
The recent changes avoiding VaribleExtractor can
be simplified a bit to not use nested array magic.