### PR TITLE
[TASK] Deprecate BaseTestCase::assertAttributeInstanceOf()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -87,6 +87,9 @@ abstract class BaseTestCase extends TestCase
         self::assertNotEmpty($value);
     }
 
+    /**
+     * @deprecated Unused. Will be removed.
+     */
     protected static function assertAttributeInstanceOf(string $expected, string $attributeName, $classOrObject): void
     {
         $reflection = new \ReflectionClass($classOrObject);

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -20,15 +20,6 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     /**
      * @test
      */
-    public function testConstructorSetsTagBuilder(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], []);
-        self::assertAttributeInstanceOf(TagBuilder::class, 'tag', $viewHelper);
-    }
-
-    /**
-     * @test
-     */
     public function testSetTagBuilderSetsTagBuilder(): void
     {
         $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);


### PR DESCRIPTION
This assertion tests for an internal state
in it's single usage. There is little reason
for whitebox tests, stuff like that should
be covered by functional tests instead.

The patch removes a single usage and
deprecates the test helper assertion method.