### PR TITLE
[TASK] Avoid and deprecate ViewHelperCompiler

### DIFF
--- a/src/Core/Compiler/ViewHelperCompiler.php
+++ b/src/Core/Compiler/ViewHelperCompiler.php
@@ -43,6 +43,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
  * it is recommended that you append the `$initialization` code
  * string variable anyway since special implementations or future
  * changes in Fluid may cause initialisation code to be generated.
+ *
+ * @deprecated Unused. Will be removed. Inline access to the constants and compileWithCallToStaticMethod() instead.
  */
 class ViewHelperCompiler
 {
@@ -81,13 +83,8 @@ class ViewHelperCompiler
      * @param string|null $onClass Class name which contains the method; null means use ViewHelper's class name.
      * @return array
      */
-    public function compileWithCallToStaticMethod(
-        ViewHelperInterface $viewHelper,
-        $argumentsName,
-        $renderChildrenClosureName,
-        $method = self::RENDER_STATIC,
-        $onClass = null
-    ) {
+    public function compileWithCallToStaticMethod(ViewHelperInterface $viewHelper, $argumentsName, $renderChildrenClosureName, $method = self::RENDER_STATIC, $onClass = null)
+    {
         $onClass = $onClass ?: get_class($viewHelper);
         return [
             self::DEFAULT_INIT,

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -8,7 +8,6 @@
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
 use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
@@ -92,13 +91,13 @@ trait CompileWithContentArgumentAndRenderStatic
         ViewHelperNode $node,
         TemplateCompiler $compiler
     ) {
-        list($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
-            $this,
+        $execution = sprintf(
+            '%s::renderStatic(%s, %s, $renderingContext)',
+            static::class,
             $argumentsName,
-            $closureName,
-            ViewHelperCompiler::RENDER_STATIC,
-            static::class
+            $closureName
         );
+
         $contentArgumentName = $this->resolveContentArgumentName();
         $initializationPhpCode .= sprintf(
             '%s = (%s[\'%s\'] !== null) ? function() use (%s) { return %s[\'%s\']; } : %s;',
@@ -110,7 +109,6 @@ trait CompileWithContentArgumentAndRenderStatic
             $contentArgumentName,
             $closureName
         );
-        $initializationPhpCode .= $initialization;
         return $execution;
     }
 

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -8,7 +8,6 @@
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Compiler\ViewHelperCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
@@ -56,12 +55,11 @@ trait CompileWithRenderStatic
         ViewHelperNode $node,
         TemplateCompiler $compiler
     ) {
-        list($initialization, $execution) = ViewHelperCompiler::getInstance()->compileWithCallToStaticMethod(
-            $this,
+        return sprintf(
+            '%s::renderStatic(%s, %s, $renderingContext)',
+            static::class,
             $argumentsName,
             $closureName
         );
-        $initializationPhpCode .= $initialization;
-        return $execution;
     }
 }


### PR DESCRIPTION
The ViewHelperCompiler helper class has been
introduced a while ago and shrinked over
time again. It consists of one method with
an sprintf() and two constants nowadays.

It is used in the two traits
CompileWithRenderStatic and
CompileWithContentArgumentAndRenderStatic.

To simplify the code a bit, the code of
ViewHelperCompiler is now inlined to the
two traits, which makes them easier to
read and understand. ViewHelperCompiler
is marked @deprecated, neither Flow nor
TYPO3 use that class, so impact should be
rather low.