### PR TITLE
[BUGFIX] Avoid null to str_replace() in StandardVariableProvider

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -256,17 +256,16 @@ class StandardVariableProvider implements VariableProviderInterface
         return $this->get($identifier);
     }
 
-    /**
-     * @param string $propertyPath
-     * @return string
-     */
-    protected function resolveSubVariableReferences($propertyPath)
+    protected function resolveSubVariableReferences(string $propertyPath): string
     {
         if (strpos($propertyPath, '{') !== false) {
             preg_match_all('/(\{.*\})/', $propertyPath, $matches);
             foreach ($matches[1] as $match) {
                 $subPropertyPath = substr($match, 1, -1);
-                $propertyPath = str_replace($match, $this->getByPath($subPropertyPath), $propertyPath);
+                $subPropertyValue = $this->getByPath($subPropertyPath);
+                if ($subPropertyValue !== null) {
+                    $propertyPath = str_replace($match, $subPropertyValue, $propertyPath);
+                }
             }
         }
         return $propertyPath;

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -288,7 +288,37 @@ class StandardVariableProviderTest extends UnitTestCase
                 'foo{dyn}bar',
                 'test'
             ],
-            'access dynamic variable with dotted path using sub variable reference' => [
+            'access dynamic variable using invalid variable reference' => [
+                [],
+                '{invalid}',
+                null
+            ],
+            'access dynamic variable using invalid sub variable reference' => [
+                [],
+                '{{invalid}}',
+                null
+            ],
+            'access dynamic variable using invalid variable reference in string' => [
+                [],
+                'foo{invalid}bar',
+                null
+            ],
+            'access dynamic variable using invalid sub variable reference in string' => [
+                [],
+                'foo{{invalid}}bar',
+                null
+            ],
+            'access dynamic variable using invalid variable reference in dotted string' => [
+                [],
+                'foo.{invalid}.bar',
+                null
+            ],
+            'access dynamic variable using invalid sub variable reference in dotted string' => [
+                [],
+                'foo.{{invalid}}.bar',
+                null
+            ],
+            'access dynamic variable with dotted path using variable reference' => [
                 [
                     'foo' => [
                         'dynamic' => [


### PR DESCRIPTION
The getByPath() call in resolveSubVariableReferences() may return null if the variable can not be resolved. This leads to a PHP 8.1 deprecation when null is
given to str_replace().

Fix this and cover with tests.

Resolves: #584