### PR TITLE
[TASK] Avoid and deprecate getAccessibleMock()

### DIFF
--- a/tests/AccessibleObjectInterface.php
+++ b/tests/AccessibleObjectInterface.php
@@ -14,6 +14,7 @@ namespace TYPO3Fluid\Fluid\Tests;
  * Do not implement this interface in own classes.
  *
  * @internal
+ * @deprecated Remove together with helper methods in UnitTestCase
  */
 interface AccessibleObjectInterface
 {

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -27,6 +27,7 @@ abstract class BaseTestCase extends TestCase
      * @template T of object
      * @param class-string<T> $originalClassName Full qualified name of the original class
      * @return MockObject&AccessibleObjectInterface&T
+     * @deprecated Unused. Will be removed.
      */
     protected function getAccessibleMock(
         string $originalClassName,
@@ -159,6 +160,7 @@ abstract class BaseTestCase extends TestCase
      * @template T of object
      * @param class-string<T> $className Full qualified name of the original class
      * @return class-string<AccessibleObjectInterface&T> Full qualified name of the built class
+     * @deprecated Remove together with consuming methods.
      */
     private function buildAccessibleProxy(string $className): string
     {

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -59,8 +59,9 @@ class StandardCacheWarmerTest extends UnitTestCase
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $renderingContextMock->expects(self::once())->method('getVariableProvider')->willReturn(new StandardVariableProvider());
         $renderingContextMock->expects(self::once())->method('getTemplateParser')->willReturn($templateParserMock);
-        $subject = $this->getAccessibleMock(StandardCacheWarmer::class, []);
-        $result = $subject->_call('warmSingleFile', '/some/file', 'some_file', $renderingContextMock);
+        $subject = new StandardCacheWarmer();
+        $method = new \ReflectionMethod($subject, 'warmSingleFile');
+        $result = $method->invoke($subject, '/some/file', 'some_file', $renderingContextMock);
         self::assertNotEmpty($result->getFailureReason());
         self::assertNotEmpty($result->getMitigations());
     }
@@ -72,7 +73,7 @@ class StandardCacheWarmerTest extends UnitTestCase
     {
         $subject = new StandardCacheWarmer();
         $method = new \ReflectionMethod($subject, 'createClosure');
-        $closure = $method->invokeArgs($subject, [__FILE__]);
+        $closure = $method->invoke($subject, __FILE__);
         self::assertNotEmpty($closure(new TemplateParser(), new TemplatePaths()));
     }
 }

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -14,50 +14,34 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class FailedCompilingStateTest extends UnitTestCase
 {
-    public static function getPropertyTestValues(): array
-    {
-        return [
-            ['failureReason', 'test reason'],
-            ['mitigations', ['m1', 'm2']]
-        ];
-    }
-
     /**
-     * @param mixed $value
-     * @dataProvider getPropertyTestValues
      * @test
      */
-    public function testGetter(string $property, $value): void
+    public function getFailureReasonReturnsPreviouslySetFailureReason(): void
     {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, []);
-        $subject->_set($property, $value);
-        $method = 'get' . ucfirst($property);
-        self::assertEquals($value, $subject->$method());
-    }
-
-    /**
-     * @param mixed $value
-     * @dataProvider getPropertyTestValues
-     * @test
-     */
-    public function testSetter(string $property, $value): void
-    {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, []);
-        $subject->_set($property, $value);
-        $method = 'set' . ucfirst($property);
-        $getter = 'get' . ucfirst($property);
-        $subject->$method($value);
-        self::assertEquals($value, $subject->$getter());
+        $subject = new FailedCompilingState();
+        $subject->setFailureReason('failed');
+        self::assertSame('failed', $subject->getFailureReason());
     }
 
     /**
      * @test
      */
-    public function testAddMitigation(): void
+    public function getMitigationsReturnsPreviouslySetMitigation(): void
     {
-        $subject = $this->getAccessibleMock(FailedCompilingState::class, []);
-        $subject->_set('mitigations', ['m1']);
+        $subject = new FailedCompilingState();
+        $subject->setMitigations(['m1', 'm2']);
+        self::assertSame(['m1', 'm2'], $subject->getMitigations());
+    }
+
+    /**
+     * @test
+     */
+    public function addMitigationAddsAnotherMitigation(): void
+    {
+        $subject = new FailedCompilingState();
+        $subject->setMitigations(['m1']);
         $subject->addMitigation('m2');
-        self::assertEquals(['m1', 'm2'], $subject->getMitigations());
+        self::assertSame(['m1', 'm2'], $subject->getMitigations());
     }
 }

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\Interceptor;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
@@ -17,52 +16,24 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Tests\AccessibleObjectInterface;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class EscapeTest extends UnitTestCase
 {
     /**
-     * @var Escape&MockObject&AccessibleObjectInterface
-     */
-    private $escapeInterceptor;
-
-    /**
-     * @var AbstractViewHelper|MockObject
-     */
-    private $mockViewHelper;
-
-    /**
-     * @var ViewHelperNode|MockObject
-     */
-    private $mockNode;
-
-    /**
-     * @var ParsingState|MockObject
-     */
-    private $mockParsingState;
-
-    public function setUp(): void
-    {
-        $this->escapeInterceptor = $this->getAccessibleMock(Escape::class, []);
-        $this->mockViewHelper = $this->getMockBuilder(AbstractViewHelper::class)->disableOriginalConstructor()->getMock();
-        $this->mockNode = $this->getMockBuilder(ViewHelperNode::class)->disableOriginalConstructor()->getMock();
-        $this->mockParsingState = $this->getMockBuilder(ParsingState::class)
-            ->onlyMethods([])->disableOriginalConstructor()->getMock();
-    }
-
-    /**
      * @test
      */
     public function processDoesNotDisableEscapingInterceptorByDefault(): void
     {
-        $interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
-        $this->mockViewHelper->expects(self::once())->method('isChildrenEscapingEnabled')->willReturn(true);
-        $this->mockNode->expects(self::once())->method('getUninitializedViewHelper')->willReturn($this->mockViewHelper);
-
-        self::assertSame(0, $this->escapeInterceptor->_get('viewHelperNodesWhichDisableTheInterceptor'));
-        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-        self::assertSame(0, $this->escapeInterceptor->_get('viewHelperNodesWhichDisableTheInterceptor'));
+        $viewHelperMock = $this->createMock(AbstractViewHelper::class);
+        $viewHelperMock->expects(self::once())->method('isChildrenEscapingEnabled')->willReturn(true);
+        $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
+        $viewHelperNodeMock->expects(self::once())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
+        $subject = new Escape();
+        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
+        self::assertSame(0, $property->getValue($subject));
+        $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, new ParsingState());
+        self::assertSame(0, $property->getValue($subject));
     }
 
     /**
@@ -70,13 +41,15 @@ class EscapeTest extends UnitTestCase
      */
     public function processDisablesEscapingInterceptorIfViewHelperDisablesIt(): void
     {
-        $interceptorPosition = InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER;
-        $this->mockViewHelper->expects(self::once())->method('isChildrenEscapingEnabled')->willReturn(false);
-        $this->mockNode->expects(self::once())->method('getUninitializedViewHelper')->willReturn($this->mockViewHelper);
-
-        self::assertSame(0, $this->escapeInterceptor->_get('viewHelperNodesWhichDisableTheInterceptor'));
-        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-        self::assertSame(1, $this->escapeInterceptor->_get('viewHelperNodesWhichDisableTheInterceptor'));
+        $viewHelperMock = $this->createMock(AbstractViewHelper::class);
+        $viewHelperMock->expects(self::once())->method('isChildrenEscapingEnabled')->willReturn(false);
+        $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
+        $viewHelperNodeMock->expects(self::once())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
+        $subject = new Escape();
+        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
+        self::assertSame(0, $property->getValue($subject));
+        $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, new ParsingState());
+        self::assertSame(1, $property->getValue($subject));
     }
 
     /**
@@ -84,14 +57,15 @@ class EscapeTest extends UnitTestCase
      */
     public function processReenablesEscapingInterceptorOnClosingViewHelperTagIfItWasDisabledBefore(): void
     {
-        $interceptorPosition = InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER;
-        $this->mockViewHelper->expects(self::once())->method('isOutputEscapingEnabled')->willReturn(false);
-        $this->mockNode->expects(self::any())->method('getUninitializedViewHelper')->willReturn($this->mockViewHelper);
-
-        $this->escapeInterceptor->_set('viewHelperNodesWhichDisableTheInterceptor', 1);
-
-        $this->escapeInterceptor->process($this->mockNode, $interceptorPosition, $this->mockParsingState);
-        self::assertSame(0, $this->escapeInterceptor->_get('viewHelperNodesWhichDisableTheInterceptor'));
+        $viewHelperMock = $this->createMock(AbstractViewHelper::class);
+        $viewHelperMock->expects(self::once())->method('isOutputEscapingEnabled')->willReturn(false);
+        $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
+        $viewHelperNodeMock->expects(self::any())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
+        $subject = new Escape();
+        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
+        $property->setValue($subject, 1);
+        $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, new ParsingState());
+        self::assertSame(0, $property->getValue($subject));
     }
 
     /**
@@ -99,9 +73,8 @@ class EscapeTest extends UnitTestCase
      */
     public function processWrapsCurrentViewHelperInEscapeNode(): void
     {
-        $interceptorPosition = InterceptorInterface::INTERCEPT_OBJECTACCESSOR;
         $mockNode = $this->createMock(ObjectAccessorNode::class);
-        $actualResult = $this->escapeInterceptor->process($mockNode, $interceptorPosition, $this->mockParsingState);
-        self::assertInstanceOf(EscapingNode::class, $actualResult);
+        $subject = new Escape();
+        self::assertInstanceOf(EscapingNode::class, $subject->process($mockNode, InterceptorInterface::INTERCEPT_OBJECTACCESSOR, new ParsingState()));
     }
 }

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -21,7 +21,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
-use TYPO3Fluid\Fluid\View\TemplateView;
 
 class RenderingContextTest extends UnitTestCase
 {
@@ -40,8 +39,7 @@ class RenderingContextTest extends UnitTestCase
      */
     public function gettersReturnPreviouslySetValues(string $property, string|array $expected): void
     {
-        $view = new TemplateView();
-        $subject = $this->getAccessibleMock(RenderingContext::class, [], [$view]);
+        $subject = new RenderingContext();
         $setter = 'set' . ucfirst($property);
         $subject->$setter($expected);
         $getter = 'get' . ucfirst($property);

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -20,195 +20,23 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
     /**
      * @test
      */
-    public function testRenderCallsRenderOnTagBuilder(): void
+    public function renderCallsRenderOnTagBuilder(): void
     {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['render'])->getMock();
+        $tagBuilder = $this->createMock(TagBuilder::class);
         $tagBuilder->expects(self::once())->method('render')->willReturn('foobar');
-        $viewHelper->setTagBuilder($tagBuilder);
-        self::assertEquals('foobar', $viewHelper->render());
+        $subject = $this->getMockBuilder(AbstractTagBasedViewHelper::class)->onlyMethods([])->getMock();
+        $subject->setTagBuilder($tagBuilder);
+        self::assertEquals('foobar', $subject->render());
     }
 
     /**
      * @test
      */
-    public function oneTagAttributeIsRenderedCorrectly(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-
-        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $mockTagBuilder->expects(self::once())->method('addAttribute')->with('foo', 'bar');
-        $viewHelper->setTagBuilder($mockTagBuilder);
-
-        $viewHelper->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
-        $arguments = ['foo' => 'bar'];
-        $viewHelper->setArguments($arguments);
-        $viewHelper->initialize();
-    }
-
-    /**
-     * @test
-     */
-    public function additionalTagAttributesAreRenderedCorrectly(): void
-    {
-        $subject = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $subject->setRenderingContext(new RenderingContextFixture());
-
-        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $mockTagBuilder->expects(self::once())->method('addAttribute')->with('foo', 'bar');
-        $subject->setTagBuilder($mockTagBuilder);
-
-        $subject->_call('registerTagAttribute', 'foo', 'string', 'Description', false);
-        $arguments = ['additionalAttributes' => ['foo' => 'bar']];
-        $subject->setArguments($arguments);
-        $subject->initialize();
-    }
-
-    /**
-     * @test
-     */
-    public function dataAttributesAreRenderedCorrectly(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-
-        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $series = [
-            ['data-foo', 'fooValue'],
-            ['data-bar', 'barValue'],
-        ];
-        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
-            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
-            self::assertSame($expectedArgOne, $args[0]);
-            self::assertSame($expectedArgTwo, $args[1]);
-        });
-        $viewHelper->setTagBuilder($mockTagBuilder);
-
-        $arguments = ['data' => ['foo' => 'fooValue', 'bar' => 'barValue']];
-        $viewHelper->setArguments($arguments);
-        $viewHelper->initialize();
-    }
-
-    /**
-     * @test
-     */
-    public function ariaAttributesAreRenderedCorrectly(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-
-        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $series = [
-            ['aria-foo', 'fooValue'],
-            ['aria-bar', 'barValue'],
-        ];
-        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
-            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
-            self::assertSame($expectedArgOne, $args[0]);
-            self::assertSame($expectedArgTwo, $args[1]);
-        });
-        $viewHelper->setTagBuilder($mockTagBuilder);
-
-        $arguments = ['aria' => ['foo' => 'fooValue', 'bar' => 'barValue']];
-        $viewHelper->setArguments($arguments);
-        $viewHelper->initialize();
-    }
-
-    /**
-     * @test
-     */
-    public function testValidateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments(): void
+    public function validateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments(): void
     {
         $this->expectException(Exception::class);
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-        $viewHelper->validateAdditionalArguments(['foo' => 'bar']);
-    }
-
-    /**
-     * @test
-     */
-    public function testHandleAdditionalArgumentsSetsTagAttributesForDataArguments(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $series = [
-            ['data-foo', 'fooValue'],
-            ['data-bar', 'barValue'],
-        ];
-        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
-            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
-            self::assertSame($expectedArgOne, $args[0]);
-            self::assertSame($expectedArgTwo, $args[1]);
-        });
-        $viewHelper->setTagBuilder($tagBuilder);
-        $viewHelper->handleAdditionalArguments(['data-foo' => 'fooValue', 'data-bar' => 'barValue']);
-        $viewHelper->initializeArgumentsAndRender();
-    }
-
-    /**
-     * @test
-     */
-    public function testHandleAdditionalArgumentsSetsTagAttributesForAriaArguments(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-        $tagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $series = [
-            ['aria-foo', 'fooValue'],
-            ['aria-bar', 'barValue'],
-        ];
-        $tagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
-            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
-            self::assertSame($expectedArgOne, $args[0]);
-            self::assertSame($expectedArgTwo, $args[1]);
-        });
-        $viewHelper->setTagBuilder($tagBuilder);
-        $viewHelper->handleAdditionalArguments(['aria-foo' => 'fooValue', 'aria-bar' => 'barValue']);
-        $viewHelper->initializeArgumentsAndRender();
-    }
-
-    /**
-     * @test
-     */
-    public function standardTagAttributesAreRegistered(): void
-    {
-        $viewHelper = $this->getAccessibleMock(AbstractTagBasedViewHelper::class, [], [], '', false);
-        $viewHelper->setRenderingContext(new RenderingContextFixture());
-
-        $mockTagBuilder = $this->getMockBuilder(TagBuilder::class)->onlyMethods(['addAttribute'])->getMock();
-        $series = [
-            ['class', 'classAttribute'],
-            ['dir', 'dirAttribute'],
-            ['id', 'idAttribute'],
-            ['lang', 'langAttribute'],
-            ['style', 'styleAttribute'],
-            ['title', 'titleAttribute'],
-            ['accesskey', 'accesskeyAttribute'],
-            ['tabindex', 'tabindexAttribute']
-        ];
-        $mockTagBuilder->expects(self::atLeastOnce())->method('addAttribute')->willReturnCallback(function (...$args) use (&$series): void {
-            [$expectedArgOne, $expectedArgTwo] = array_shift($series);
-            self::assertSame($expectedArgOne, $args[0]);
-            self::assertSame($expectedArgTwo, $args[1]);
-        });
-        $viewHelper->setTagBuilder($mockTagBuilder);
-
-        $arguments = [
-            'class' => 'classAttribute',
-            'dir' => 'dirAttribute',
-            'id' => 'idAttribute',
-            'lang' => 'langAttribute',
-            'style' => 'styleAttribute',
-            'title' => 'titleAttribute',
-            'accesskey' => 'accesskeyAttribute',
-            'tabindex' => 'tabindexAttribute'
-        ];
-        $viewHelper->_call('registerUniversalTagAttributes');
-        $viewHelper->setArguments($arguments);
-        $viewHelper->initializeArguments();
-        $viewHelper->initialize();
+        $subject = $this->getMockBuilder(AbstractTagBasedViewHelper::class)->onlyMethods([])->getMock();
+        $subject->setRenderingContext(new RenderingContextFixture());
+        $subject->validateAdditionalArguments(['foo' => 'bar']);
     }
 }

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -230,18 +230,15 @@ class TagBuilderTest extends UnitTestCase
      */
     public function resetResetsTagBuilder(): void
     {
-        $tagBuilder = $this->getAccessibleMock(TagBuilder::class, []);
+        $tagBuilder = new TagBuilder();
         $tagBuilder->setTagName('tagName');
         $tagBuilder->setContent('some content');
-        $tagBuilder->forceClosingTag(true);
         $tagBuilder->addAttribute('attribute1', 'attribute1value');
-        $tagBuilder->addAttribute('attribute2', 'attribute2value');
         $tagBuilder->reset();
 
-        self::assertEquals('', $tagBuilder->_get('tagName'));
-        self::assertEquals('', $tagBuilder->_get('content'));
-        self::assertEquals([], $tagBuilder->_get('attributes'));
-        self::assertFalse($tagBuilder->_get('forceClosingTag'));
+        self::assertSame('', $tagBuilder->getTagName());
+        self::assertSame('', $tagBuilder->getContent());
+        self::assertSame([], $tagBuilder->getAttributes());
     }
 
     /**


### PR DESCRIPTION
This is another test related method that tends
to perform whitebox tests. The patch refactors
usages to avoid the method which uses some phpunit methods that are soft-deprecated itself. The
strategy is to get rid of a lot of whitebox
tests, but to fetch and set state using PHP
reflection directly in cases where this is not
useful.