### PR TITLE
[TASK] Avoid and deprecate assertAttributeEquals()

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -55,6 +55,9 @@ abstract class BaseTestCase extends TestCase
         return $builder->getMock();
     }
 
+    /**
+     * @deprecated Unused. Will be removed.
+     */
     protected static function assertAttributeEquals($expected, string $actualAttributeName, $actualClassOrObject): void
     {
         $reflection = new \ReflectionClass($actualClassOrObject);

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -30,11 +30,12 @@ class NodeConverterTest extends UnitTestCase
     /**
      * @test
      */
-    public function setVariableCounterSetsVariableCounter(): void
+    public function variableNameReturnsIncrementedName(): void
     {
-        $instance = new NodeConverter(new TemplateCompiler());
-        $instance->setVariableCounter(10);
-        self::assertAttributeEquals(10, 'variableCounter', $instance);
+        $subject = new NodeConverter(new TemplateCompiler());
+        $subject->setVariableCounter(10);
+        self::assertSame('$test10', $subject->variableName('test'));
+        self::assertSame('$test11', $subject->variableName('test'));
     }
 
     public static function convertReturnsExpectedExecutionDataProvider(): array
@@ -120,8 +121,8 @@ class NodeConverterTest extends UnitTestCase
      */
     public function convertReturnsExpectedExecution(NodeInterface $node, string $expected): void
     {
-        $instance = new NodeConverter(new TemplateCompiler());
-        $result = $instance->convert($node);
+        $subject = new NodeConverter(new TemplateCompiler());
+        $result = $subject->convert($node);
         self::assertEquals($expected, $result['execution']);
     }
 
@@ -130,8 +131,8 @@ class NodeConverterTest extends UnitTestCase
      */
     public function instanceOfAbstractMockReturnsEmptyStringConvertExecution(): void
     {
-        $instance = new NodeConverter(new TemplateCompiler());
-        $result = $instance->convert($this->getMockBuilder(NodeInterface::class)->getMockForAbstractClass());
+        $subject = new NodeConverter(new TemplateCompiler());
+        $result = $subject->convert($this->getMockBuilder(NodeInterface::class)->getMockForAbstractClass());
         self::assertEquals('', $result['execution']);
     }
 }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -9,62 +9,49 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
-use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class ViewHelperNodeTest extends UnitTestCase
 {
     /**
-     * @var RenderingContextInterface
+     * @test
      */
-    private $renderingContext;
-
-    /**
-     * @var ViewHelperResolver&MockObject
-     */
-    private $mockViewHelperResolver;
-
-    public function setUp(): void
+    public function getArgumentsReturnsArgumentsSetByConstructor(): void
     {
-        $this->renderingContext = new RenderingContextFixture();
-        $this->mockViewHelperResolver = $this->createMock(ViewHelperResolver::class);
-        $this->mockViewHelperResolver->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
-        $this->mockViewHelperResolver->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
-        $this->mockViewHelperResolver->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([
-            'foo' => new ArgumentDefinition('foo', 'string', 'Dummy required argument', true)
-        ]);
-        $this->renderingContext->setViewHelperResolver($this->mockViewHelperResolver);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $viewHelperResolverMock = $this->createMock(ViewHelperResolver::class);
+        $renderingContextMock->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolverMock);
+        $viewHelperResolverMock->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+        $viewHelperResolverMock->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+        $viewHelperResolverMock->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
+        $arguments = [$this->createMock(NodeInterface::class)];
+        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', $arguments, new ParsingState());
+        self::assertSame($arguments, $subject->getArguments());
     }
 
     /**
      * @test
      */
-    public function constructorSetsViewHelperAndArguments(): void
+    public function evaluateCallsViewHelperInvoker(): void
     {
-        $arguments = ['foo' => 'bar'];
-        /** @var ViewHelperNode|MockObject $viewHelperNode */
-        $viewHelperNode = new ViewHelperNode($this->renderingContext, 'f', 'vh', $arguments, new ParsingState());
-        self::assertAttributeEquals($arguments, 'arguments', $viewHelperNode);
-    }
-
-    /**
-     * @test
-     */
-    public function testEvaluateCallsInvoker(): void
-    {
-        $invoker = $this->createMock(ViewHelperInvoker::class);
-        $invoker->expects(self::once())->method('invoke')->willReturn('test');
-        $this->renderingContext->setViewHelperInvoker($invoker);
-        $node = new ViewHelperNode($this->renderingContext, 'f', 'vh', ['foo' => 'bar'], new ParsingState());
-        $result = $node->evaluate($this->renderingContext);
-        self::assertEquals('test', $result);
+        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $viewHelperResolverMock = $this->createMock(ViewHelperResolver::class);
+        $renderingContextMock->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolverMock);
+        $viewHelperResolverMock->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+        $viewHelperResolverMock->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+        $viewHelperResolverMock->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
+        $viewHelperInvokerMock = $this->createMock(ViewHelperInvoker::class);
+        $renderingContextMock->expects(self::once())->method('getViewHelperInvoker')->willReturn($viewHelperInvokerMock);
+        $viewHelperInvokerMock->expects(self::once())->method('invoke')->willReturn('test');
+        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', [$this->createMock(NodeInterface::class)], new ParsingState());
+        $result = $subject->evaluate($renderingContextMock);
+        self::assertSame('test', $result);
     }
 }

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -193,7 +193,7 @@ class StandardVariableProviderTest extends UnitTestCase
     {
         $subject = new StandardVariableProvider(['foo' => 'bar', 'settings' => ['baz' => 'bam']]);
         $copy = $subject->getScopeCopy(['bar' => 'foo']);
-        self::assertAttributeEquals(['settings' => ['baz' => 'bam'], 'bar' => 'foo'], 'variables', $copy);
+        self::assertSame(['bar' => 'foo', 'settings' => ['baz' => 'bam']], $copy->getAll());
     }
 
     /**

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
 
 class ViewHelperResolverTest extends UnitTestCase
 {
@@ -22,7 +23,7 @@ class ViewHelperResolverTest extends UnitTestCase
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('t', 'test');
-        self::assertEquals(['test'], $subject->getNamespaces()['t']);
+        self::assertSame(['test'], $subject->getNamespaces()['t']);
     }
 
     /**
@@ -32,199 +33,39 @@ class ViewHelperResolverTest extends UnitTestCase
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('t', ['test']);
-        self::assertEquals(['test'], $subject->getNamespaces()['t']);
+        self::assertSame(['test'], $subject->getNamespaces()['t']);
     }
 
     /**
      * @test
      */
-    public function setNamespacesSetsNamespaces(): void
-    {
-        $subject = new ViewHelperResolver();
-        $subject->setNamespaces(['t' => ['test']]);
-        self::assertEquals(['t' => ['test']], $subject->getNamespaces());
-    }
-
-    /**
-     * @test
-     */
-    public function testSetNamespacesSetsNamespacesAndConvertsStringNamespaceToArray(): void
-    {
-        $subject = new ViewHelperResolver();
-        $subject->setNamespaces(['t' => 'test']);
-        self::assertAttributeEquals(['t' => ['test']], 'namespaces', $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function testIsNamespaceReturnsFalseIfNamespaceNotValid(): void
-    {
-        $subject = new ViewHelperResolver();
-        $result = $subject->isNamespaceValid('test2');
-        self::assertFalse($result);
-    }
-
-    /**
-     * @test
-     */
-    public function testResolveViewHelperClassNameThrowsExceptionIfClassNotResolved(): void
-    {
-        $this->expectException(Exception::class);
-        $subject = new ViewHelperResolver();
-        $subject->resolveViewHelperClassName('f', 'invalid');
-    }
-
-    /**
-     * @test
-     */
-    public function testResolveViewHelperNameSupportsMultipleNamespaces(): void
-    {
-        $subject = $this->getAccessibleMock(ViewHelperResolver::class, []);
-        $subject->_set('namespaces', [
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                'Foo\\Bar'
-            ]
-        ]);
-        $result = $subject->_call('resolveViewHelperName', 'f', 'render');
-        self::assertEquals('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function testResolveViewHelperNameDoesNotChokeOnNullInMultipleNamespaces(): void
-    {
-        $subject = $this->getAccessibleMock(ViewHelperResolver::class, []);
-        $subject->_set('namespaces', [
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                null
-            ]
-        ]);
-        $result = $subject->_call('resolveViewHelperName', 'f', 'render');
-        self::assertEquals('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function testResolveViewHelperNameTrimsBackslashSuffixFromNamespace(): void
-    {
-        $subject = $this->getAccessibleMock(ViewHelperResolver::class, []);
-        $subject->_set('namespaces', ['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers\\']]);
-        $result = $subject->_call('resolveViewHelperName', 'f', 'render');
-        self::assertEquals('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $result);
-    }
-
-    /**
-     * @test
-     */
-    public function testAddNamespaceWithString(): void
-    {
-        $subject = new ViewHelperResolver();
-        $subject->addNamespace('f', 'Foo\\Bar');
-        self::assertAttributeEquals([
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                'Foo\\Bar'
-            ]
-        ], 'namespaces', $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function testAddNamespaceWithArray(): void
-    {
-        $subject = new ViewHelperResolver();
-        $subject->addNamespace('f', ['Foo\\Bar']);
-        self::assertAttributeEquals([
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                'Foo\\Bar'
-            ]
-        ], 'namespaces', $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function testAddNamespaceWithNull(): void
+    public function addNamespaceWithNullDoesNotChoke(): void
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('ignored', null);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $subject);
+        self::assertSame(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'ignored' => null], $subject->getNamespaces());
     }
 
     /**
      * @test
      */
-    public function testAddSecondNamespaceWithNullWithExistingNullStillIgnoresNamespace(): void
+    public function addNamespaceWithNullTwiceDoesNotChoke(): void
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('ignored', null);
         $subject->addNamespace('ignored', null);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], 'namespaces', $subject);
+        self::assertSame(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], $subject->getNamespaces());
     }
 
     /**
      * @test
      */
-    public function testAddSecondNamespaceWithExistingNullConvertsToNotIgnoredNamespace(): void
+    public function addNamespaceWithNullAndThenValidValueConvertsToNotIgnoredNamespace(): void
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('ignored', null);
         $subject->addNamespace('ignored', ['Foo\\Bar']);
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => ['Foo\\Bar']], 'namespaces', $subject);
-    }
-
-    /**
-     * @test
-     */
-    public function testAddNamespaces(): void
-    {
-        $subject = new ViewHelperResolver();
-        $subject->addNamespaces(['f' => 'Foo\\Bar']);
-        self::assertAttributeEquals([
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                'Foo\\Bar'
-            ]
-        ], 'namespaces', $subject);
-    }
-
-    public static function getResolvePhpNamespaceFromFluidNamespaceTestValues(): array
-    {
-        return [
-            ['Foo\\Bar', 'Foo\\Bar\\ViewHelpers'],
-            ['Foo\\Bar\\ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
-            ['http://typo3.org/ns/Foo/Bar/ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider getResolvePhpNamespaceFromFluidNamespaceTestValues
-     */
-    public function testResolvePhpNamespaceFromFluidNamespace(string $input, string $expected): void
-    {
-        $subject = new ViewHelperResolver();
-        self::assertEquals($expected, $subject->resolvePhpNamespaceFromFluidNamespace($input));
-    }
-
-    /**
-     * @test
-     */
-    public function testCreateViewHelperInstance(): void
-    {
-        $subject = $this->getMockBuilder(ViewHelperResolver::class)
-            ->onlyMethods(['resolveViewHelperClassName', 'createViewHelperInstanceFromClassName'])
-            ->getMock();
-        $subject->expects(self::once())->method('resolveViewHelperClassName')->with('foo', 'bar')->willReturn('foobar');
-        $subject->expects(self::once())->method('createViewHelperInstanceFromClassName')->with('foobar')->willReturn('baz');
-        self::assertEquals('baz', $subject->createViewHelperInstance('foo', 'bar'));
+        self::assertSame(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => ['Foo\\Bar']], $subject->getNamespaces());
     }
 
     /**
@@ -234,34 +75,54 @@ class ViewHelperResolverTest extends UnitTestCase
     {
         $subject = new ViewHelperResolver();
         $subject->addNamespace('foo', 'Some\Namespace');
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], 'namespaces', $subject);
+        self::assertSame(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], $subject->getNamespaces());
         $subject->addNamespace('foo', 'Some\Namespace');
-        self::assertAttributeEquals(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], 'namespaces', $subject);
+        self::assertSame(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], $subject->getNamespaces());
     }
 
-    public static function getIsNamespaceValidTestValues(): array
+    /**
+     * @test
+     */
+    public function setNamespacesSetsNamespaces(): void
+    {
+        $subject = new ViewHelperResolver();
+        $subject->setNamespaces(['t' => ['test']]);
+        self::assertSame(['t' => ['test']], $subject->getNamespaces());
+    }
+
+    /**
+     * @test
+     */
+    public function setNamespacesConvertsStringNamespaceToArray(): void
+    {
+        $subject = new ViewHelperResolver();
+        $subject->setNamespaces(['t' => 'test']);
+        self::assertSame(['t' => ['test']], $subject->getNamespaces());
+    }
+
+    public static function isNamespaceValidReturnsExpectedValueDataProvider(): array
     {
         return [
             [['foo' => null], 'foo', false],
             [['foo' => ['test']], 'foo', true],
             [['foo' => ['test']], 'foobar', false],
             [['foo*' => null], 'foo', false],
+            [[], 'invalid', false]
         ];
     }
 
     /**
      * @test
-     * @dataProvider getIsNamespaceValidTestValues
+     * @dataProvider isNamespaceValidReturnsExpectedValueDataProvider
      */
-    public function testIsNamespaceValidOrIgnored(array $namespaces, string $namespace, bool $expected): void
+    public function isNamespaceValidReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
         $subject->setNamespaces($namespaces);
-        $result = $subject->isNamespaceValid($namespace);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $subject->isNamespaceValid($namespace));
     }
 
-    public static function getIsNamespaceIgnoredTestValues(): array
+    public static function isNamespaceIgnoredReturnsExpectedValueDataProvider(): array
     {
         return [
             [['foo' => null], 'foo', true],
@@ -273,17 +134,16 @@ class ViewHelperResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @dataProvider getIsNamespaceIgnoredTestValues
+     * @dataProvider isNamespaceIgnoredReturnsExpectedValueDataProvider
      */
-    public function testIsNamespaceIgnored(array $namespaces, string $namespace, bool $expected): void
+    public function isNamespaceIgnoredReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
         $subject->setNamespaces($namespaces);
-        $result = $subject->isNamespaceIgnored($namespace);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $subject->isNamespaceIgnored($namespace));
     }
 
-    public static function getIsNamespaceValidOrIgnoredTestValues(): array
+    public static function isNamespaceValidOrIgnoredReturnsExpectedValueDataProvider(): array
     {
         return [
             [['foo' => null], 'foo', true],
@@ -295,13 +155,85 @@ class ViewHelperResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @dataProvider getIsNamespaceValidOrIgnoredTestValues
+     * @dataProvider isNamespaceValidOrIgnoredReturnsExpectedValueDataProvider
      */
-    public function testIsNamespaceValidOrIgnoredTestValues(array $namespaces, string $namespace, bool $expected): void
+    public function isNamespaceValidOrIgnoredReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
         $subject->setNamespaces($namespaces);
-        $result = $subject->isNamespaceValidOrIgnored($namespace);
-        self::assertEquals($expected, $result);
+        self::assertSame($expected, $subject->isNamespaceValidOrIgnored($namespace));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveViewHelperClassNameThrowsExceptionIfClassNotResolved(): void
+    {
+        $this->expectException(Exception::class);
+        $subject = new ViewHelperResolver();
+        $subject->resolveViewHelperClassName('f', 'invalid');
+    }
+
+    /**
+     * @test
+     */
+    public function resolveViewHelperClassNameSupportsMultipleNamespaces(): void
+    {
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('f', 'Foo1\\Bar1');
+        $subject->addNamespace('f', 'TYPO3Fluid\\Fluid\\ViewHelpers');
+        $subject->addNamespace('f', 'Foo2\\Bar2');
+        self::assertSame('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $subject->resolveViewHelperClassName('f', 'render'));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveViewHelperClassNameDoesNotChokeOnNullInMultipleNamespaces(): void
+    {
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('f', null);
+        $subject->addNamespace('f', 'TYPO3Fluid\\Fluid\\ViewHelpers');
+        $subject->addNamespace('f', null);
+        self::assertSame('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $subject->resolveViewHelperClassName('f', 'render'));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveViewHelperClassNameTrimsBackslashSuffixFromNamespace(): void
+    {
+        $subject = new ViewHelperResolver();
+        $subject->addNamespace('f', 'TYPO3Fluid\\Fluid\\ViewHelpers\\');
+        self::assertSame('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $subject->resolveViewHelperClassName('f', 'render'));
+    }
+
+    public static function resolvePhpNamespaceFromFluidNamespaceDataProvider(): array
+    {
+        return [
+            ['Foo\\Bar', 'Foo\\Bar\\ViewHelpers'],
+            ['Foo\\Bar\\ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
+            ['http://typo3.org/ns/Foo/Bar/ViewHelpers', 'Foo\\Bar\\ViewHelpers'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider resolvePhpNamespaceFromFluidNamespaceDataProvider
+     */
+    public function resolvePhpNamespaceFromFluidNamespace(string $input, string $expected): void
+    {
+        $subject = new ViewHelperResolver();
+        self::assertSame($expected, $subject->resolvePhpNamespaceFromFluidNamespace($input));
+    }
+
+    /**
+     * @test
+     */
+    public function createViewHelperInstanceCreatesInstance(): void
+    {
+        $subject = new ViewHelperResolver();
+        $result = $subject->createViewHelperInstance('f', 'render');
+        self::assertInstanceOf(RenderViewHelper::class, $result);
     }
 }

--- a/tests/Unit/View/AbstractViewTest.php
+++ b/tests/Unit/View/AbstractViewTest.php
@@ -9,19 +9,18 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
+use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\AbstractViewTestFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\AbstractView;
 
 class AbstractViewTest extends UnitTestCase
 {
     /**
      * @test
      */
-    public function testParentRenderMethodReturnsEmptyString(): void
+    public function renderReturnsEmptyString(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractView::class);
-        $result = $instance->render();
-        self::assertEquals('', $result);
+        $subject = new AbstractViewTestFixture();
+        self::assertSame('', $subject->render());
     }
 
     /**
@@ -29,9 +28,9 @@ class AbstractViewTest extends UnitTestCase
      */
     public function testAssignsVariableAndReturnsSelf(): void
     {
-        $mock = $this->getMockForAbstractClass(AbstractView::class);
-        $mock->assign('test', 'foobar');
-        self::assertAttributeEquals(['test' => 'foobar'], 'variables', $mock);
+        $subject = new AbstractViewTestFixture();
+        $subject->assign('test', 'foobar');
+        self::assertSame(['test' => 'foobar'], $subject->variables);
     }
 
     /**
@@ -39,8 +38,8 @@ class AbstractViewTest extends UnitTestCase
      */
     public function testAssignsMultipleVariablesAndReturnsSelf(): void
     {
-        $mock = $this->getMockForAbstractClass(AbstractView::class);
-        $mock->assignMultiple(['test' => 'foobar', 'baz' => 'barfoo']);
-        self::assertAttributeEquals(['test' => 'foobar', 'baz' => 'barfoo'], 'variables', $mock);
+        $subject = new AbstractViewTestFixture();
+        $subject->assignMultiple(['test' => 'foobar', 'baz' => 'barfoo']);
+        self::assertSame(['test' => 'foobar', 'baz' => 'barfoo'], $subject->variables);
     }
 }

--- a/tests/Unit/View/Fixtures/AbstractViewTestFixture.php
+++ b/tests/Unit/View/Fixtures/AbstractViewTestFixture.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures;
+
+use TYPO3Fluid\Fluid\View\AbstractView;
+
+/**
+ * Fixture to test AbstractView
+ */
+class AbstractViewTestFixture extends AbstractView
+{
+    /**
+     * Made public
+     */
+    public $variables = [];
+
+    /**
+     * Implement interface
+     */
+    public function renderSection($sectionName, array $variables = [], $ignoreUnknown = false)
+    {
+        return '';
+    }
+
+    /**
+     * Implement interface
+     */
+    public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = false)
+    {
+        return '';
+    }
+}

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 
 class TemplatePathsTest extends BaseTestCase
 {
-    public static function getSanitizePathTestValues(): array
+    public static function sanitizePathDataProvider(): array
     {
         return [
             ['', ''],
@@ -32,20 +32,18 @@ class TemplatePathsTest extends BaseTestCase
     }
 
     /**
-     * @param string|array $input
-     * @param string|array $expected
      * @test
-     * @dataProvider getSanitizePathTestValues
+     * @dataProvider sanitizePathDataProvider
      */
-    public function testSanitizePath($input, $expected): void
+    public function sanitizePath(string|array $input, string|array $expected): void
     {
-        $instance = new TemplatePaths();
-        $method = new \ReflectionMethod($instance, 'sanitizePath');
-        $output = $method->invokeArgs($instance, [$input]);
-        self::assertEquals($expected, $output);
+        $subject = new TemplatePaths();
+        $method = new \ReflectionMethod($subject, 'sanitizePath');
+        $output = $method->invokeArgs($subject, [$input]);
+        self::assertSame($expected, $output);
     }
 
-    public static function getSanitizePathsTestValues(): array
+    public static function sanitizePathsDataProvider(): array
     {
         return [
             [['/foo/bar/baz', 'C:\\foo\\bar\\baz'], ['/foo/bar/baz', 'C:/foo/bar/baz']],
@@ -56,37 +54,24 @@ class TemplatePathsTest extends BaseTestCase
 
     /**
      * @test
-     * @dataProvider getSanitizePathsTestValues
+     * @dataProvider sanitizePathsDataProvider
      */
-    public function testSanitizePaths(array $input, array $expected): void
+    public function sanitizePaths(array $input, array $expected): void
     {
-        $instance = new TemplatePaths();
-        $method = new \ReflectionMethod($instance, 'sanitizePaths');
-        $output = $method->invokeArgs($instance, [$input]);
-        self::assertEquals($expected, $output);
+        $subject = new TemplatePaths();
+        $method = new \ReflectionMethod($subject, 'sanitizePaths');
+        $output = $method->invokeArgs($subject, [$input]);
+        self::assertSame($expected, $output);
     }
 
     /**
      * @test
      */
-    public function setsLayoutPathAndFilename(): void
+    public function getLayoutPathAndFilenameReturnsPreviouslySetLayoutPathAndFilename(): void
     {
-        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
-        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $subject->setLayoutPathAndFilename('foobar');
-        self::assertAttributeEquals('foobar', 'layoutPathAndFilename', $subject);
-        self::assertEquals('foobar', $subject->getLayoutPathAndFilename());
-    }
-
-    /**
-     * @test
-     */
-    public function setsTemplatePathAndFilename(): void
-    {
-        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
-        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
-        $subject->setTemplatePathAndFilename('foobar');
-        self::assertAttributeEquals('foobar', 'templatePathAndFilename', $subject);
+        $subject = new TemplatePaths();
+        $subject->setLayoutPathAndFilename('/foobar');
+        self::assertSame('/foobar', $subject->getLayoutPathAndFilename());
     }
 
     public static function getGetterAndSetterTestValues(): array
@@ -109,7 +94,7 @@ class TemplatePathsTest extends BaseTestCase
         $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
         $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
         $subject->$setter($value);
-        self::assertEquals($value, $subject->$getter());
+        self::assertSame($value, $subject->$getter());
     }
 
     /**
@@ -194,7 +179,7 @@ class TemplatePathsTest extends BaseTestCase
         ];
         sort($result);
         sort($expected);
-        self::assertEquals(
+        self::assertSame(
             $expected,
             $result
         );
@@ -219,7 +204,7 @@ class TemplatePathsTest extends BaseTestCase
         $instance = new TemplatePaths();
         $stream = fopen($fixture, 'r');
         $instance->setTemplateSource($stream);
-        self::assertEquals(stream_get_contents($stream), $instance->getTemplateSource());
+        self::assertSame(stream_get_contents($stream), $instance->getTemplateSource());
         fclose($stream);
     }
 
@@ -241,7 +226,7 @@ class TemplatePathsTest extends BaseTestCase
     {
         $instance = new TemplatePaths();
         $instance->setTemplateSource('foobar');
-        self::assertEquals('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+        self::assertSame('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
     }
 
     /**
@@ -253,7 +238,7 @@ class TemplatePathsTest extends BaseTestCase
         $baseTemplatePath = __DIR__ . '/Fixtures';
         $subject->setTemplateRootPaths([$baseTemplatePath]);
         $foundFixture = $subject->resolveTemplateFileForControllerAndActionAndFormat('ARandomController', 'TestTemplate');
-        self::assertEquals($baseTemplatePath . '/ARandomController/TestTemplate.html', $foundFixture);
+        self::assertSame($baseTemplatePath . '/ARandomController/TestTemplate.html', $foundFixture);
         $identifier = $subject->getTemplateIdentifier('ARandomController', 'TestTemplate');
         self::assertStringStartsWith('ARandomController_action_TestTemplate_', $identifier);
     }
@@ -267,7 +252,7 @@ class TemplatePathsTest extends BaseTestCase
         $baseTemplatePath = __DIR__ . '/Fixtures';
         $subject->setTemplateRootPaths([$baseTemplatePath]);
         $foundFixture = $subject->resolveTemplateFileForControllerAndActionAndFormat('', 'UnparsedTemplateFixture');
-        self::assertEquals($baseTemplatePath . '/UnparsedTemplateFixture.html', $foundFixture);
+        self::assertSame($baseTemplatePath . '/UnparsedTemplateFixture.html', $foundFixture);
         $identifier = $subject->getTemplateIdentifier('', 'UnparsedTemplateFixture');
         self::assertStringStartsWith('action_UnparsedTemplateFixture_', $identifier);
     }


### PR DESCRIPTION
This asserter is used for whitebox tests.
The patch refactors usages to avoid whitebox
tests and deprecates the method.