### PR TITLE
[TASK] Avoid and deprecate getMock()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -88,12 +88,7 @@ abstract class BaseTestCase extends TestCase
     }
 
     /**
-     * Returns a mock object which allows for calling protected methods and access
-     * of protected properties.
-     *
-     * @template T of object
-     * @param class-string<T> $originalClassName Full qualified name of the original class
-     * @return MockObject&T
+     * @deprecated Unused. Will be removed. Use createMock() or getMockBuilder() directly.
      */
     protected function getMock(
         string $originalClassName,
@@ -121,12 +116,6 @@ abstract class BaseTestCase extends TestCase
     }
 
     /**
-     * Returns a mock object which allows for calling protected methods and access
-     * of protected properties.
-     *
-     * @template T of object
-     * @param class-string<T> $originalClassName Full qualified name of the original class
-     * @return MockObject&AccessibleObjectInterface&T
      * @deprecated Unused. Will be removed.
      */
     protected function getAccessibleMockForAbstractClass(

--- a/tests/Functional/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Functional/Core/Cache/SimpleFileCacheTest.php
@@ -68,13 +68,11 @@ class SimpleFileCacheTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
-    public function flushAll(): void
+    public function flushWithoutNameCallsGetCachedFilenamesAndFlushByFilename(): void
     {
-        $cache = $this->getMock(
-            SimpleFileCache::class,
-            ['getCachedFilenames', 'flushByFilename', 'flushByname'],
-            [self::$cachePath]
-        );
+        $cache = $this->getMockBuilder(SimpleFileCache::class)
+            ->onlyMethods(['getCachedFilenames', 'flushByFilename', 'flushByName'])
+            ->getMock();
         $cache->expects(self::never())->method('flushByName');
         $cache->expects(self::once())->method('getCachedFilenames')->willReturn(['foo']);
         $cache->expects(self::once())->method('flushByFilename')->with('foo');
@@ -84,13 +82,11 @@ class SimpleFileCacheTest extends AbstractFunctionalTestCase
     /**
      * @test
      */
-    public function flushByName(): void
+    public function flushWithNameCallsFlushByName(): void
     {
-        $cache = $this->getMock(
-            SimpleFileCache::class,
-            ['getCachedFilenames', 'flushByFilename', 'flushByname'],
-            [self::$cachePath]
-        );
+        $cache = $this->getMockBuilder(SimpleFileCache::class)
+            ->onlyMethods(['getCachedFilenames', 'flushByFilename', 'flushByName'])
+            ->getMock();
         $cache->expects(self::once())->method('flushByName')->with('foo');
         $cache->expects(self::never())->method('getCachedFilenames');
         $cache->expects(self::never())->method('flushByFilename');

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -113,7 +113,7 @@ class StandardCacheWarmerTest extends UnitTestCase
     {
         $subject = new StandardCacheWarmer();
         $context = new RenderingContextFixture();
-        $parser = $this->getMock(TemplateParser::class, ['getOrParseAndStoreTemplate']);
+        $parser = $this->createMock(TemplateParser::class);
         $parser->expects(self::once())->method('getOrParseAndStoreTemplate')->willThrowException($error);
         $variableProvider = new StandardVariableProvider(['foo' => 'bar']);
         $context->setVariableProvider($variableProvider);

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -15,7 +15,6 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionNodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\TernaryExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
@@ -36,32 +35,6 @@ class NodeConverterTest extends UnitTestCase
         $instance = new NodeConverter(new TemplateCompiler());
         $instance->setVariableCounter(10);
         self::assertAttributeEquals(10, 'variableCounter', $instance);
-    }
-
-    public static function convertCallsExpectedMethodDataProvider(): array
-    {
-        return [
-            [TextNode::class, 'convertTextNode'],
-            [ExpressionNodeInterface::class, 'convertExpressionNode'],
-            [NumericNode::class, 'convertNumericNode'],
-            [ViewHelperNode::class, 'convertViewHelperNode'],
-            [ObjectAccessorNode::class, 'convertObjectAccessorNode'],
-            [ArrayNode::class, 'convertArrayNode'],
-            [RootNode::class, 'convertListOfSubNodes'],
-            [BooleanNode::class, 'convertBooleanNode'],
-            [EscapingNode::class, 'convertEscapingNode'],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider convertCallsExpectedMethodDataProvider
-     */
-    public function convertCallsExpectedMethod(string $nodeName, string $expected): void
-    {
-        $instance = $this->getMock(NodeConverter::class, [$expected], [], false, false);
-        $instance->expects(self::once())->method($expected);
-        $instance->convert($this->getMock($nodeName, [], [], false, false));
     }
 
     public static function convertReturnsExpectedExecutionDataProvider(): array

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -100,7 +100,7 @@ class EscapeTest extends UnitTestCase
     public function processWrapsCurrentViewHelperInEscapeNode(): void
     {
         $interceptorPosition = InterceptorInterface::INTERCEPT_OBJECTACCESSOR;
-        $mockNode = $this->getMock(ObjectAccessorNode::class, [], [], false, false);
+        $mockNode = $this->createMock(ObjectAccessorNode::class);
         $actualResult = $this->escapeInterceptor->process($mockNode, $interceptorPosition, $this->mockParsingState);
         self::assertInstanceOf(EscapingNode::class, $actualResult);
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -565,10 +565,10 @@ class BooleanNodeTest extends UnitTestCase
 
         $rootNode = new RootNode();
 
-        $object1Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object1Node = $this->createMock(ObjectAccessorNode::class);
         $object1Node->expects(self::any())->method('evaluate')->willReturn($object1);
 
-        $object2Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object2Node = $this->createMock(ObjectAccessorNode::class);
         $object2Node->expects(self::any())->method('evaluate')->willReturn($object2);
 
         $rootNode->addChildNode($object1Node);
@@ -590,10 +590,10 @@ class BooleanNodeTest extends UnitTestCase
 
         $rootNode = new RootNode();
 
-        $object1Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object1Node = $this->createMock(ObjectAccessorNode::class);
         $object1Node->expects(self::any())->method('evaluate')->willReturn($object1);
 
-        $object2Node = $this->getMock(ObjectAccessorNode::class, ['evaluate'], ['foo']);
+        $object2Node = $this->createMock(ObjectAccessorNode::class);
         $object2Node->expects(self::any())->method('evaluate')->willReturn($object2);
 
         $rootNode->addChildNode($object1Node);

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -23,7 +23,7 @@ class CastingExpressionNodeTest extends UnitTestCase
      */
     public function testEvaluateDelegatesToEvaluteExpression(): void
     {
-        $subject = $this->getMock(CastingExpressionNode::class, [], ['{test as string}', ['test as string']]);
+        $subject = new CastingExpressionNode('{test as string}', ['test as string']);
         $context = new RenderingContext();
         $context->setVariableProvider(new StandardVariableProvider(['test' => 10]));
         $result = $subject->evaluate($context);

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -37,7 +37,7 @@ class ObjectAccessorNodeTest extends UnitTestCase
     public function testEvaluateGetsExpectedValue(array $variables, string $path, $expected): void
     {
         $node = new ObjectAccessorNode($path);
-        $renderingContext = $this->getMock(RenderingContextInterface::class);
+        $renderingContext = $this->createMock(RenderingContextInterface::class);
         $variableContainer = new StandardVariableProvider($variables);
         $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);
@@ -50,8 +50,8 @@ class ObjectAccessorNodeTest extends UnitTestCase
     public function testEvaluatedUsesVariableProviderGetByPath(): void
     {
         $node = new ObjectAccessorNode('foo.bar');
-        $renderingContext = $this->getMock(RenderingContextInterface::class);
-        $variableContainer = $this->getMock(StandardVariableProvider::class);
+        $renderingContext = $this->createMock(RenderingContextInterface::class);
+        $variableContainer = $this->createMock(StandardVariableProvider::class);
         $variableContainer->expects(self::once())->method('getByPath')->with('foo.bar')->willReturn('foo');
         $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -20,7 +20,7 @@ class RootNodeTest extends UnitTestCase
      */
     public function testEvaluateCallsEvaluateChildNodes(): void
     {
-        $subject = $this->getMock(RootNode::class, ['evaluateChildNodes']);
+        $subject = $this->getMockBuilder(RootNode::class)->onlyMethods(['evaluateChildNodes'])->getMock();
         $subject->expects(self::once())->method('evaluateChildNodes');
         $subject->evaluate(new RenderingContext());
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -35,7 +35,7 @@ class ViewHelperNodeTest extends UnitTestCase
     public function setUp(): void
     {
         $this->renderingContext = new RenderingContextFixture();
-        $this->mockViewHelperResolver = $this->getMock(ViewHelperResolver::class, ['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName', 'getArgumentDefinitionsForViewHelper']);
+        $this->mockViewHelperResolver = $this->createMock(ViewHelperResolver::class);
         $this->mockViewHelperResolver->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
         $this->mockViewHelperResolver->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
         $this->mockViewHelperResolver->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([
@@ -60,7 +60,7 @@ class ViewHelperNodeTest extends UnitTestCase
      */
     public function testEvaluateCallsInvoker(): void
     {
-        $invoker = $this->getMock(ViewHelperInvoker::class, ['invoke']);
+        $invoker = $this->createMock(ViewHelperInvoker::class);
         $invoker->expects(self::once())->method('invoke')->willReturn('test');
         $this->renderingContext->setViewHelperInvoker($invoker);
         $node = new ViewHelperNode($this->renderingContext, 'f', 'vh', ['foo' => 'bar'], new ParsingState());

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -47,14 +47,14 @@ class TemplateParserTest extends UnitTestCase
      */
     public function testInitializeViewHelperAndAddItToStackReturnsFalseIfNamespaceIgnored(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceIgnored']);
+        $resolver = $this->createMock(ViewHelperResolver::class);
         $resolver->expects(self::once())->method('isNamespaceIgnored')->willReturn(true);
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($context);
-        $method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
-        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render', []]);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($context);
+        $method = new \ReflectionMethod($subject, 'initializeViewHelperAndAddItToStack');
+        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render', []]);
         self::assertNull($result);
     }
 
@@ -64,15 +64,15 @@ class TemplateParserTest extends UnitTestCase
     public function testInitializeViewHelperAndAddItToStackThrowsExceptionIfNamespaceInvalid(): void
     {
         $this->expectException(UnknownNamespaceException::class);
-        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceIgnored', 'isNamespaceValid']);
+        $resolver = $this->createMock(ViewHelperResolver::class);
         $resolver->expects(self::once())->method('isNamespaceIgnored')->willReturn(false);
         $resolver->expects(self::once())->method('isNamespaceValid')->willReturn(false);
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($context);
-        $method = new \ReflectionMethod($templateParser, 'initializeViewHelperAndAddItToStack');
-        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render', []]);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($context);
+        $method = new \ReflectionMethod($subject, 'initializeViewHelperAndAddItToStack');
+        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render', []]);
         self::assertNull($result);
     }
 
@@ -81,14 +81,14 @@ class TemplateParserTest extends UnitTestCase
      */
     public function testClosingViewHelperTagHandlerReturnsFalseIfNamespaceIgnored(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceIgnored']);
+        $resolver = $this->createMock(ViewHelperResolver::class);
         $resolver->expects(self::once())->method('isNamespaceIgnored')->willReturn(true);
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($context);
-        $method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
-        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render']);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($context);
+        $method = new \ReflectionMethod($subject, 'closingViewHelperTagHandler');
+        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render']);
         self::assertFalse($result);
     }
 
@@ -98,15 +98,15 @@ class TemplateParserTest extends UnitTestCase
     public function testClosingViewHelperTagHandlerThrowsExceptionIfNamespaceInvalid(): void
     {
         $this->expectException(UnknownNamespaceException::class);
-        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceValid', 'isNamespaceIgnored']);
+        $resolver = $this->createMock(ViewHelperResolver::class);
         $resolver->expects(self::once())->method('isNamespaceIgnored')->willReturn(false);
         $resolver->expects(self::once())->method('isNamespaceValid')->willReturn(false);
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($context);
-        $method = new \ReflectionMethod($templateParser, 'closingViewHelperTagHandler');
-        $result = $method->invokeArgs($templateParser, [new ParsingState(), 'f', 'render']);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($context);
+        $method = new \ReflectionMethod($subject, 'closingViewHelperTagHandler');
+        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render']);
         self::assertFalse($result);
     }
 
@@ -129,10 +129,10 @@ class TemplateParserTest extends UnitTestCase
         $this->expectException(Exception::class);
         $renderingContext = new RenderingContextFixture();
         $renderingContext->setVariableProvider(new StandardVariableProvider());
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($renderingContext);
-        $method = new \ReflectionMethod($templateParser, 'buildObjectTree');
-        $method->invokeArgs($templateParser, [['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($renderingContext);
+        $method = new \ReflectionMethod($subject, 'buildObjectTree');
+        $method->invokeArgs($subject, [['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
     }
 
     /**
@@ -140,7 +140,7 @@ class TemplateParserTest extends UnitTestCase
      */
     public function testParseCallsPreProcessOnTemplateProcessors(): void
     {
-        $templateParser = new TemplateParser();
+        $subject = new TemplateParser();
         $processor1 = $this->getMockForAbstractClass(TemplateProcessorInterface::class, [], '', false, false, true, ['preProcessSource']);
         $processor2 = clone $processor1;
         $processor1->expects(self::once())->method('preProcessSource')->with('source1')->willReturn('source2');
@@ -148,8 +148,8 @@ class TemplateParserTest extends UnitTestCase
         $context = new RenderingContextFixture();
         $context->setTemplateProcessors([$processor1, $processor2]);
         $context->setVariableProvider(new StandardVariableProvider());
-        $templateParser->setRenderingContext($context);
-        $result = $templateParser->parse('source1')->render($context);
+        $subject->setRenderingContext($context);
+        $result = $subject->parse('source1')->render($context);
         self::assertEquals('final', $result);
     }
 
@@ -160,10 +160,10 @@ class TemplateParserTest extends UnitTestCase
     {
         $parsedTemplate = new ParsingState();
         $parsedTemplate->setCompilable(true);
-        $templateParser = $this->getMock(TemplateParser::class, ['parse']);
-        $templateParser->expects(self::once())->method('parse')->willReturn($parsedTemplate);
+        $subject = $this->getMockBuilder(TemplateParser::class)->onlyMethods(['parse'])->getMock();
+        $subject->expects(self::once())->method('parse')->willReturn($parsedTemplate);
         $context = new RenderingContextFixture();
-        $compiler = $this->getMock(TemplateCompiler::class, ['store', 'get', 'has']);
+        $compiler = $this->createMock(TemplateCompiler::class);
         $compiler->expects(self::never())->method('get');
         $compiler->expects(self::atLeastOnce())->method('has')->willReturn(false);
         $compiler->expects(self::atLeastOnce())->method('store')->willReturnOnConsecutiveCalls(
@@ -172,8 +172,8 @@ class TemplateParserTest extends UnitTestCase
         );
         $context->setTemplateCompiler($compiler);
         $context->setVariableProvider(new StandardVariableProvider());
-        $templateParser->setRenderingContext($context);
-        $result = $templateParser->getOrParseAndStoreTemplate('fake-foo-baz', function ($a, $b) {
+        $subject->setRenderingContext($context);
+        $result = $subject->getOrParseAndStoreTemplate('fake-foo-baz', function ($a, $b) {
             return 'test';
         });
         self::assertSame($parsedTemplate, $result);
@@ -186,8 +186,7 @@ class TemplateParserTest extends UnitTestCase
     public function parseThrowsExceptionWhenStringArgumentMissing(): void
     {
         $this->expectException(\Exception::class);
-        $templateParser = new TemplateParser();
-        $templateParser->parse(123);
+        (new TemplateParser())->parse(123);
     }
 
     public static function quotedStrings(): array
@@ -208,8 +207,8 @@ class TemplateParserTest extends UnitTestCase
      */
     public function unquoteStringReturnsUnquotedStrings(string $quoted, string $unquoted): void
     {
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        self::assertEquals($unquoted, $templateParser->_call('unquoteString', $quoted));
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        self::assertEquals($unquoted, $subject->_call('unquoteString', $quoted));
     }
 
     public static function templatesToSplit()
@@ -229,8 +228,8 @@ class TemplateParserTest extends UnitTestCase
     {
         $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html');
         $expectedResult = require __DIR__ . '/Fixtures/' . $templateName . '-split.php';
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        self::assertSame($expectedResult, $templateParser->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        self::assertSame($expectedResult, $subject->_call('splitTemplateAtDynamicTags', $template), 'Filed for ' . $templateName);
     }
 
     /**
@@ -240,9 +239,9 @@ class TemplateParserTest extends UnitTestCase
     {
         $context = new RenderingContextFixture();
         $context->setVariableProvider(new StandardVariableProvider());
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->setRenderingContext($context);
-        $result = $templateParser->_call('buildObjectTree', [], TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->setRenderingContext($context);
+        $result = $subject->_call('buildObjectTree', [], TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
         self::assertInstanceOf(ParsingState::class, $result);
     }
 
@@ -251,7 +250,7 @@ class TemplateParserTest extends UnitTestCase
      */
     public function buildObjectTreeDelegatesHandlingOfTemplateElements(): void
     {
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             [
                 'textHandler',
@@ -262,9 +261,9 @@ class TemplateParserTest extends UnitTestCase
         );
         $context = new RenderingContextFixture();
         $context->setVariableProvider(new StandardVariableProvider());
-        $templateParser->setRenderingContext($context);
-        $splitTemplate = $templateParser->_call('splitTemplateAtDynamicTags', 'The first part is simple<![CDATA[<f:for each="{a: {a: 0, b: 2, c: 4}}" as="array"><f:for each="{array}" as="value">{value} </f:for>]]><f:format.printf arguments="{number : 362525200}">%.3e</f:format.printf>and here goes some {text} that could have {shorthand}');
-        $result = $templateParser->_call('buildObjectTree', $splitTemplate, TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+        $subject->setRenderingContext($context);
+        $splitTemplate = $subject->_call('splitTemplateAtDynamicTags', 'The first part is simple<![CDATA[<f:for each="{a: {a: 0, b: 2, c: 4}}" as="array"><f:for each="{array}" as="value">{value} </f:for>]]><f:format.printf arguments="{number : 362525200}">%.3e</f:format.printf>and here goes some {text} that could have {shorthand}');
+        $result = $subject->_call('buildObjectTree', $splitTemplate, TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
         self::assertInstanceOf(ParsingState::class, $result);
     }
 
@@ -273,9 +272,9 @@ class TemplateParserTest extends UnitTestCase
      */
     public function openingViewHelperTagHandlerDelegatesViewHelperInitialization(): void
     {
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::never())->method('popNodeFromStack');
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['parseArguments', 'initializeViewHelperAndAddItToStack']
         );
@@ -284,13 +283,13 @@ class TemplateParserTest extends UnitTestCase
         $resolver->expects(self::once())->method('isNamespaceValid')->with('namespaceIdentifier')->willReturn(true);
         $resolver->expects(self::once())->method('resolveViewHelperClassName')->with('namespaceIdentifier')->willReturn(CommentViewHelper::class);
         $context->setViewHelperResolver($resolver);
-        $templateParser->setRenderingContext($context);
-        $templateParser->expects(self::once())->method('parseArguments')
+        $subject->setRenderingContext($context);
+        $subject->expects(self::once())->method('parseArguments')
             ->with(['arguments'])->willReturn(['parsedArguments']);
-        $templateParser->expects(self::once())->method('initializeViewHelperAndAddItToStack')
+        $subject->expects(self::once())->method('initializeViewHelperAndAddItToStack')
             ->with($mockState, 'namespaceIdentifier', 'methodIdentifier', ['parsedArguments']);
 
-        $templateParser->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', ['arguments'], false, '');
+        $subject->_call('openingViewHelperTagHandler', $mockState, 'namespaceIdentifier', 'methodIdentifier', ['arguments'], false, '');
     }
 
     /**
@@ -298,9 +297,9 @@ class TemplateParserTest extends UnitTestCase
      */
     public function openingViewHelperTagHandlerPopsNodeFromStackForSelfClosingTags(): void
     {
-        $mockState = $this->getMock(ParsingState::class);
-        $mockState->expects(self::once())->method('popNodeFromStack')->willReturn($this->getMock(NodeInterface::class));
-        $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($this->getMock(NodeInterface::class));
+        $mockState = $this->createMock(ParsingState::class);
+        $mockState->expects(self::once())->method('popNodeFromStack')->willReturn($this->createMock(NodeInterface::class));
+        $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($this->createMock(NodeInterface::class));
 
         $resolver = $this->getMockBuilder(ViewHelperResolver::class)->onlyMethods(['isNamespaceValid', 'isNamespaceIgnored', 'resolveViewHelperClassName'])->getMock();
         $resolver->expects(self::once())->method('isNamespaceIgnored')->with('')->willReturn(false);
@@ -310,15 +309,15 @@ class TemplateParserTest extends UnitTestCase
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['parseArguments', 'initializeViewHelperAndAddItToStack']
         );
-        $templateParser->setRenderingContext($context);
-        $node = $this->getMock(ViewHelperNode::class, [], [], false, false);
-        $templateParser->expects(self::once())->method('initializeViewHelperAndAddItToStack')->willReturn($node);
+        $subject->setRenderingContext($context);
+        $node = $this->createMock(ViewHelperNode::class);
+        $subject->expects(self::once())->method('initializeViewHelperAndAddItToStack')->willReturn($node);
 
-        $templateParser->_call('openingViewHelperTagHandler', $mockState, '', '', [], true, '');
+        $subject->_call('openingViewHelperTagHandler', $mockState, '', '', [], true, '');
     }
 
     /**
@@ -327,10 +326,8 @@ class TemplateParserTest extends UnitTestCase
     public function initializeViewHelperAndAddItToStackThrowsExceptionIfViewHelperClassNameIsWronglyCased()
     {
         $this->expectException(\Exception::class);
-
-        $mockState = $this->getMock(ParsingState::class);
-
-        $templateParser = $this->getAccessibleMock(
+        $mockState = $this->createMock(ParsingState::class);
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             [
                 'abortIfUnregisteredArgumentsExist',
@@ -339,7 +336,7 @@ class TemplateParserTest extends UnitTestCase
             ]
         );
 
-        $templateParser->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'wRongLyCased', ['arguments']);
+        $subject->_call('initializeViewHelperAndAddItToStack', $mockState, 'f', 'wRongLyCased', ['arguments']);
     }
 
     /**
@@ -349,14 +346,14 @@ class TemplateParserTest extends UnitTestCase
     {
         $this->expectException(\Exception::class);
 
-        $mockNodeOnStack = $this->getMock(NodeInterface::class, [], [], false, false);
-        $mockState = $this->getMock(ParsingState::class);
+        $mockNodeOnStack = $this->createMock(NodeInterface::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('popNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_set('renderingContext', new RenderingContextFixture());
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_set('renderingContext', new RenderingContextFixture());
 
-        $templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
+        $subject->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
     }
 
     /**
@@ -366,10 +363,10 @@ class TemplateParserTest extends UnitTestCase
     {
         $this->expectException(\Exception::class);
 
-        $mockState = $this->getMock(ParsingState::class);
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_set('renderingContext', new RenderingContextFixture());
-        $templateParser->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
+        $mockState = $this->createMock(ParsingState::class);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_set('renderingContext', new RenderingContextFixture());
+        $subject->_call('closingViewHelperTagHandler', $mockState, 'f', 'render');
     }
 
     /**
@@ -377,24 +374,22 @@ class TemplateParserTest extends UnitTestCase
      */
     public function objectAccessorHandlerCallsInitializeViewHelperAndAddItToStackIfViewHelperSyntaxIsPresent(): void
     {
-        $mockState = $this->getMock(ParsingState::class);
-        $mockState->expects(self::exactly(2))->method('popNodeFromStack')
-            ->willReturn($this->getMock(NodeInterface::class));
-        $mockState->expects(self::exactly(2))->method('getNodeFromStack')
-            ->willReturn($this->getMock(NodeInterface::class));
+        $mockState = $this->createMock(ParsingState::class);
+        $mockState->expects(self::exactly(2))->method('popNodeFromStack')->willReturn($this->createMock(NodeInterface::class));
+        $mockState->expects(self::exactly(2))->method('getNodeFromStack')->willReturn($this->createMock(NodeInterface::class));
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['recursiveArrayHandler', 'initializeViewHelperAndAddItToStack']
         );
-        $templateParser->setRenderingContext(new RenderingContextFixture());
-        $templateParser->expects(self::atLeastOnce())->method('recursiveArrayHandler')
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $subject->expects(self::atLeastOnce())->method('recursiveArrayHandler')
             ->with($mockState, 'arguments: {0: \'foo\'}')->willReturn(['arguments' => ['foo']]);
         $series = [
             [$mockState, 'f', 'format.printf', ['arguments' => ['foo']]],
             [$mockState, 'f', 'debug', []],
         ];
-        $templateParser->expects(self::atLeastOnce())->method('initializeViewHelperAndAddItToStack')->willReturnCallback(function (...$args) use (&$series): bool {
+        $subject->expects(self::atLeastOnce())->method('initializeViewHelperAndAddItToStack')->willReturnCallback(function (...$args) use (&$series): bool {
             $expectedArgs = array_shift($series);
             self::assertSame($expectedArgs[0], $args[0]);
             self::assertSame($expectedArgs[1], $args[1]);
@@ -402,7 +397,7 @@ class TemplateParserTest extends UnitTestCase
             self::assertSame($expectedArgs[3], $args[3]);
             return true;
         });
-        $templateParser->_call('objectAccessorHandler', $mockState, '', '', 'f:debug() -> f:format.printf(arguments: {0: \'foo\'})', '');
+        $subject->_call('objectAccessorHandler', $mockState, '', '', 'f:debug() -> f:format.printf(arguments: {0: \'foo\'})', '');
     }
 
     /**
@@ -412,12 +407,12 @@ class TemplateParserTest extends UnitTestCase
     {
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false, false, ['addChildNode']);
         $mockNodeOnStack->expects(self::once())->method('addChildNode')->with(self::anything());
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
 
-        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+        $subject->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
     }
 
     /**
@@ -425,24 +420,24 @@ class TemplateParserTest extends UnitTestCase
      */
     public function valuesFromObjectAccessorsAreRunThroughEscapingInterceptorsByDefault(): void
     {
-        $objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
+        $objectAccessorNodeInterceptor = $this->createMock(InterceptorInterface::class);
         $objectAccessorNodeInterceptor->expects(self::once())->method('process')
             ->with(self::anything())->willReturnArgument(0);
 
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::any())->method('getInterceptors')->willReturn([]);
         $parserConfiguration->expects(self::once())->method('getEscapingInterceptors')
             ->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)
             ->willReturn([$objectAccessorNodeInterceptor]);
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false);
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_set('configuration', $parserConfiguration);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_set('configuration', $parserConfiguration);
 
-        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+        $subject->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
     }
 
     /**
@@ -450,19 +445,19 @@ class TemplateParserTest extends UnitTestCase
      */
     public function valuesFromObjectAccessorsAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled(): void
     {
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::any())->method('getInterceptors')->willReturn([]);
         $parserConfiguration->expects(self::never())->method('getEscapingInterceptors');
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false);
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_set('configuration', $parserConfiguration);
-        $templateParser->_set('escapingEnabled', false);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_set('configuration', $parserConfiguration);
+        $subject->_set('escapingEnabled', false);
 
-        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+        $subject->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
     }
 
     /**
@@ -470,24 +465,24 @@ class TemplateParserTest extends UnitTestCase
      */
     public function valuesFromObjectAccessorsAreRunThroughInterceptors(): void
     {
-        $objectAccessorNodeInterceptor = $this->getMock(InterceptorInterface::class);
+        $objectAccessorNodeInterceptor = $this->createMock(InterceptorInterface::class);
         $objectAccessorNodeInterceptor->expects(self::once())->method('process')
             ->with(self::anything())->willReturnArgument(0);
 
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::any())->method('getEscapingInterceptors')->willReturn([]);
         $parserConfiguration->expects(self::once())->method('getInterceptors')
             ->with(InterceptorInterface::INTERCEPT_OBJECTACCESSOR)->willReturn([$objectAccessorNodeInterceptor]);
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false);
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_set('configuration', $parserConfiguration);
-        $templateParser->_set('escapingEnabled', false);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_set('configuration', $parserConfiguration);
+        $subject->_set('escapingEnabled', false);
 
-        $templateParser->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
+        $subject->_call('objectAccessorHandler', $mockState, 'objectAccessorString', '', '', '');
     }
 
     public static function argumentsStrings(): array
@@ -509,11 +504,11 @@ class TemplateParserTest extends UnitTestCase
         $viewHelper = $this->getMockBuilder(CommentViewHelper::class)->onlyMethods(['validateAdditionalArguments'])->getMock();
         $viewHelper->expects(self::once())->method('validateAdditionalArguments');
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['buildArgumentObjectTree']);
-        $templateParser->setRenderingContext($context);
-        $templateParser->expects(self::any())->method('buildArgumentObjectTree')->willReturnArgument(0);
+        $subject = $this->getAccessibleMock(TemplateParser::class, ['buildArgumentObjectTree']);
+        $subject->setRenderingContext($context);
+        $subject->expects(self::any())->method('buildArgumentObjectTree')->willReturnArgument(0);
 
-        self::assertSame($expected, $templateParser->_call('parseArguments', $argumentsString, $viewHelper));
+        self::assertSame($expected, $subject->_call('parseArguments', $argumentsString, $viewHelper));
     }
 
     /**
@@ -521,8 +516,8 @@ class TemplateParserTest extends UnitTestCase
      */
     public function buildArgumentObjectTreeReturnsTextNodeForSimplyString(): void
     {
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $this->assertInstanceof(TextNode::class, $templateParser->_call('buildArgumentObjectTree', 'a very plain string'));
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $this->assertInstanceof(TextNode::class, $subject->_call('buildArgumentObjectTree', 'a very plain string'));
     }
 
     /**
@@ -530,19 +525,19 @@ class TemplateParserTest extends UnitTestCase
      */
     public function buildArgumentObjectTreeBuildsObjectTreeForComlexString(): void
     {
-        $objectTree = $this->getMock(ParsingState::class);
+        $objectTree = $this->createMock(ParsingState::class);
         $objectTree->expects(self::once())->method('getRootNode')->willReturn('theRootNode');
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['splitTemplateAtDynamicTags', 'buildObjectTree']
         );
-        $templateParser->expects(self::atLeastOnce())->method('splitTemplateAtDynamicTags')
+        $subject->expects(self::atLeastOnce())->method('splitTemplateAtDynamicTags')
             ->with('a <very> {complex} string')->willReturn(['split string']);
-        $templateParser->expects(self::atLeastOnce())->method('buildObjectTree')
+        $subject->expects(self::atLeastOnce())->method('buildObjectTree')
             ->with(['split string'])->willReturn($objectTree);
 
-        self::assertEquals('theRootNode', $templateParser->_call('buildArgumentObjectTree', 'a <very> {complex} string'));
+        self::assertEquals('theRootNode', $subject->_call('buildArgumentObjectTree', 'a <very> {complex} string'));
     }
 
     /**
@@ -550,30 +545,29 @@ class TemplateParserTest extends UnitTestCase
      */
     public function textAndShorthandSyntaxHandlerDelegatesAppropriately(): void
     {
-        $mockState = $this->getMock(ParsingState::class, ['getNodeFromStack']);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::any())->method('getNodeFromStack')->willReturn(new RootNode());
 
-        $templateParser = $this->getMock(
-            TemplateParser::class,
-            ['objectAccessorHandler', 'arrayHandler', 'textHandler']
-        );
+        $subject = $this->getMockBuilder(TemplateParser::class)
+            ->onlyMethods(['objectAccessorHandler', 'arrayHandler', 'textHandler'])
+            ->getMock();
         $context = new RenderingContextFixture();
-        $templateParser->setRenderingContext($context);
+        $subject->setRenderingContext($context);
         $series = [
             [$mockState, ' '],
             [$mockState, ' "fishy" is \'going\' ']
         ];
-        $templateParser->expects(self::atLeastOnce())->method('textHandler')->willReturnCallback(function (...$args) use (&$series): void {
+        $subject->expects(self::atLeastOnce())->method('textHandler')->willReturnCallback(function (...$args) use (&$series): void {
             [$expectedArgOne, $expectedArgTwo] = array_shift($series);
             self::assertSame($expectedArgOne, $args[0]);
             self::assertSame($expectedArgTwo, $args[1]);
         });
-        $templateParser->expects(self::atLeastOnce())->method('objectAccessorHandler')->with($mockState, 'someThing.absolutely', '', '', '');
-        $templateParser->expects(self::atLeastOnce())->method('arrayHandler')->with($mockState, self::anything());
+        $subject->expects(self::atLeastOnce())->method('objectAccessorHandler')->with($mockState, 'someThing.absolutely', '', '', '');
+        $subject->expects(self::atLeastOnce())->method('arrayHandler')->with($mockState, self::anything());
 
         $text = ' {someThing.absolutely} "fishy" is \'going\' {on: "here"}';
         $method = new \ReflectionMethod(TemplateParser::class, 'textAndShorthandSyntaxHandler');
-        $method->invokeArgs($templateParser, [$mockState, $text, TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
+        $method->invokeArgs($subject, [$mockState, $text, TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
     }
 
     /**
@@ -583,17 +577,17 @@ class TemplateParserTest extends UnitTestCase
     {
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false, false, ['addChildNode']);
         $mockNodeOnStack->expects(self::once())->method('addChildNode')->with(self::anything());
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['recursiveArrayHandler']
         );
-        $templateParser->expects(self::any())->method('recursiveArrayHandler')
+        $subject->expects(self::any())->method('recursiveArrayHandler')
             ->with(['arrayText'])->willReturn('processedArrayText');
 
-        $templateParser->_call('arrayHandler', $mockState, ['arrayText']);
+        $subject->_call('arrayHandler', $mockState, ['arrayText']);
     }
 
     /**
@@ -601,23 +595,23 @@ class TemplateParserTest extends UnitTestCase
      */
     public function textNodesAreRunThroughEscapingInterceptorsByDefault(): void
     {
-        $textInterceptor = $this->getMock(InterceptorInterface::class);
+        $textInterceptor = $this->createMock(InterceptorInterface::class);
         $textInterceptor->expects(self::once())->method('process')->with(self::anything())->willReturnArgument(0);
 
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::once())->method('getEscapingInterceptors')
             ->with(InterceptorInterface::INTERCEPT_TEXT)->willReturn([$textInterceptor]);
         $parserConfiguration->expects(self::any())->method('getInterceptors')->willReturn([]);
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false, false, ['addChildNode']);
         $mockNodeOnStack->expects(self::once())->method('addChildNode')->with(self::anything());
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, ['splitTemplateAtDynamicTags', 'buildObjectTree']);
-        $templateParser->_set('configuration', $parserConfiguration);
+        $subject = $this->getAccessibleMock(TemplateParser::class, ['splitTemplateAtDynamicTags', 'buildObjectTree']);
+        $subject->_set('configuration', $parserConfiguration);
 
-        $templateParser->_call('textHandler', $mockState, 'string');
+        $subject->_call('textHandler', $mockState, 'string');
     }
 
     /**
@@ -625,23 +619,23 @@ class TemplateParserTest extends UnitTestCase
      */
     public function textNodesAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled(): void
     {
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::never())->method('getEscapingInterceptors');
         $parserConfiguration->expects(self::any())->method('getInterceptors')->willReturn([]);
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false, false, ['addChildNode']);
         $mockNodeOnStack->expects(self::once())->method('addChildNode')->with(self::anything());
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['splitTemplateAtDynamicTags', 'buildObjectTree']
         );
-        $templateParser->_set('configuration', $parserConfiguration);
-        $templateParser->_set('escapingEnabled', false);
+        $subject->_set('configuration', $parserConfiguration);
+        $subject->_set('escapingEnabled', false);
 
-        $templateParser->_call('textHandler', $mockState, 'string');
+        $subject->_call('textHandler', $mockState, 'string');
     }
 
     /**
@@ -649,27 +643,27 @@ class TemplateParserTest extends UnitTestCase
      */
     public function textNodesAreRunThroughInterceptors(): void
     {
-        $textInterceptor = $this->getMock(InterceptorInterface::class);
+        $textInterceptor = $this->createMock(InterceptorInterface::class);
         $textInterceptor->expects(self::once())->method('process')->with(self::anything())->willReturnArgument(0);
 
-        $parserConfiguration = $this->getMock(Configuration::class);
+        $parserConfiguration = $this->createMock(Configuration::class);
         $parserConfiguration->expects(self::once())->method('getInterceptors')
             ->with(InterceptorInterface::INTERCEPT_TEXT)->willReturn([$textInterceptor]);
         $parserConfiguration->expects(self::any())->method('getEscapingInterceptors')->willReturn([]);
 
         $mockNodeOnStack = $this->getMockForAbstractClass(AbstractNode::class, [], '', false, false, false, ['addChildNode']);
         $mockNodeOnStack->expects(self::once())->method('addChildNode')->with(self::anything());
-        $mockState = $this->getMock(ParsingState::class);
+        $mockState = $this->createMock(ParsingState::class);
         $mockState->expects(self::once())->method('getNodeFromStack')->willReturn($mockNodeOnStack);
 
-        $templateParser = $this->getAccessibleMock(
+        $subject = $this->getAccessibleMock(
             TemplateParser::class,
             ['splitTemplateAtDynamicTags', 'buildObjectTree']
         );
-        $templateParser->_set('configuration', $parserConfiguration);
-        $templateParser->_set('escapingEnabled', false);
+        $subject->_set('configuration', $parserConfiguration);
+        $subject->_set('escapingEnabled', false);
 
-        $templateParser->_call('textHandler', $mockState, 'string');
+        $subject->_call('textHandler', $mockState, 'string');
     }
 
     public static function dataProviderRecursiveArrayHandler(): \Generator
@@ -794,15 +788,15 @@ class TemplateParserTest extends UnitTestCase
     public function testRecursiveArrayHandler(string $string, array $expected): void
     {
         $state = new ParsingState();
-        $resolver = $this->getMock(ViewHelperResolver::class, ['isNamespaceIgnored']);
+        $resolver = $this->createMock(ViewHelperResolver::class);
         $resolver->expects(self::any())->method('isNamespaceIgnored')->willReturn(true);
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
         $context->setVariableProvider(new StandardVariableProvider());
-        $templateParser = new TemplateParser();
-        $templateParser->setRenderingContext($context);
-        $method = new \ReflectionMethod($templateParser, 'recursiveArrayHandler');
-        $result = $method->invokeArgs($templateParser, [$state, $string]);
+        $subject = new TemplateParser();
+        $subject->setRenderingContext($context);
+        $method = new \ReflectionMethod($subject, 'recursiveArrayHandler');
+        $result = $method->invokeArgs($subject, [$state, $string]);
 
         self::assertEquals($expected, $result);
     }
@@ -818,8 +812,8 @@ class TemplateParserTest extends UnitTestCase
             'firstArgument' => new ArgumentDefinition('firstArgument', 'string', '', false),
             'secondArgument' => new ArgumentDefinition('secondArgument', 'string', '', true)
         ];
-        $templateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $templateParser->_call('abortIfRequiredArgumentsAreMissing', $expected, []);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->_call('abortIfRequiredArgumentsAreMissing', $expected, []);
     }
 
     /**
@@ -835,9 +829,9 @@ class TemplateParserTest extends UnitTestCase
             'name2' => 'bla'
         ];
 
-        $mockTemplateParser = $this->getAccessibleMock(TemplateParser::class);
+        $subject = $this->getAccessibleMock(TemplateParser::class);
 
-        $mockTemplateParser->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
+        $subject->_call('abortIfRequiredArgumentsAreMissing', $expectedArguments, $actualArguments);
         // dummy assertion to avoid "did not perform any assertions" error
         self::assertTrue(true);
     }
@@ -859,10 +853,10 @@ class TemplateParserTest extends UnitTestCase
         $context = new RenderingContextFixture();
         $context->setViewHelperResolver($resolver);
 
-        $mockTemplateParser = $this->getAccessibleMock(TemplateParser::class, []);
-        $mockTemplateParser->setRenderingContext($context);
+        $subject = $this->getAccessibleMock(TemplateParser::class, []);
+        $subject->setRenderingContext($context);
 
-        $parsedArguments = $mockTemplateParser->_call('parseArguments', 'var1="1" var2="0"}', $viewHelper);
+        $parsedArguments = $subject->_call('parseArguments', 'var1="1" var2="0"}', $viewHelper);
 
         self::assertEquals(
             [

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
+use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
@@ -29,7 +31,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function getTemplateProcessorsReturnsExpectedResult(): void
     {
-        $get = [$this->getMock(TemplateProcessorInterface::class), $this->getMock(TemplateProcessorInterface::class)];
+        $get = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
         $view = new TemplateView();
         $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
         $subject->_set('templateProcessors', $get);
@@ -42,7 +44,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function setTemplateProcessorsSetsAttribute(): void
     {
-        $set = [$this->getMock(TemplateProcessorInterface::class), $this->getMock(TemplateProcessorInterface::class)];
+        $set = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
         $subject = new RenderingContext();
         $setter = 'set' . ucfirst('templateProcessors');
         $subject->$setter($set);
@@ -104,7 +106,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function getObjectTypesReturnsExpectedResult(string $property, string $expected): void
     {
-        $expected = $this->getMock($expected);
+        $expected = $this->createMock($expected);
         $view = new TemplateView();
         $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
         $subject->_set($property, $expected);
@@ -118,7 +120,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function setObjectTypeSetsAttribute(string $property, string $expected): void
     {
-        $expected = $this->getMock($expected);
+        $expected = $this->createMock($expected);
         $subject = new RenderingContext();
         $setter = 'set' . ucfirst($property);
         $subject->$setter($expected);
@@ -130,7 +132,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function templateVariableContainerCanBeReadCorrectly(): void
     {
-        $templateVariableContainer = $this->getMock(StandardVariableProvider::class);
+        $templateVariableContainer = $this->createMock(VariableProviderInterface::class);
         $renderingContextFixture = new RenderingContextFixture();
         $renderingContextFixture->setVariableProvider($templateVariableContainer);
         self::assertSame($renderingContextFixture->getVariableProvider(), $templateVariableContainer, 'Template Variable Container could not be read out again.');
@@ -141,7 +143,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function viewHelperVariableContainerCanBeReadCorrectly(): void
     {
-        $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
+        $viewHelperVariableContainer = $this->createMock(ViewHelperVariableContainer::class);
         $renderingContextFixture = new RenderingContextFixture();
         $renderingContextFixture->setViewHelperVariableContainer($viewHelperVariableContainer);
         self::assertSame($viewHelperVariableContainer, $renderingContextFixture->getViewHelperVariableContainer());
@@ -162,7 +164,7 @@ class RenderingContextTest extends UnitTestCase
     public function isCacheEnabledReturnsTrueIfCacheIsEnabled(): void
     {
         $subject = new RenderingContext();
-        $subject->setCache($this->getMock(SimpleFileCache::class));
+        $subject->setCache($this->createMock(FluidCacheInterface::class));
         self::assertTrue($subject->isCacheEnabled());
     }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -43,7 +43,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     public function testRenderCallsRenderOnTagBuilder(): void
     {
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $tagBuilder = $this->getMock(TagBuilder::class, ['render']);
+        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['render'])->getMock();
         $tagBuilder->expects(self::once())->method('render')->willReturn('foobar');
         $viewHelper->setTagBuilder($tagBuilder);
         self::assertEquals('foobar', $viewHelper->render());
@@ -57,7 +57,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
-        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
+        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $mockTagBuilder->expects(self::once())->method('addAttribute')->with('foo', 'bar');
         $viewHelper->setTagBuilder($mockTagBuilder);
 
@@ -72,17 +72,17 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
      */
     public function additionalTagAttributesAreRenderedCorrectly(): void
     {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
+        $subject = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
+        $subject->setRenderingContext(new RenderingContextFixture());
 
-        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
+        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $mockTagBuilder->expects(self::once())->method('addAttribute')->with('foo', 'bar');
-        $viewHelper->setTagBuilder($mockTagBuilder);
+        $subject->setTagBuilder($mockTagBuilder);
 
-        $viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
+        $subject->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
         $arguments = ['additionalAttributes' => ['foo' => 'bar']];
-        $viewHelper->setArguments($arguments);
-        $viewHelper->initialize();
+        $subject->setArguments($arguments);
+        $subject->initialize();
     }
 
     /**
@@ -93,7 +93,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
-        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
+        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $series = [
             ['data-foo', 'fooValue'],
             ['data-bar', 'barValue'],
@@ -118,7 +118,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
-        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
+        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $series = [
             ['aria-foo', 'fooValue'],
             ['aria-bar', 'barValue'],
@@ -153,7 +153,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     {
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
-        $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
+        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $series = [
             ['data-foo', 'fooValue'],
             ['data-bar', 'barValue'],
@@ -175,7 +175,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     {
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
-        $tagBuilder = $this->getMock(TagBuilder::class, ['addAttribute']);
+        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $series = [
             ['aria-foo', 'fooValue'],
             ['aria-bar', 'barValue'],
@@ -198,7 +198,7 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
         $viewHelper->setRenderingContext(new RenderingContextFixture());
 
-        $mockTagBuilder = $this->getMock(TagBuilder::class, ['addAttribute'], [], false, false);
+        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
         $series = [
             ['class', 'classAttribute'],
             ['dir', 'dirAttribute'],

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
@@ -188,8 +188,8 @@ class AbstractViewHelperTest extends UnitTestCase
      */
     public function setRenderingContextShouldSetInnerVariables(): void
     {
-        $templateVariableContainer = $this->getMock(StandardVariableProvider::class);
-        $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class);
+        $templateVariableContainer = $this->createMock(VariableProviderInterface::class);
+        $viewHelperVariableContainer = $this->createMock(ViewHelperVariableContainer::class);
 
         $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider($templateVariableContainer);

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -123,14 +123,14 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddNamespaceWithString(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespace('f', 'Foo\\Bar');
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('f', 'Foo\\Bar');
         self::assertAttributeEquals([
             'f' => [
                 'TYPO3Fluid\\Fluid\\ViewHelpers',
                 'Foo\\Bar'
             ]
-        ], 'namespaces', $resolver);
+        ], 'namespaces', $subject);
     }
 
     /**
@@ -138,14 +138,14 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddNamespaceWithArray(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespace('f', ['Foo\\Bar']);
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('f', ['Foo\\Bar']);
         self::assertAttributeEquals([
             'f' => [
                 'TYPO3Fluid\\Fluid\\ViewHelpers',
                 'Foo\\Bar'
             ]
-        ], 'namespaces', $resolver);
+        ], 'namespaces', $subject);
     }
 
     /**
@@ -153,9 +153,9 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddNamespaceWithNull(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespace('ignored', null);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $resolver);
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('ignored', null);
+        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $subject);
     }
 
     /**
@@ -163,10 +163,10 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddSecondNamespaceWithNullWithExistingNullStillIgnoresNamespace(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespace('ignored', null);
-        $resolver->addNamespace('ignored', null);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $resolver);
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('ignored', null);
+        $subject->addNamespace('ignored', null);
+        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $subject);
     }
 
     /**
@@ -174,10 +174,10 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddSecondNamespaceWithExistingNullConvertsToNotIgnoredNamespace(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespace('ignored', null);
-        $resolver->addNamespace('ignored', ['Foo\\Bar']);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => ['Foo\\Bar']], 'namespaces', $resolver);
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('ignored', null);
+        $subject->addNamespace('ignored', ['Foo\\Bar']);
+        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => ['Foo\\Bar']], 'namespaces', $subject);
     }
 
     /**
@@ -185,14 +185,14 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testAddNamespaces(): void
     {
-        $resolver = $this->getMock(ViewHelperResolver::class, []);
-        $resolver->addNamespaces(['f' => 'Foo\\Bar']);
+        $subject = new ViewHelperResolver();
+        $subject->addNamespaces(['f' => 'Foo\\Bar']);
         self::assertAttributeEquals([
             'f' => [
                 'TYPO3Fluid\\Fluid\\ViewHelpers',
                 'Foo\\Bar'
             ]
-        ], 'namespaces', $resolver);
+        ], 'namespaces', $subject);
     }
 
     public static function getResolvePhpNamespaceFromFluidNamespaceTestValues(): array
@@ -219,13 +219,12 @@ class ViewHelperResolverTest extends UnitTestCase
      */
     public function testCreateViewHelperInstance(): void
     {
-        $resolver = $this->getMock(
-            ViewHelperResolver::class,
-            ['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName']
-        );
-        $resolver->expects(self::once())->method('resolveViewHelperClassName')->with('foo', 'bar')->willReturn('foobar');
-        $resolver->expects(self::once())->method('createViewHelperInstanceFromClassName')->with('foobar')->willReturn('baz');
-        self::assertEquals('baz', $resolver->createViewHelperInstance('foo', 'bar'));
+        $subject = $this->getMockBuilder(ViewHelperResolver::class)
+            ->onlyMethods(['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName'])
+            ->getMock();
+        $subject->expects(self::once())->method('resolveViewHelperClassName')->with('foo', 'bar')->willReturn('foobar');
+        $subject->expects(self::once())->method('createViewHelperInstanceFromClassName')->with('foobar')->willReturn('baz');
+        self::assertEquals('baz', $subject->createViewHelperInstance('foo', 'bar'));
     }
 
     /**

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -40,8 +40,8 @@ class AbstractTemplateViewTest extends UnitTestCase
 
     public function setUp(): void
     {
-        $this->templateVariableContainer = $this->getMock(StandardVariableProvider::class);
-        $viewHelperVariableContainer = $this->getMock(ViewHelperVariableContainer::class, ['setView']);
+        $this->templateVariableContainer = $this->createMock(VariableProviderInterface::class);
+        $viewHelperVariableContainer = $this->createMock(ViewHelperVariableContainer::class);
         $this->renderingContext = new RenderingContextFixture();
         $this->renderingContext->viewHelperVariableContainer = $viewHelperVariableContainer;
         $this->renderingContext->variableProvider = $this->templateVariableContainer;
@@ -63,7 +63,7 @@ class AbstractTemplateViewTest extends UnitTestCase
      */
     public function testGetViewHelperResolverReturnsExpectedViewHelperResolver(): void
     {
-        $viewHelperResolver = $this->getMock(ViewHelperResolver::class);
+        $viewHelperResolver = $this->createMock(ViewHelperResolver::class);
         $this->renderingContext->setViewHelperResolver($viewHelperResolver);
         $result = $this->view->getViewHelperResolver();
         self::assertSame($viewHelperResolver, $result);

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -71,11 +71,11 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function setsLayoutPathAndFilename(): void
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
-        $instance->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $instance->setLayoutPathAndFilename('foobar');
-        self::assertAttributeEquals('foobar', 'layoutPathAndFilename', $instance);
-        self::assertEquals('foobar', $instance->getLayoutPathAndFilename());
+        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
+        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
+        $subject->setLayoutPathAndFilename('foobar');
+        self::assertAttributeEquals('foobar', 'layoutPathAndFilename', $subject);
+        self::assertEquals('foobar', $subject->getLayoutPathAndFilename());
     }
 
     /**
@@ -83,10 +83,10 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function setsTemplatePathAndFilename(): void
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
-        $instance->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $instance->setTemplatePathAndFilename('foobar');
-        self::assertAttributeEquals('foobar', 'templatePathAndFilename', $instance);
+        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
+        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
+        $subject->setTemplatePathAndFilename('foobar');
+        self::assertAttributeEquals('foobar', 'templatePathAndFilename', $subject);
     }
 
     public static function getGetterAndSetterTestValues(): array
@@ -106,10 +106,10 @@ class TemplatePathsTest extends BaseTestCase
     {
         $getter = 'get' . ucfirst($property);
         $setter = 'set' . ucfirst($property);
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
-        $instance->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $instance->$setter($value);
-        self::assertEquals($value, $instance->$getter());
+        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
+        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
+        $subject->$setter($value);
+        self::assertEquals($value, $subject->$getter());
     }
 
     /**
@@ -150,10 +150,10 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testResolveFilesMethodCallsResolveFilesInFolders(string $method, string $pathsMethod): void
     {
-        $instance = $this->getMock(TemplatePaths::class, ['resolveFilesInFolders']);
-        $instance->$pathsMethod(['foo']);
-        $instance->expects(self::once())->method('resolveFilesInFolders')->with(self::anything(), 'format');
-        $instance->$method('format', 'format');
+        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['resolveFilesInFolders'])->getMock();
+        $subject->$pathsMethod(['foo']);
+        $subject->expects(self::once())->method('resolveFilesInFolders')->with(self::anything(), 'format');
+        $subject->$method('format', 'format');
     }
 
     /**
@@ -161,12 +161,12 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testToArray(): void
     {
-        $instance = $this->getMock(TemplatePaths::class, ['sanitizePath']);
-        $instance->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $instance->setTemplateRootPaths(['1']);
-        $instance->setLayoutRootPaths(['2']);
-        $instance->setPartialRootPaths(['3']);
-        $result = $instance->toArray();
+        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
+        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
+        $subject->setTemplateRootPaths(['1']);
+        $subject->setLayoutRootPaths(['2']);
+        $subject->setPartialRootPaths(['3']);
+        $result = $subject->toArray();
         $expected = [
             TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [1],
             TemplatePaths::CONFIG_LAYOUTROOTPATHS => [2],


### PR DESCRIPTION
With latest phpunit versions BaseTestCase::getMock() becomes more and more unfortunate. The patch avoids all usages and deprecated the test helper method.

Strategies:
* Use phpunit native createMock() if possible
* Use phpunit native createMock() with interfaces if possible
* Use getMockBuilder() with onlyMethods() for more complex things
* Avoid mocking the test subject altogether if possible