### PR TITLE
[TASK] Avoid and deprecate assertAttributeSame()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -63,6 +63,9 @@ abstract class BaseTestCase extends TestCase
         self::assertEquals($expected, $value);
     }
 
+    /**
+     * @deprecated Unused. Will be removed.
+     */
     protected static function assertAttributeSame($expected, string $actualAttributeName, $actualClassOrObject): void
     {
         $reflection = new \ReflectionClass($actualClassOrObject);

--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\TestViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\MutableTestViewHelper;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 class ViewHelperEscapingTest extends BaseTestCase

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 
 class TagBasedTest extends BaseTestCase
 {

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\TemplateProcessor;
 
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class NamespaceDetectionTemplateProcessorTest extends UnitTestCase

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractCompiledTemplateTest extends UnitTestCase

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -22,7 +22,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class NodeConverterTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class BooleanParserTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class ParsingStateTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class BooleanNodeTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class EscapingNodeTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class NumericNodeTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class TextNodeTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class ViewHelperNodeTest extends UnitTestCase

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -30,7 +30,7 @@ use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
 
@@ -113,12 +113,14 @@ class TemplateParserTest extends UnitTestCase
     /**
      * @test
      */
-    public function testPublicGetAndSetEscapingEnabledWorks(): void
+    public function isEscapingEnabledReturnsPreviouslySetEscapingEnabled(): void
     {
         $subject = new TemplateParser();
-        $default = $subject->isEscapingEnabled();
-        $subject->setEscapingEnabled(!$default);
-        self::assertAttributeSame(!$default, 'escapingEnabled', $subject);
+        self::assertTrue($subject->isEscapingEnabled());
+        $subject->setEscapingEnabled(false);
+        self::assertFalse($subject->isEscapingEnabled());
+        $subject->setEscapingEnabled(true);
+        self::assertTrue($subject->isEscapingEnabled());
     }
 
     /**

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProcessor;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class EscapingModifierTemplateProcessorTest extends UnitTestCase

--- a/tests/Unit/Core/Rendering/Fixtures/RenderingContextFixture.php
+++ b/tests/Unit/Core/Rendering/Fixtures/RenderingContextFixture.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * See LICENSE.txt that was shipped with this package.
  */
 
-namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures;
 
 use PHPUnit\Framework\MockObject\Generator;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -15,7 +15,6 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
@@ -26,35 +25,9 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 
 class RenderingContextTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
-    public function getTemplateProcessorsReturnsExpectedResult(): void
-    {
-        $get = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
-        $view = new TemplateView();
-        $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
-        $subject->_set('templateProcessors', $get);
-        $getter = 'get' . ucfirst('templateProcessors');
-        self::assertSame($get, $subject->$getter());
-    }
-
-    /**
-     * @test
-     */
-    public function setTemplateProcessorsSetsAttribute(): void
-    {
-        $set = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
-        $subject = new RenderingContext();
-        $setter = 'set' . ucfirst('templateProcessors');
-        $subject->$setter($set);
-        self::assertAttributeSame($set, 'templateProcessors', $subject);
-    }
-
-    public static function simpleTypeDataProvider(): array
+    public static function gettersReturnPreviouslySetValuesDataProvider(): array
     {
         return [
-            ['variableProvider', new StandardVariableProvider(['foo' => 'bar'])],
             ['controllerName', 'foobar-controllerName'],
             ['controllerAction', 'foobar-controllerAction'],
             ['expressionNodeTypes', ['Foo', 'Bar']],
@@ -63,90 +36,55 @@ class RenderingContextTest extends UnitTestCase
 
     /**
      * @test
-     * @param mixed $expected
-     * @dataProvider simpleTypeDataProvider
+     * @dataProvider gettersReturnPreviouslySetValuesDataProvider
      */
-    public function getSimpleTypesReturnsExpectedResult(string $property, $expected): void
+    public function gettersReturnPreviouslySetValues(string $property, string|array $expected): void
     {
         $view = new TemplateView();
         $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
-        $subject->_set($property, $expected);
+        $setter = 'set' . ucfirst($property);
+        $subject->$setter($expected);
         $getter = 'get' . ucfirst($property);
         self::assertSame($expected, $subject->$getter());
     }
 
-    /**
-     * @test
-     * @param mixed $expected
-     * @dataProvider simpleTypeDataProvider
-     */
-    public function setSimpleTypeSetsAttribute(string $property, $expected): void
-    {
-        $subject = new RenderingContext();
-        $setter = 'set' . ucfirst($property);
-        $subject->$setter($expected);
-        self::assertAttributeSame($expected, $property, $subject);
-    }
-
-    public static function objectTypeDataProvider(): array
+    public static function gettersReturnPreviouslySetObjectsDataProvider(): array
     {
         return [
+            ['variableProvider', VariableProviderInterface::class],
             ['viewHelperResolver', ViewHelperResolver::class],
             ['viewHelperInvoker', ViewHelperInvoker::class],
             ['templatePaths', TemplatePaths::class],
             ['cache', SimpleFileCache::class],
             ['templateParser', TemplateParser::class],
             ['templateCompiler', TemplateCompiler::class],
+            ['viewHelperVariableContainer', ViewHelperVariableContainer::class]
         ];
     }
 
     /**
      * @test
-     * @dataProvider objectTypeDataProvider
+     * @dataProvider gettersReturnPreviouslySetObjectsDataProvider
      */
-    public function getObjectTypesReturnsExpectedResult(string $property, string $expected): void
+    public function gettersReturnPreviouslySetObjects(string $property, string $expected): void
     {
         $expected = $this->createMock($expected);
-        $view = new TemplateView();
-        $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
-        $subject->_set($property, $expected);
+        $subject = new RenderingContext();
+        $setter = 'set' . ucfirst($property);
+        $subject->$setter($expected);
         $getter = 'get' . ucfirst($property);
         self::assertSame($expected, $subject->$getter());
     }
 
     /**
      * @test
-     * @dataProvider objectTypeDataProvider
      */
-    public function setObjectTypeSetsAttribute(string $property, string $expected): void
+    public function getTemplateProcessorsReturnsPreviouslySetTemplateProcessor(): void
     {
-        $expected = $this->createMock($expected);
+        $processors = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
         $subject = new RenderingContext();
-        $setter = 'set' . ucfirst($property);
-        $subject->$setter($expected);
-        self::assertAttributeSame($expected, $property, $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function templateVariableContainerCanBeReadCorrectly(): void
-    {
-        $templateVariableContainer = $this->createMock(VariableProviderInterface::class);
-        $renderingContextFixture = new RenderingContextFixture();
-        $renderingContextFixture->setVariableProvider($templateVariableContainer);
-        self::assertSame($renderingContextFixture->getVariableProvider(), $templateVariableContainer, 'Template Variable Container could not be read out again.');
-    }
-
-    /**
-     * @test
-     */
-    public function viewHelperVariableContainerCanBeReadCorrectly(): void
-    {
-        $viewHelperVariableContainer = $this->createMock(ViewHelperVariableContainer::class);
-        $renderingContextFixture = new RenderingContextFixture();
-        $renderingContextFixture->setViewHelperVariableContainer($viewHelperVariableContainer);
-        self::assertSame($viewHelperVariableContainer, $renderingContextFixture->getViewHelperVariableContainer());
+        $subject->setTemplateProcessors($processors);
+        self::assertSame($processors, $subject->getTemplateProcessors());
     }
 
     /**

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -19,7 +19,6 @@ class ChainedVariableProviderTest extends UnitTestCase
     {
         $a = new StandardVariableProvider(['a' => 'a']);
         $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
-
         return [
             [['a' => 'local'], [$a, $b], 'a', 'local'],
             [[], [$a, $b], 'a', 'a'],
@@ -31,29 +30,28 @@ class ChainedVariableProviderTest extends UnitTestCase
     }
 
     /**
-     * @param mixed $expected
      * @dataProvider getGetTestValues
      * @test
      */
-    public function testGet(array $local, array $chain, string $path, $expected): void
+    public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
     {
-        $chainedProvider = new ChainedVariableProvider($chain);
-        $chainedProvider->setSource($local);
-        self::assertEquals($expected, $chainedProvider->get($path));
+        $subject = new ChainedVariableProvider($chain);
+        $subject->setSource($local);
+        self::assertEquals($expected, $subject->get($path));
     }
 
     /**
-     * @param mixed $expected
      * @dataProvider getGetTestValues
+     * @test
      */
-    public function testGetByPath(array $local, array $chain, string $path, $expected): void
+    public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
     {
-        $chainedProvider = new ChainedVariableProvider($chain);
-        $chainedProvider->setSource($local);
-        self::assertEquals($expected, $chainedProvider->getByPath($path));
+        $subject = new ChainedVariableProvider($chain);
+        $subject->setSource($local);
+        self::assertEquals($expected, $subject->getByPath($path));
     }
 
-    public static function getGetAllTestValues(): array
+    public static function getAllReturnsPreviouslySetSourceVariablesDataProvider(): array
     {
         $a = new StandardVariableProvider(['a' => 'a']);
         $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
@@ -66,21 +64,20 @@ class ChainedVariableProviderTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider getGetAllTestValues
+     * @dataProvider getAllReturnsPreviouslySetSourceVariablesDataProvider
      * @test
      */
-    public function testGetAll(array $local, array $chain, array $expected): void
+    public function getAllReturnsPreviouslySetSourceVariables(array $local, array $chain, array $expected): void
     {
-        $chainedProvider = new ChainedVariableProvider($chain);
-        $chainedProvider->setSource($local);
-        self::assertEquals($expected, $chainedProvider->getAll());
+        $subject = new ChainedVariableProvider($chain);
+        $subject->setSource($local);
+        self::assertEquals($expected, $subject->getAll());
     }
 
-    public static function getGetAllIdentifiersTestValues(): array
+    public static function getAllIdentifiersReturnsPreviouslySetSourceIdentifiersDataProvider(): array
     {
         $a = new StandardVariableProvider(['a' => 'a']);
         $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
-
         return [
             [['a' => 'local'], [$a, $b], ['a', 'b']],
             [[], [$a, $b], ['a', 'b']],
@@ -90,24 +87,24 @@ class ChainedVariableProviderTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider getGetAllIdentifiersTestValues
+     * @dataProvider getAllIdentifiersReturnsPreviouslySetSourceIdentifiersDataProvider
      * @test
      */
-    public function testGetAllIdentifiers(array $local, array $chain, array $expected): void
+    public function getAllIdentifiersReturnsPreviouslySetSourceIdentifiers(array $local, array $chain, array $expected): void
     {
-        $chainedProvider = new ChainedVariableProvider($chain);
-        $chainedProvider->setSource($local);
-        self::assertEquals($expected, $chainedProvider->getAllIdentifiers());
+        $subject = new ChainedVariableProvider($chain);
+        $subject->setSource($local);
+        self::assertEquals($expected, $subject->getAllIdentifiers());
     }
 
     /**
      * @test
      */
-    public function testGetScopeCopy(): void
+    public function getScopeCopyKeepsExistingVariableProviders(): void
     {
-        $chain = [new StandardVariableProvider(), new StandardVariableProvider()];
-        $chainedProvider = new ChainedVariableProvider($chain);
-        $copy = $chainedProvider->getScopeCopy([]);
-        self::assertAttributeSame($chain, 'variableProviders', $copy);
+        $chain = [new StandardVariableProvider(['a' => 'a']), new StandardVariableProvider()];
+        $subject = new ChainedVariableProvider($chain);
+        $copy = $subject->getScopeCopy([]);
+        self::assertSame('a', $copy->get('a'));
     }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -12,22 +12,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractTagBasedViewHelperTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
-    public function testSetTagBuilderSetsTagBuilder(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $tagBuilder = new TagBuilder('div');
-        $viewHelper->setTagBuilder($tagBuilder);
-        self::assertAttributeSame($tagBuilder, 'tag', $viewHelper);
-    }
-
     /**
      * @test
      */

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeDefaultRenderStaticViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -16,7 +16,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;


### PR DESCRIPTION
This asserter is used for whitebox tests.
The patch refactors usages to avoid whitebox
tests and deprecates the method.

Also, class RenderingContextFixture is moved
to a dedicated fixture directory.