### PR TITLE
[TASK] Simplify ChainedVariableProvider

### DIFF
--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -64,31 +64,8 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
      */
     public function getByPath($path, array $accessors = [])
     {
-        // First, see if we can resolve the value directly using "native" StandardVariableProvider.
-        // Even though this class extends StandardVariableProvider, we need to instantiate a new
-        // instance of StandardVariableProvider since getByPath() of parent calls itself recursive,
-        // and we must not become a victim of late-static binding here.
-        // @todo: It *might* be possible to simplify this, to:
-        //        $standardVariableProvider = new StandardVariableProvider($this->variables);
-        //        standardVariableProvider->getByPath($path, $accessors);
-        //        With current test coverage, this works. However, the old VariableExtractor
-        //        accepted mixed as variables, while StandardVariableProvider only accepts array.
-        //        We're currently unsure if this is a problem, it should be investigated further
-        //        to see if the given solution should be kept and this comment should be removed,
-        //        or if the code could be simplified.
-        // @todo: Also, this is unclear: The chained variable provider should most likely call
-        //        *only* variable resolving for attached single providers, and not use the
-        //        StandardVariableProvider as standard solution. As such, this default should
-        //        probably vanish altogether, to then rely on single variable provider implementations
-        //        instead, without this magic resolver?
-        // @todo: All in all, the entire VariableProvider construct feels over abstracted covering
-        //        very seldom use cases only. We may want to look at this again to see if we could
-        //        simplify the entire construct again.
-        $standardVariableProvider = new StandardVariableProvider();
-        $standardVariableProvider->setSource($this->variables);
-        $value = $standardVariableProvider->getByPath($path, $accessors);
-        if ($value !== null) {
-            return $value;
+        if (array_key_exists($path, $this->variables)) {
+            return $this->variables[$path];
         }
         // We did not resolve with native StandardVariableProvider. Let's try the chain.
         foreach ($this->variableProviders as $provider) {


### PR DESCRIPTION
ChainedVariableProvider adds an instance of
StandardVariableProvider by default. This is
odd, it should add it explicitly if needed.
This change is not considered breaking since
it affects an internal use case, mostly
related to cache warming.