### PR TITLE
[TASK] Move StandardVariableProviderModelFixture to unit namespace

### DIFF
--- a/tests/Unit/Core/Variables/Fixtures/StandardVariableProviderModelFixture.php
+++ b/tests/Unit/Core/Variables/Fixtures/StandardVariableProviderModelFixture.php
@@ -7,26 +7,17 @@ declare(strict_types=1);
  * See LICENSE.txt that was shipped with this package.
  */
 
-namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures;
 
 /**
  * Used by StandardVariableProviderTest
  */
 class StandardVariableProviderModelFixture
 {
-    /**
-     * @var string
-     */
-    protected $name;
+    public string $existingPublicProperty = 'existingPublicPropertyValue';
 
-    /**
-     * @var string
-     */
-    public $existingPublicProperty = 'existingPublicPropertyValue';
-
-    public function __construct(string $name)
+    public function __construct(private readonly string $name)
     {
-        $this->name = $name;
     }
 
     public function getName(): string

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StandardVariableProviderModelFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\StandardVariableProviderModelFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class StandardVariableProviderTest extends UnitTestCase


### PR DESCRIPTION
Move this fixture file to a more appropriate place.