### PR TITLE
[TASK] Prefer invoke() over invokeArgs() in tests

### DIFF
--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -27,9 +27,9 @@ class StandardCacheWarmerTest extends UnitTestCase
     public function testDetectControllerNamesInTemplateRootPaths(): void
     {
         $subject = new StandardCacheWarmer();
-        $method = new \ReflectionMethod($subject, 'detectControllerNamesInTemplateRootPaths');
         $directory = realpath(__DIR__ . '/../../../../examples/Resources/Private/Templates/');
-        $generator = $method->invokeArgs($subject, [[$directory]]);
+        $method = new \ReflectionMethod($subject, 'detectControllerNamesInTemplateRootPaths');
+        $generator = $method->invoke($subject, [$directory]);
         foreach ($generator as $resolvedControllerName) {
             self::assertNotEmpty($resolvedControllerName, 'Generator yielded an empty controller name!');
         }

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -54,7 +54,7 @@ class AbstractNodeTest extends UnitTestCase
         $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
         $subject->addChildNode($childNode);
         $method = new \ReflectionMethod($subject, 'evaluateChildNode');
-        $method->invokeArgs($subject, [$childNode, $renderingContextMock, true]);
+        $method->invoke($subject, $childNode, $renderingContextMock, true);
     }
 
     /**
@@ -69,7 +69,7 @@ class AbstractNodeTest extends UnitTestCase
         $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
         $subject->addChildNode($childNode);
         $method = new \ReflectionMethod($subject, 'evaluateChildNode');
-        $result = $method->invokeArgs($subject, [$childNode, $renderingContextMock, true]);
+        $result = $method->invoke($subject, $childNode, $renderingContextMock, true);
         self::assertEquals('foobar', $result);
     }
 
@@ -87,7 +87,7 @@ class AbstractNodeTest extends UnitTestCase
         $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn('foo');
         $subject->addChildNode($child2);
         $method = new \ReflectionMethod($subject, 'evaluateChildNodes');
-        $result = $method->invokeArgs($subject, [$renderingContextMock, true]);
+        $result = $method->invoke($subject, $renderingContextMock, true);
         self::assertEquals('foobar', $result);
     }
 

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -52,7 +52,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($context);
         $method = new \ReflectionMethod($subject, 'initializeViewHelperAndAddItToStack');
-        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render', []]);
+        $result = $method->invoke($subject, new ParsingState(), 'f', 'render', []);
         self::assertNull($result);
     }
 
@@ -70,7 +70,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($context);
         $method = new \ReflectionMethod($subject, 'initializeViewHelperAndAddItToStack');
-        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render', []]);
+        $result = $method->invoke($subject, new ParsingState(), 'f', 'render', []);
         self::assertNull($result);
     }
 
@@ -86,7 +86,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($context);
         $method = new \ReflectionMethod($subject, 'closingViewHelperTagHandler');
-        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render']);
+        $result = $method->invoke($subject, new ParsingState(), 'f', 'render');
         self::assertFalse($result);
     }
 
@@ -104,7 +104,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($context);
         $method = new \ReflectionMethod($subject, 'closingViewHelperTagHandler');
-        $result = $method->invokeArgs($subject, [new ParsingState(), 'f', 'render']);
+        $result = $method->invoke($subject, new ParsingState(), 'f', 'render');
         self::assertFalse($result);
     }
 
@@ -132,7 +132,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($renderingContext);
         $method = new \ReflectionMethod($subject, 'buildObjectTree');
-        $method->invokeArgs($subject, [['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS]);
+        $method->invoke($subject, ['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS);
     }
 
     /**
@@ -589,7 +589,7 @@ class TemplateParserTest extends UnitTestCase
         $subject = new TemplateParser();
         $subject->setRenderingContext($context);
         $method = new \ReflectionMethod($subject, 'recursiveArrayHandler');
-        $result = $method->invokeArgs($subject, [$state, $string]);
+        $result = $method->invoke($subject, $state, $string);
 
         self::assertEquals($expected, $result);
     }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -39,7 +39,7 @@ class TemplatePathsTest extends BaseTestCase
     {
         $subject = new TemplatePaths();
         $method = new \ReflectionMethod($subject, 'sanitizePath');
-        $output = $method->invokeArgs($subject, [$input]);
+        $output = $method->invoke($subject, $input);
         self::assertSame($expected, $output);
     }
 
@@ -60,7 +60,7 @@ class TemplatePathsTest extends BaseTestCase
     {
         $subject = new TemplatePaths();
         $method = new \ReflectionMethod($subject, 'sanitizePaths');
-        $output = $method->invokeArgs($subject, [$input]);
+        $output = $method->invoke($subject, $input);
         self::assertSame($expected, $output);
     }
 
@@ -165,12 +165,9 @@ class TemplatePathsTest extends BaseTestCase
      */
     public function testResolveFilesInFolders(): void
     {
-        $instance = new TemplatePaths();
-        $method = new \ReflectionMethod($instance, 'resolveFilesInFolders');
-        $result = $method->invokeArgs(
-            $instance,
-            [['examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'], 'html']
-        );
+        $subject = new TemplatePaths();
+        $method = new \ReflectionMethod($subject, 'resolveFilesInFolders');
+        $result = $method->invoke($subject, ['examples/Resources/Private/Layouts/', 'examples/Resources/Private/Templates/Default/'], 'html');
         $expected = [
             'examples/Resources/Private/Layouts/Default.html',
             'examples/Resources/Private/Layouts/Dynamic.html',
@@ -216,7 +213,7 @@ class TemplatePathsTest extends BaseTestCase
         $this->expectException(InvalidTemplateResourceException::class);
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
-        $method->invokeArgs($instance, [['/not/', '/found/'], 'notfound.html']);
+        $method->invoke($instance, ['/not/', '/found/'], 'notfound.html');
     }
 
     /**


### PR DESCRIPTION
Calling invoke() instead of invokeArgs()
on reflected methods is more easy to read.