### PR TITLE
[TASK] Require php mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
     },
     "license": ["LGPL-3.0-or-later"],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "ext-mbstring": "*"
     },
     "config": {
         "sort-packages": true
     },
     "require-dev": {
         "ext-json": "*",
-        "ext-mbstring": "*",
         "friendsofphp/php-cs-fixer": "^3.16.0",
         "phpstan/phpstan": "^1.10.14",
         "phpstan/phpstan-phpunit": "^1.3.11",


### PR DESCRIPTION
PHP mbstring is used by boolean parser in
a couple of places. TYPO3 core v12 has it
as hard requirement as well, it shouldn't
hurt much to finally require this in Fluid
as well.

> composer req ext-mbstring:*

Resolves: #622