### PR TITLE
[TASK] Avoid and deprecate ParserRuntimeOnly trait

### DIFF
--- a/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
+++ b/src/Core/ViewHelper/Traits/ParserRuntimeOnly.php
@@ -12,6 +12,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
  * Class ParserRuntimeOnly
+ *
+ * @deprecated inline to consumers directly.
  */
 trait ParserRuntimeOnly
 {

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -7,8 +7,9 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
 
 /**
  * This ViewHelper prevents rendering of any content inside the tag.
@@ -60,8 +61,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
  */
 class CommentViewHelper extends AbstractViewHelper
 {
-    use ParserRuntimeOnly;
-
     /**
      * @var bool
      */
@@ -71,4 +70,20 @@ class CommentViewHelper extends AbstractViewHelper
      * @var bool
      */
     protected $escapeOutput = false;
+
+    public function render()
+    {
+        return null;
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '';
+    }
 }

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -7,10 +7,10 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
 
 /**
  * With this tag, you can select a layout to be used for the current template.
@@ -30,8 +30,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
  */
 class LayoutViewHelper extends AbstractViewHelper
 {
-    use ParserRuntimeOnly;
-
     /**
      * Initialize arguments
      *
@@ -40,6 +38,22 @@ class LayoutViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         $this->registerArgument('name', 'string', 'Name of layout to use. If none given, "Default" is used.');
+    }
+
+    public function render()
+    {
+        return null;
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '';
     }
 
     /**

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -7,11 +7,11 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
 
 /**
  * A ViewHelper to declare sections in templates for later use with e.g. the ``f:render`` ViewHelper.
@@ -66,8 +66,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
  */
 class SectionViewHelper extends AbstractViewHelper
 {
-    use ParserRuntimeOnly;
-
     /**
      * @var bool
      */
@@ -81,6 +79,33 @@ class SectionViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         $this->registerArgument('name', 'string', 'Name of the section', true);
+    }
+
+    /**
+     * Rendering directly returns all child nodes.
+     *
+     * @return string HTML String of all child nodes.
+     * @api
+     */
+    public function render()
+    {
+        $content = '';
+        if ($this->viewHelperVariableContainer->exists(SectionViewHelper::class, 'isCurrentlyRenderingSection')) {
+            $this->viewHelperVariableContainer->remove(SectionViewHelper::class, 'isCurrentlyRenderingSection');
+            $content = $this->renderChildren();
+        }
+        return $content;
+    }
+
+    /**
+     * @param string $argumentsName
+     * @param string $closureName
+     * @param string $initializationPhpCode
+     * @return string
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    {
+        return '';
     }
 
     /**
@@ -98,21 +123,5 @@ class SectionViewHelper extends AbstractViewHelper
         $sections = $variableContainer['1457379500_sections'] ? $variableContainer['1457379500_sections'] : [];
         $sections[$sectionName] = $node;
         $variableContainer['1457379500_sections'] = $sections;
-    }
-
-    /**
-     * Rendering directly returns all child nodes.
-     *
-     * @return string HTML String of all child nodes.
-     * @api
-     */
-    public function render()
-    {
-        $content = '';
-        if ($this->viewHelperVariableContainer->exists(SectionViewHelper::class, 'isCurrentlyRenderingSection')) {
-            $this->viewHelperVariableContainer->remove(SectionViewHelper::class, 'isCurrentlyRenderingSection');
-            $content = $this->renderChildren();
-        }
-        return $content;
     }
 }

--- a/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
+++ b/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
@@ -9,6 +9,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\ParserRuntimeOnly;
 
+/**
+ * @deprecated remove together with ParserRuntimeOnlyTest.
+ */
 class ParserRuntimeOnlyFixture
 {
     use ParserRuntimeOnly;

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -14,6 +14,9 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures\ParserRuntimeOnlyFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
+/**
+ * @deprecated remove together with ParserRuntimeOnly.
+ */
 class ParserRuntimeOnlyTest extends UnitTestCase
 {
     /**


### PR DESCRIPTION
This trait has been added with 127d8e70 for
no apparent reason: It was used three times
with one consumer overriding the render()
method again. There is no point to have a
trait for methods that only return null
or empty strings.

To simplify the construct a bit, the trait
is avoided and marked as @deprecated. Neither
Flow nor TYPO3 use the trait in own VH's,
impact should be quite small.