### PR TITLE
[TASK] Avoid and deprecated assertAttributeContains()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -71,6 +71,9 @@ abstract class BaseTestCase extends TestCase
         self::assertSame($expected, $value);
     }
 
+    /**
+     * @deprecated Unused. Will be removed.
+     */
     protected static function assertAttributeContains($needle, string $haystackAttributeName, $haystackClassOrObject): void
     {
         $reflection = new \ReflectionClass($haystackClassOrObject);

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -18,31 +18,31 @@ class ViewHelperResolverTest extends UnitTestCase
     /**
      * @test
      */
-    public function testAddNamespaceWithStringRecordsNamespace(): void
+    public function addNamespaceWithStringRecordsNamespace(): void
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('t', 'test');
-        self::assertAttributeContains(['test'], 'namespaces', $subject);
+        self::assertEquals(['test'], $subject->getNamespaces()['t']);
     }
 
     /**
      * @test
      */
-    public function testAddNamespaceWithArrayRecordsNamespace(): void
+    public function addNamespaceWithArrayRecordsNamespace(): void
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('t', ['test']);
-        self::assertAttributeContains(['test'], 'namespaces', $subject);
+        self::assertEquals(['test'], $subject->getNamespaces()['t']);
     }
 
     /**
      * @test
      */
-    public function testSetNamespacesSetsNamespaces(): void
+    public function setNamespacesSetsNamespaces(): void
     {
         $subject = new ViewHelperResolver();
         $subject->setNamespaces(['t' => ['test']]);
-        self::assertAttributeEquals(['t' => ['test']], 'namespaces', $subject);
+        self::assertEquals(['t' => ['test']], $subject->getNamespaces());
     }
 
     /**


### PR DESCRIPTION
This whitebox test related methods can be
avoided by using casual getter methods on
test subject instead.