### PR TITLE
[TASK] Remove variable accessors from ObjectAccessorNode

### DIFF
--- a/src/Core/Compiler/NodeConverter.php
+++ b/src/Core/Compiler/NodeConverter.php
@@ -18,7 +18,6 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
 class NodeConverter
 {
@@ -213,47 +212,20 @@ class NodeConverter
         return $initializationArray;
     }
 
-    /**
-     * @param ObjectAccessorNode $node
-     * @return array
-     * @see convert()
-     */
-    protected function convertObjectAccessorNode(ObjectAccessorNode $node)
+    protected function convertObjectAccessorNode(ObjectAccessorNode $node): array
     {
-        $arrayVariableName = $this->variableName('array');
-        $accessors = $node->getAccessors();
         $path = $node->getObjectPath();
-        $pathSegments = explode('.', $path);
         if ($path === '_all') {
             return [
                 'initialization' => '',
                 'execution' => '$renderingContext->getVariableProvider()->getAll()',
             ];
         }
-        if (1 === count(array_unique($accessors))
-            && reset($accessors) === StandardVariableProvider::ACCESSOR_ARRAY
-            && count($accessors) === count($pathSegments)
-            && false === strpos($path, '{')
-        ) {
-            // every extractor used in this path is a straight-forward arrayaccess.
-            // Create the compiled code as a plain old variable assignment:
-            return [
-                'initialization' => '',
-                'execution' => sprintf(
-                    'isset($renderingContext->getVariableProvider()[\'%s\']) ? $renderingContext->getVariableProvider()[\'%s\'] : NULL',
-                    str_replace('.', '\'][\'', $path),
-                    str_replace('.', '\'][\'', $path)
-                )
-            ];
-        }
-        $accessorsVariable = var_export($accessors, true);
-        $initialization = sprintf('%s = %s;', $arrayVariableName, $accessorsVariable);
         return [
-            'initialization' => $initialization,
+            'initialization' => '',
             'execution' => sprintf(
-                '$renderingContext->getVariableProvider()->getByPath(\'%s\', %s)',
-                $path,
-                $arrayVariableName
+                '$renderingContext->getVariableProvider()->getByPath(\'%s\')',
+                $path
             )
         ];
     }

--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -23,26 +23,16 @@ class ObjectAccessorNode extends AbstractNode
     protected $objectPath;
 
     /**
-     * Accessor names, one per segment in the object path.
-     * Use constants from StandardVariableProvider.
-     *
-     * @var array
-     */
-    protected $accessors = [];
-
-    /**
      * Constructor. Takes an object path as input.
      *
      * The first part of the object path has to be a variable in the
      * VariableProvider.
      *
      * @param string $objectPath An Object Path, like object1.object2.object3
-     * @param array $accessors Optional list of accessor strategies; starting from beginning of dotted path. Incomplete allowed.
      */
-    public function __construct($objectPath, array $accessors = [])
+    public function __construct($objectPath)
     {
         $this->objectPath = $objectPath;
-        $this->accessors = $accessors;
     }
 
     /**
@@ -55,11 +45,11 @@ class ObjectAccessorNode extends AbstractNode
     }
 
     /**
-     * @return array
+     * @deprecated Unused. Will be removed.
      */
-    public function getAccessors()
+    public function getAccessors(): array
     {
-        return $this->accessors;
+        return [];
     }
 
     /**
@@ -83,6 +73,6 @@ class ObjectAccessorNode extends AbstractNode
         if ($objectPath === '_all') {
             return $variableProvider->getAll();
         }
-        return $variableProvider->getByPath($this->objectPath, $this->accessors);
+        return $variableProvider->getByPath($this->objectPath);
     }
 }

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -84,11 +84,7 @@ class NodeConverterTest extends UnitTestCase
             ],
             [
                 new ObjectAccessorNode('foo.bar'),
-                '$renderingContext->getVariableProvider()->getByPath(\'foo.bar\', $array0)'
-            ],
-            [
-                new ObjectAccessorNode('foo.bar', ['array', 'array']),
-                'isset($renderingContext->getVariableProvider()[\'foo\'][\'bar\']) ? $renderingContext->getVariableProvider()[\'foo\'][\'bar\'] : NULL'
+                '$renderingContext->getVariableProvider()->getByPath(\'foo.bar\')'
             ],
             [
                 new BooleanNode(new TextNode('TRUE')),


### PR DESCRIPTION
In an attempt to improve compiled template performance, 82911b85 and 735f3362 established a second constructor argument on ObjectAccessorNode, handing over "accessors". This was later reverted in 48e43466 to fix #255.

As a result, ObjectAccessorNode is never called with a second constructor argument in business code, so $this->accessors is always an empty array.

The patch removes the second constructor argument
again and simplifies the generated template code
in NodeConverter accordingly.

Related: #255