### PR TITLE
[TASK] Remove StandardVariableProvider->getAccessorsForPath()

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -222,30 +222,6 @@ class StandardVariableProvider implements VariableProviderInterface
 
     /**
      * @param string $propertyPath
-     * @return array
-     */
-    public function getAccessorsForPath($propertyPath)
-    {
-        $subject = $this->variables;
-        $accessors = [];
-        $propertyPathSegments = explode('.', $propertyPath);
-        foreach ($propertyPathSegments as $index => $pathSegment) {
-            $accessor = $this->detectAccessor($subject, $pathSegment);
-            if ($accessor === null) {
-                // Note: this may include cases of sub-variable references. When such
-                // a reference is encountered the accessor chain is stopped and new
-                // accessors will be detected for the sub-variable and all following
-                // path segments since the variable is now fully dynamic.
-                break;
-            }
-            $accessors[] = $accessor;
-            $subject = $this->extractSingleValue($subject, $pathSegment);
-        }
-        return $accessors;
-    }
-
-    /**
-     * @param string $propertyPath
      * @return string
      */
     protected function resolveSubVariableReferences($propertyPath)

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -193,35 +193,6 @@ class StandardVariableProviderTest extends UnitTestCase
         self::assertEquals($expected, $result);
     }
 
-    public static function getAccessorsForPathTestValues(): array
-    {
-        $namedUser = new UserWithoutToString('Foobar Name');
-        $inArray = ['user' => $namedUser];
-        $inArrayAccess = new StandardVariableProvider($inArray);
-        $inPublic = (object)$inArray;
-        $asArray = StandardVariableProvider::ACCESSOR_ARRAY;
-        $asGetter = StandardVariableProvider::ACCESSOR_GETTER;
-        $asPublic = StandardVariableProvider::ACCESSOR_PUBLICPROPERTY;
-        return [
-            [['inArray' => $inArray], 'inArray.user', [$asArray, $asArray]],
-            [['inArray' => $inArray], 'inArray.user.name', [$asArray, $asArray, $asGetter]],
-            [['inArrayAccess' => $inArrayAccess], 'inArrayAccess.user.name', [$asArray, $asArray, $asGetter]],
-            [['inArrayAccessWithGetter' => $inArrayAccess], 'inArrayAccessWithGetter.allIdentifiers', [$asArray, $asGetter]],
-            [['inPublic' => $inPublic], 'inPublic.user.name', [$asArray, $asPublic, $asGetter]],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider getAccessorsForPathTestValues
-     */
-    public function testGetAccessorsForPath(array $subject, string $path, array $expected): void
-    {
-        $provider = new StandardVariableProvider($subject);
-        $result = $provider->getAccessorsForPath($path);
-        self::assertEquals($expected, $result);
-    }
-
     public static function getExtractRedectAccessorTestValues(): array
     {
         return [


### PR DESCRIPTION
This method has been copied over from
deprecated VariableExtractor when this
class has been prepared for deprecation.
It is unused an can be removed without
further impact.