### PR TITLE
[TASK] Avoid TestCase::getMockForTrait()

### DIFF
--- a/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
+++ b/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
+
+class ParserRuntimeOnlyFixture
+{
+    use ParserRuntimeOnly;
+}

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures\ParserRuntimeOnlyFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class ParserRuntimeOnlyTest extends UnitTestCase
@@ -19,22 +19,19 @@ class ParserRuntimeOnlyTest extends UnitTestCase
     /**
      * @test
      */
-    public function testRenderReturnsNull(): void
+    public function renderReturnsNull(): void
     {
-        $instance = $this->getMockBuilder(ParserRuntimeOnly::class)->getMockForTrait();
-        $result = $instance->render();
-        self::assertNull($result);
+        self::assertNull((new ParserRuntimeOnlyFixture())->render());
     }
 
     /**
      * @test
      */
-    public function testCompileReturnsEmptyString(): void
+    public function compileReturnsEmptyString(): void
     {
-        $trait = $this->getMockBuilder(ParserRuntimeOnly::class)->getMockForTrait();
-        $init = '';
-        $viewHelperNodeMock = $this->getMock(ViewHelperNode::class, [], [], false, false);
-        $result = $trait->compile('fake', 'fake', $init, $viewHelperNodeMock, new TemplateCompiler());
+        $initializationPhpCode = '';
+        $subject = new ParserRuntimeOnlyFixture();
+        $result = $subject->compile('', '', $initializationPhpCode, $this->createMock(ViewHelperNode::class), new TemplateCompiler());
         self::assertSame('', $result);
     }
 }


### PR DESCRIPTION
phpunit 10.1 soft deprecated getMockForTrait().
We can avoid usages by adding a fixture class
that uses the trait.