### PR TITLE
[TASK] Avoid second argument on getByPath()

### DIFF
--- a/examples/src/CustomVariableProvider.php
+++ b/examples/src/CustomVariableProvider.php
@@ -34,7 +34,7 @@ class CustomVariableProvider extends StandardVariableProvider implements Variabl
      * @param string $path
      * @return mixed
      */
-    public function getByPath($path, array $accessors = [])
+    public function getByPath($path)
     {
         if ($path === 'random') {
             return 'random' . sha1(rand(0, 999999999));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: src/Core/Rendering/RenderingContext.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\Variables\\\\VariableProviderInterface\\:\\:getByPath\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 1
-			path: src/Core/Variables/ChainedVariableProvider.php
-
-		-
 			message: "#^Unsafe call to private method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\AbstractConditionViewHelper\\:\\:evaluateElseClosures\\(\\) through static\\:\\:\\.$#"
 			count: 1
 			path: src/Core/ViewHelper/AbstractConditionViewHelper.php

--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -59,17 +59,16 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
 
     /**
      * @param string $path
-     * @param array $accessors
      * @return mixed|null
      */
-    public function getByPath($path, array $accessors = [])
+    public function getByPath($path)
     {
         if (array_key_exists($path, $this->variables)) {
             return $this->variables[$path];
         }
         // We did not resolve with native StandardVariableProvider. Let's try the chain.
         foreach ($this->variableProviders as $provider) {
-            $value = $provider->getByPath($path, $accessors);
+            $value = $provider->getByPath($path);
             if ($value !== null) {
                 return $value;
             }

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -116,18 +116,14 @@ class StandardVariableProvider implements VariableProviderInterface
      * which indicate how each value is extracted.
      *
      * @param string $path
-     * @param array $accessors Optional list of accessors (see class constants)
      * @return mixed
      */
-    public function getByPath($path, array $accessors = [])
+    public function getByPath($path)
     {
         $subject = $this->variables;
         $subVariableReferences = explode('.', $this->resolveSubVariableReferences($path));
-        foreach ($subVariableReferences as $index => $pathSegment) {
-            $accessor = $accessors[$index] ?? null;
-            if ($accessor === null || !$this->canExtractWithAccessor($subject, $pathSegment, $accessor)) {
-                $accessor = $this->detectAccessor($subject, $pathSegment);
-            }
+        foreach ($subVariableReferences as $pathSegment) {
+            $accessor = $this->detectAccessor($subject, $pathSegment);
             $subject = $this->extractWithAccessor($subject, $pathSegment, $accessor);
             if ($subject === null) {
                 break;
@@ -238,33 +234,6 @@ class StandardVariableProvider implements VariableProviderInterface
             }
         }
         return $propertyPath;
-    }
-
-    /**
-     * Returns TRUE if the data type of $subject is potentially compatible
-     * with the $accessor.
-     *
-     * @param mixed $subject
-     * @param string $propertyName
-     * @param string $accessor
-     * @return bool
-     */
-    protected function canExtractWithAccessor($subject, $propertyName, $accessor)
-    {
-        if ($accessor === self::ACCESSOR_ARRAY) {
-            return is_array($subject) || ($subject instanceof \ArrayAccess && $subject->offsetExists($propertyName));
-        }
-        $class = is_object($subject) ? get_class($subject) : false;
-        if ($accessor === self::ACCESSOR_GETTER) {
-            return $class !== false && method_exists($subject, 'get' . ucfirst($propertyName));
-        }
-        if ($accessor === self::ACCESSOR_ASSERTER) {
-            return $class !== false && $this->isExtractableThroughAsserter($subject, $propertyName);
-        }
-        if ($accessor === self::ACCESSOR_PUBLICPROPERTY) {
-            return $class !== false && property_exists($subject, $propertyName);
-        }
-        return false;
     }
 
     /**

--- a/src/Core/Variables/VariableExtractor.php
+++ b/src/Core/Variables/VariableExtractor.php
@@ -71,7 +71,7 @@ class VariableExtractor
     public function getByPath($subject, $propertyPath, array $accessors = [])
     {
         if ($subject instanceof StandardVariableProvider) {
-            return $subject->getByPath($propertyPath, $accessors);
+            return $subject->getByPath($propertyPath);
         }
 
         $propertyPath = $this->resolveSubVariableReferences($subject, $propertyPath);

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -52,7 +52,7 @@ class ObjectAccessorNodeTest extends UnitTestCase
         $node = new ObjectAccessorNode('foo.bar');
         $renderingContext = $this->getMock(RenderingContextInterface::class);
         $variableContainer = $this->getMock(StandardVariableProvider::class);
-        $variableContainer->expects(self::once())->method('getByPath')->with('foo.bar', [])->willReturn('foo');
+        $variableContainer->expects(self::once())->method('getByPath')->with('foo.bar')->willReturn('foo');
         $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);
         self::assertEquals('foo', $value);

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -192,26 +192,4 @@ class StandardVariableProviderTest extends UnitTestCase
         $result = $provider->getByPath($path);
         self::assertEquals($expected, $result);
     }
-
-    public static function getByPathRedetectsAccessorIfUnusableAccessorPassedDataProvider(): array
-    {
-        return [
-            [['test' => 'test'], 'test', null, 'test'],
-            [['test' => 'test'], 'test', 'garbageextractionname', 'test'],
-            [['test' => 'test'], 'test', StandardVariableProvider::ACCESSOR_PUBLICPROPERTY, 'test'],
-            [['test' => 'test'], 'test', StandardVariableProvider::ACCESSOR_GETTER, 'test'],
-            [['test' => 'test'], 'test', StandardVariableProvider::ACCESSOR_ASSERTER, 'test'],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider getByPathRedetectsAccessorIfUnusableAccessorPassedDataProvider
-     */
-    public function getByPathRedetectsAccessorIfUnusableAccessorPassed(array $subject, string $path, ?string $accessor, string $expected): void
-    {
-        $provider = new StandardVariableProvider($subject);
-        $result = $provider->getByPath($path, [$accessor]);
-        self::assertEquals($expected, $result);
-    }
 }


### PR DESCRIPTION
Simplify especially StandardVariableProvider
getByPath() by avoiding the second argument
in the implementation. That argument has been removed from the VariableProviderInterface with c4f24ecd.