### PR TITLE
[TASK] Avoid dependency to ParsingState in ViewHelperNode

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,11 +46,6 @@ parameters:
 			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php
 
 		-
-			message: "#^Constructor of class TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\SyntaxTree\\\\ViewHelperNode has an unused parameter \\$state\\.$#"
-			count: 1
-			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php
-
-		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -9,7 +9,6 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
@@ -51,9 +50,8 @@ class ViewHelperNode extends AbstractNode
      * @param string $namespace the namespace identifier of the ViewHelper.
      * @param string $identifier the name of the ViewHelper to render, inside the namespace provided.
      * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
-     * @param ParsingState $state
      */
-    public function __construct(RenderingContextInterface $renderingContext, $namespace, $identifier, array $arguments, ParsingState $state)
+    public function __construct(RenderingContextInterface $renderingContext, $namespace, $identifier, array $arguments)
     {
         $resolver = $renderingContext->getViewHelperResolver();
         $this->arguments = $arguments;

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -388,8 +388,7 @@ class TemplateParser
                 $this->renderingContext,
                 $namespaceIdentifier,
                 $methodIdentifier,
-                $argumentsObjectTree,
-                $state
+                $argumentsObjectTree
             );
 
             $this->callInterceptor($currentViewHelperNode, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, $state);

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
-use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -32,7 +31,7 @@ class ViewHelperNodeTest extends UnitTestCase
         $viewHelperResolverMock->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
         $viewHelperResolverMock->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
         $arguments = [$this->createMock(NodeInterface::class)];
-        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', $arguments, new ParsingState());
+        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', $arguments);
         self::assertSame($arguments, $subject->getArguments());
     }
 
@@ -50,7 +49,7 @@ class ViewHelperNodeTest extends UnitTestCase
         $viewHelperInvokerMock = $this->createMock(ViewHelperInvoker::class);
         $renderingContextMock->expects(self::once())->method('getViewHelperInvoker')->willReturn($viewHelperInvokerMock);
         $viewHelperInvokerMock->expects(self::once())->method('invoke')->willReturn('test');
-        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', [$this->createMock(NodeInterface::class)], new ParsingState());
+        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', [$this->createMock(NodeInterface::class)]);
         $result = $subject->evaluate($renderingContextMock);
         self::assertSame('test', $result);
     }

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
@@ -178,7 +177,7 @@ class AbstractViewHelperTest extends UnitTestCase
     public function testCompileReturnsAndAssignsExpectedPhpCode(): void
     {
         $context = new RenderingContext();
-        $node = new ViewHelperNode($context, 'f', 'comment', [], new ParsingState());
+        $node = new ViewHelperNode($context, 'f', 'comment', []);
         $init = '';
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
         $result = $subject->compile('foobar', 'baz', $init, $node, new TemplateCompiler());


### PR DESCRIPTION
ViewHelperNode has an unused constructor argument
$parsingState. This is also not used in casual consumer and can be removed without further headaches. This seems to be an left over from early v2 development.