### PR TITLE
[TASK] Avoid setAccessible()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -84,7 +84,6 @@ abstract class BaseTestCase extends TestCase
     {
         $reflection = new \ReflectionClass($actualClassOrObject);
         $attribute = $reflection->getProperty($actualAttributeName);
-        $attribute->setAccessible(true);
         return $attribute->getValue($actualClassOrObject);
     }
 

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -85,7 +85,6 @@ class StandardCacheWarmerTest extends UnitTestCase
     {
         $subject = new StandardCacheWarmer();
         $method = new \ReflectionMethod($subject, 'detectControllerNamesInTemplateRootPaths');
-        $method->setAccessible(true);
         $directory = realpath(__DIR__ . '/../../../../examples/Resources/Private/Templates/');
         $generator = $method->invokeArgs($subject, [[$directory]]);
         foreach ($generator as $resolvedControllerName) {
@@ -120,7 +119,6 @@ class StandardCacheWarmerTest extends UnitTestCase
         $context->setVariableProvider($variableProvider);
         $context->setTemplateParser($parser);
         $method = new \ReflectionMethod($subject, 'warmSingleFile');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($subject, ['/some/file', 'some_file', $context]);
         self::assertInstanceOf(ParsedTemplateInterface::class, $result);
         self::assertAttributeNotEmpty('failureReason', $result);
@@ -134,7 +132,6 @@ class StandardCacheWarmerTest extends UnitTestCase
     {
         $subject = new StandardCacheWarmer();
         $method = new \ReflectionMethod($subject, 'createClosure');
-        $method->setAccessible(true);
         $closure = $method->invokeArgs($subject, [__FILE__]);
         self::assertNotEmpty($closure(new TemplateParser(), new TemplatePaths()));
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -55,7 +55,6 @@ class AbstractNodeTest extends UnitTestCase
         $this->expectException(Exception::class);
         $this->childNode->expects(self::once())->method('evaluate')->with($this->renderingContext)->willReturn(new \DateTime('now'));
         $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
-        $method->setAccessible(true);
         $method->invokeArgs($this->abstractNode, [$this->childNode, $this->renderingContext, true]);
     }
 
@@ -67,7 +66,6 @@ class AbstractNodeTest extends UnitTestCase
         $withToString = new UserWithToString('foobar');
         $this->childNode->expects(self::once())->method('evaluate')->with($this->renderingContext)->willReturn($withToString);
         $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($this->abstractNode, [$this->childNode, $this->renderingContext, true]);
         self::assertEquals('foobar', $result);
     }
@@ -82,7 +80,6 @@ class AbstractNodeTest extends UnitTestCase
         $this->childNode->expects(self::once())->method('evaluate')->with($this->renderingContext)->willReturn('foo');
         $this->abstractNode->addChildNode($child2);
         $method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNodes');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($this->abstractNode, [$this->renderingContext, true]);
         self::assertEquals('foobar', $result);
     }

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -54,7 +54,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($context);
         $method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render', []]);
         self::assertNull($result);
     }
@@ -73,7 +72,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($context);
         $method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render', []]);
         self::assertNull($result);
     }
@@ -90,7 +88,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($context);
         $method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render']);
         self::assertFalse($result);
     }
@@ -109,7 +106,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($context);
         $method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render']);
         self::assertFalse($result);
     }
@@ -136,7 +132,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($renderingContext);
         $method = new \ReflectionMethod($templateParser, 'buildObjectTree');
-        $method->setAccessible(true);
         $method->invokeArgs($templateParser, [['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
     }
 
@@ -578,7 +573,6 @@ class TemplateParserTest extends UnitTestCase
 
         $text = ' {someThing.absolutely} "fishy" is \'going\' {on: "here"}';
         $method = new \ReflectionMethod(TemplateParser::class, 'textAndShorthandSyntaxHandler');
-        $method->setAccessible(true);
         $method->invokeArgs($templateParser, [$mockState, $text, TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
     }
 
@@ -808,7 +802,6 @@ class TemplateParserTest extends UnitTestCase
         $templateParser = new TemplateParser();
         $templateParser->setRenderingContext($context);
         $method = new \ReflectionMethod($templateParser, 'recursiveArrayHandler');
-        $method->setAccessible(true);
         $result = $method->invokeArgs($templateParser, [$state, $string]);
 
         self::assertEquals($expected, $result);

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -292,7 +292,6 @@ class AbstractViewHelperTest extends UnitTestCase
     {
         $subject = new RenderMethodFreeViewHelper();
         $method = new \ReflectionMethod($subject, 'callRenderMethod');
-        $method->setAccessible(true);
         $subject->setRenderingContext(new RenderingContextFixture());
         $result = $method->invoke($subject);
         self::assertSame('I was rendered', $result);
@@ -306,7 +305,6 @@ class AbstractViewHelperTest extends UnitTestCase
         $this->expectException(Exception::class);
         $subject = new RenderMethodFreeDefaultRenderStaticViewHelper();
         $method = new \ReflectionMethod($subject, 'callRenderMethod');
-        $method->setAccessible(true);
         $subject->setRenderingContext(new RenderingContextFixture());
         $method->invoke($subject);
     }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -41,7 +41,6 @@ class TemplatePathsTest extends BaseTestCase
     {
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'sanitizePath');
-        $method->setAccessible(true);
         $output = $method->invokeArgs($instance, [$input]);
         self::assertEquals($expected, $output);
     }
@@ -63,7 +62,6 @@ class TemplatePathsTest extends BaseTestCase
     {
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'sanitizePaths');
-        $method->setAccessible(true);
         $output = $method->invokeArgs($instance, [$input]);
         self::assertEquals($expected, $output);
     }
@@ -184,7 +182,6 @@ class TemplatePathsTest extends BaseTestCase
     {
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'resolveFilesInFolders');
-        $method->setAccessible(true);
         $result = $method->invokeArgs(
             $instance,
             [['examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'], 'html']
@@ -234,7 +231,6 @@ class TemplatePathsTest extends BaseTestCase
         $this->expectException(InvalidTemplateResourceException::class);
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
-        $method->setAccessible(true);
         $method->invokeArgs($instance, [['/not/', '/found/'], 'notfound.html']);
     }
 


### PR DESCRIPTION
setAccessible is a no-op since PHP 8.1
and can be removed.