### PR TITLE
[TASK] Comment broken VariableProviderInterface constructor

### DIFF
--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -20,12 +20,19 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  */
 interface VariableProviderInterface extends \ArrayAccess
 {
-
     /**
      * Variables, if any, with which to initialize this
      * VariableProvider.
      *
      * @param array $variables
+     * @todo: This must be removed from the interface! At the moment,
+     *        StandardVariableProvider accepts variables as constructor
+     *        arguments, while ChainedVariableProvider expects an array
+     *        of sub providers as constructor argument.
+     *        Thus, setSource() should be the only way to set variables
+     *        and StandardVariableProvider *must not* accept current
+     *        variables as constructor argument.
+     *        Adding variables as constructor must not be relied on!
      */
     public function __construct(array $variables = []);
 


### PR DESCRIPTION
The constructor declared in VariableProviderInterface is broken with the current usage. Add an @todo to clarify this needs to be changed.