### PR TITLE
[TASK] Avoid and deprecate assertAttributeNotEmpty()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -79,6 +79,9 @@ abstract class BaseTestCase extends TestCase
         self::assertContains($needle, $value);
     }
 
+    /**
+     * @deprecated Unused. Will be removed.
+     */
     protected static function assertAttributeNotEmpty(string $haystackAttributeName, $haystackClassOrObject): void
     {
         $reflection = new \ReflectionClass($haystackClassOrObject);


### PR DESCRIPTION
BaseTestCase::assertAttributeNotEmpty() can be
avoided by refactoring a single test.