### PR TITLE
[TASK] Avoid unused variable in TemplateParser

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -341,7 +341,8 @@ class TemplateParser
         }
 
         $viewHelper = $viewHelperResolver->createViewHelperInstance($namespaceIdentifier, $methodIdentifier);
-        $argumentDefinitions = $viewHelper->prepareArguments();
+        // @todo: Is this call needed?
+        $viewHelper->prepareArguments();
         $viewHelperNode = $this->initializeViewHelperAndAddItToStack(
             $state,
             $namespaceIdentifier,


### PR DESCRIPTION
$argumentDefinition is not used within the method
and can be removed. It's unclear if the call to
prepareArguments() is needed (no test fail when
removed), we'll keep it for now and add a @todo.