### PR TITLE
[TASK] Avoid getMockForAbstractClass()

### DIFF
--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
-use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler\Fixtures\AbstractCompiledTemplateTestFixture;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\Fixtures\RenderingContextFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -19,92 +19,86 @@ class AbstractCompiledTemplateTest extends UnitTestCase
     /**
      * @test
      */
-    public function testSetIdentifierDoesNotChangeObject(): void
+    public function setIdentifierDoesNotChangeObject(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $before = clone $instance;
-        $instance->setIdentifier('test');
-        self::assertEquals($before, $instance);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        $before = clone $subject;
+        $subject->setIdentifier('test');
+        self::assertEquals($before, $subject);
     }
 
     /**
      * @test
      */
-    public function testGetIdentifierReturnsClassName(): void
+    public function getIdentifierReturnsClassName(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        self::assertEquals($instance->getIdentifier(), get_class($instance));
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertEquals($subject->getIdentifier(), get_class($subject));
     }
 
     /**
      * @test
      */
-    public function testParentGetVariableContainerMethodReturnsStandardVariableProvider(): void
+    public function getVariableContainerReturnsStandardVariableProvider(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->getVariableContainer();
-        self::assertInstanceOf(StandardVariableProvider::class, $result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertInstanceOf(StandardVariableProvider::class, $subject->getVariableContainer());
     }
 
     /**
      * @test
      */
-    public function testParentRenderMethodReturnsEmptyString(): void
+    public function renderReturnsEmptyString(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->render(new RenderingContextFixture());
-        self::assertEquals('', $result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertEquals('', $subject->render(new RenderingContextFixture()));
     }
 
     /**
      * @test
      */
-    public function testParentGetLayoutNameMethodReturnsEmptyString(): void
+    public function getLayoutNameReturnsEmptyString(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->getLayoutName(new RenderingContextFixture());
-        self::assertEquals('', $result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertEquals('', $subject->getLayoutName(new RenderingContextFixture()));
     }
 
     /**
      * @test
      */
-    public function testParentHasLayoutMethodReturnsFalse(): void
+    public function hasLayoutReturnsFalse(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->hasLayout();
-        self::assertFalse($result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertFalse($subject->hasLayout());
     }
 
     /**
      * @test
      */
-    public function testIsCompilableReturnsFalse(): void
+    public function isCompilableReturnsFalse(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->isCompilable();
-        self::assertFalse($result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertFalse($subject->isCompilable());
     }
 
     /**
      * @test
      */
-    public function testIsCompiledReturnsTrue(): void
+    public function isCompiledReturnsTrue(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
-        $result = $instance->isCompiled();
-        self::assertTrue($result);
+        $subject = new AbstractCompiledTemplateTestFixture();
+        self::assertTrue($subject->isCompiled());
     }
 
     /**
      * @test
      */
-    public function testAddCompiledNamespacesDoesNothing(): void
+    public function addCompiledNamespacesDoesNothing(): void
     {
-        $instance = $this->getMockForAbstractClass(AbstractCompiledTemplate::class);
+        $subject = new AbstractCompiledTemplateTestFixture();
         $context = new RenderingContextFixture();
         $before = $context->getViewHelperResolver()->getNamespaces();
-        $instance->addCompiledNamespaces($context);
+        $subject->addCompiledNamespaces($context);
         $after = $context->getViewHelperResolver()->getNamespaces();
         self::assertEquals($before, $after);
     }

--- a/tests/Unit/Core/Compiler/Fixtures/AbstractCompiledTemplateTestFixture.php
+++ b/tests/Unit/Core/Compiler/Fixtures/AbstractCompiledTemplateTestFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
+
+/**
+ * Subject fixture for AbstractCompiledTemplateTest
+ */
+class AbstractCompiledTemplateTestFixture extends AbstractCompiledTemplate
+{
+}

--- a/tests/Unit/Core/Compiler/NodeConverterTest.php
+++ b/tests/Unit/Core/Compiler/NodeConverterTest.php
@@ -129,10 +129,10 @@ class NodeConverterTest extends UnitTestCase
     /**
      * @test
      */
-    public function instanceOfAbstractMockReturnsEmptyStringConvertExecution(): void
+    public function convertReturnsEmptyExecutionWithNodeOnlyImplementingNodeInterface(): void
     {
         $subject = new NodeConverter(new TemplateCompiler());
-        $result = $subject->convert($this->getMockBuilder(NodeInterface::class)->getMockForAbstractClass());
+        $result = $subject->convert($this->createMock(NodeInterface::class));
         self::assertEquals('', $result['execution']);
     }
 }

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -141,8 +141,8 @@ class TemplateParserTest extends UnitTestCase
     public function testParseCallsPreProcessOnTemplateProcessors(): void
     {
         $subject = new TemplateParser();
-        $processor1 = $this->getMockForAbstractClass(TemplateProcessorInterface::class, [], '', false, false, true, ['preProcessSource']);
-        $processor2 = clone $processor1;
+        $processor1 = $this->createMock(TemplateProcessorInterface::class);
+        $processor2 = $this->createMock(TemplateProcessorInterface::class);
         $processor1->expects(self::once())->method('preProcessSource')->with('source1')->willReturn('source2');
         $processor2->expects(self::once())->method('preProcesssource')->with('source2')->willReturn('final');
         $context = new RenderingContextFixture();

--- a/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
+++ b/tests/Unit/Core/ViewHelper/Traits/Fixtures/ParserRuntimeOnlyFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
-use TYPO3Fluid\Fluid\View\AbstractTemplateView;
+use TYPO3Fluid\Fluid\View\ViewInterface;
 
 class ViewHelperVariableContainerTest extends UnitTestCase
 {
@@ -21,13 +21,12 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function storedDataCanBeReadOutAgain(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
+        $subject = new ViewHelperVariableContainer();
         $variable = 'Hello world';
-        self::assertFalse($viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
-        $viewHelperVariableContainer->add(TestViewHelper::class, 'test', $variable);
-        self::assertTrue($viewHelperVariableContainer->exists(TestViewHelper::class, 'test'));
-
-        self::assertEquals($variable, $viewHelperVariableContainer->get(TestViewHelper::class, 'test'));
+        self::assertFalse($subject->exists(TestViewHelper::class, 'test'));
+        $subject->add(TestViewHelper::class, 'test', $variable);
+        self::assertTrue($subject->exists(TestViewHelper::class, 'test'));
+        self::assertEquals($variable, $subject->get(TestViewHelper::class, 'test'));
     }
 
     /**
@@ -35,9 +34,9 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function addOrUpdateSetsAKeyIfItDoesNotExistYet(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
-        self::assertEquals($viewHelperVariableContainer->get('Foo\Bar', 'nonExistentKey'), 'value1');
+        $subject = new ViewHelperVariableContainer();
+        $subject->add('Foo\Bar', 'nonExistentKey', 'value1');
+        self::assertEquals($subject->get('Foo\Bar', 'nonExistentKey'), 'value1');
     }
 
     /**
@@ -45,10 +44,10 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function addOrUpdateOverridesAnExistingKey(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'value1');
-        $viewHelperVariableContainer->addOrUpdate('Foo\Bar', 'someKey', 'value2');
-        self::assertEquals($viewHelperVariableContainer->get('Foo\Bar', 'someKey'), 'value2');
+        $subject = new ViewHelperVariableContainer();
+        $subject->add('Foo\Bar', 'someKey', 'value1');
+        $subject->addOrUpdate('Foo\Bar', 'someKey', 'value2');
+        self::assertEquals($subject->get('Foo\Bar', 'someKey'), 'value2');
     }
 
     /**
@@ -56,10 +55,10 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function aSetValueCanBeRemovedAgain(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->add('Foo\Bar', 'nonExistentKey', 'value1');
-        $viewHelperVariableContainer->remove('Foo\Bar', 'nonExistentKey');
-        self::assertFalse($viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
+        $subject = new ViewHelperVariableContainer();
+        $subject->add('Foo\Bar', 'nonExistentKey', 'value1');
+        $subject->remove('Foo\Bar', 'nonExistentKey');
+        self::assertFalse($subject->exists('Foo\Bar', 'nonExistentKey'));
     }
 
     /**
@@ -67,8 +66,8 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function existsReturnsFalseIfTheSpecifiedKeyDoesNotExist(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        self::assertFalse($viewHelperVariableContainer->exists('Foo\Bar', 'nonExistentKey'));
+        $subject = new ViewHelperVariableContainer();
+        self::assertFalse($subject->exists('Foo\Bar', 'nonExistentKey'));
     }
 
     /**
@@ -76,9 +75,9 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function existsReturnsTrueIfTheSpecifiedKeyExists(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->add('Foo\Bar', 'someKey', 'someValue');
-        self::assertTrue($viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
+        $subject = new ViewHelperVariableContainer();
+        $subject->add('Foo\Bar', 'someKey', 'someValue');
+        self::assertTrue($subject->exists('Foo\Bar', 'someKey'));
     }
 
     /**
@@ -86,20 +85,20 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function existsReturnsTrueIfTheSpecifiedKeyExistsAndIsNull(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->add('Foo\Bar', 'someKey', null);
-        self::assertTrue($viewHelperVariableContainer->exists('Foo\Bar', 'someKey'));
+        $subject = new ViewHelperVariableContainer();
+        $subject->add('Foo\Bar', 'someKey', null);
+        self::assertTrue($subject->exists('Foo\Bar', 'someKey'));
     }
 
     /**
      * @test
      */
-    public function viewCanBeReadOutAgain(): void
+    public function getViewReturnsPreviouslySetView(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $view = $this->getMockForAbstractClass(AbstractTemplateView::class);
-        $viewHelperVariableContainer->setView($view);
-        self::assertSame($view, $viewHelperVariableContainer->getView());
+        $subject = new ViewHelperVariableContainer();
+        $view = $this->createMock(ViewInterface::class);
+        $subject->setView($view);
+        self::assertSame($view, $subject->getView());
     }
 
     /**
@@ -107,9 +106,9 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function getAllGetsAllVariables(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->addAll('Foo\\Bar', ['foo' => 'foo', 'bar' => 'bar']);
-        self::assertSame(['foo' => 'foo', 'bar' => 'bar'], $viewHelperVariableContainer->getAll('Foo\\Bar'));
+        $subject = new ViewHelperVariableContainer();
+        $subject->addAll('Foo\\Bar', ['foo' => 'foo', 'bar' => 'bar']);
+        self::assertSame(['foo' => 'foo', 'bar' => 'bar'], $subject->getAll('Foo\\Bar'));
     }
 
     /**
@@ -117,9 +116,9 @@ class ViewHelperVariableContainerTest extends UnitTestCase
      */
     public function getAllReturnsDefaultIfNotFound(): void
     {
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->addAll('Foo\\Bar', ['foo' => 'foo']);
-        self::assertSame(['foo' => 'bar'], $viewHelperVariableContainer->getAll('Baz\\Baz', ['foo' => 'bar']));
+        $subject = new ViewHelperVariableContainer();
+        $subject->addAll('Foo\\Bar', ['foo' => 'foo']);
+        self::assertSame(['foo' => 'bar'], $subject->getAll('Baz\\Baz', ['foo' => 'bar']));
     }
 
     /**
@@ -128,14 +127,14 @@ class ViewHelperVariableContainerTest extends UnitTestCase
     public function addAllThrowsInvalidArgumentExceptionOnUnsupportedType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $viewHelperVariableContainer = new ViewHelperVariableContainer();
-        $viewHelperVariableContainer->addAll('Foo\\Bar', new \DateTime('now'));
+        $subject = new ViewHelperVariableContainer();
+        $subject->addAll('Foo\\Bar', new \DateTime('now'));
     }
 
     /**
      * @test
      */
-    public function testSleepReturnsExpectedPropertyNames(): void
+    public function sleepReturnsExpectedPropertyNames(): void
     {
         $subject = new ViewHelperVariableContainer();
         $properties = $subject->__sleep();
@@ -145,7 +144,7 @@ class ViewHelperVariableContainerTest extends UnitTestCase
     /**
      * @test
      */
-    public function testGetReturnsDefaultIfRequestedVariableDoesNotExist(): void
+    public function getReturnsDefaultIfRequestedVariableDoesNotExist(): void
     {
         $subject = new ViewHelperVariableContainer();
         self::assertEquals('test', $subject->get('foo', 'bar', 'test'));

--- a/tests/Unit/View/Fixtures/AbstractTemplateViewTestFixture.php
+++ b/tests/Unit/View/Fixtures/AbstractTemplateViewTestFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures;
+
+use TYPO3Fluid\Fluid\View\AbstractTemplateView;
+
+/**
+ * Fixture to test AbstractTemplateView
+ */
+class AbstractTemplateViewTestFixture extends AbstractTemplateView
+{
+}

--- a/tests/Unit/View/Fixtures/AbstractViewTestFixture.php
+++ b/tests/Unit/View/Fixtures/AbstractViewTestFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.


### PR DESCRIPTION
phpunit 10.1 deprecated getMockForAbstractClass(). We rewrite a couple of tests to avoid it.