### PR TITLE
[FEATURE] Add runtime cache for object access in fluid

### DIFF
--- a/tests/Functional/Cases/Rendering/DataAccessorTest.php
+++ b/tests/Functional/Cases/Rendering/DataAccessorTest.php
@@ -83,6 +83,20 @@ class DataAccessorTest extends AbstractFunctionalTestCase
                     'publicValue@getPublicValue()'
                 ],
             ],
+            'cached object accessors' => [
+                '["{data.privateValue}", "{data.protectedValue}", "{data.publicValue}", "{data.privateValue}", "{data.protectedValue}", "{data.publicValue}"]',
+                [
+                    'data' => new WithEverything(),
+                ],
+                [
+                    'privateValue@getPrivateValue()',
+                    'protectedValue@getProtectedValue()',
+                    'publicValue@getPublicValue()',
+                    'privateValue@getPrivateValue()',
+                    'protectedValue@getProtectedValue()',
+                    'publicValue@getPublicValue()'
+                ],
+            ]
         ];
     }
 


### PR DESCRIPTION
This change reduces PHP function calls when accessing multiple instances of the same class in a fluid template. The current implementation checks the class structure with each property access for the availability of getter or asserter methods, which can be cached after the first check and re-used for all subsequent accesses of the same property.

Due to the way variable providers are implemented, this cache can also be re-used in partials, layouts and sections.