### PR TITLE
[TASK] Simplify VariableProviderInterface->getByPath()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,6 +81,11 @@ parameters:
 			path: src/Core/Rendering/RenderingContext.php
 
 		-
+			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\Variables\\\\VariableProviderInterface\\:\\:getByPath\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/Core/Variables/ChainedVariableProvider.php
+
+		-
 			message: "#^Unsafe call to private method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\AbstractConditionViewHelper\\:\\:evaluateElseClosures\\(\\) through static\\:\\:\\.$#"
 			count: 1
 			path: src/Core/ViewHelper/AbstractConditionViewHelper.php

--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -94,15 +94,11 @@ interface VariableProviderInterface extends \ArrayAccess
     /**
      * Get a variable by dotted path expression, retrieving the
      * variable from nested arrays/objects one segment at a time.
-     * If the second variable is passed, it is expected to contain
-     * extraction method names (constants from StandardVariableProvider)
-     * which indicate how each value is extracted.
      *
      * @param string $path
-     * @param array $accessors
      * @return mixed
      */
-    public function getByPath($path, array $accessors = []);
+    public function getByPath($path);
 
     /**
      * Remove a variable from context.


### PR DESCRIPTION
The second argument $accessors can be removed
from VariableProviderInterface since it fits
no purpose anymore with a1645c53 being merged.

The patch removes the argument from the interface
only, keeping consumers as is for now, to verify
this change is not breaking.