### PR TITLE
[TASK] Set native `$node` property type `NodeInterface` in EscapingNode

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Core/Parser/ParsingState.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\SyntaxTree\\\\EscapingNode\\:\\:evaluate\\(\\) should return float\\|int but returns string\\.$#"
-			count: 1
-			path: src/Core/Parser/SyntaxTree/EscapingNode.php
-
-		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:setViewHelperNode\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -18,10 +18,8 @@ class EscapingNode extends AbstractNode
 {
     /**
      * Node to be escaped
-     *
-     * @var NodeInterface
      */
-    protected $node;
+    protected NodeInterface $node;
 
     /**
      * Constructor.
@@ -37,7 +35,7 @@ class EscapingNode extends AbstractNode
      * Return the value associated to the syntax tree.
      *
      * @param RenderingContextInterface $renderingContext
-     * @return number the value stored in this node/subtree.
+     * @return mixed the value stored in this node/subtree.
      */
     public function evaluate(RenderingContextInterface $renderingContext)
     {
@@ -48,10 +46,7 @@ class EscapingNode extends AbstractNode
         return $evaluated;
     }
 
-    /**
-     * @return NodeInterface
-     */
-    public function getNode()
+    public function getNode(): NodeInterface
     {
         return $this->node;
     }


### PR DESCRIPTION
Since minimum php version raise we can now use native
typed properties. `EscapingNode` property  `$node` can
be safely set to `NodeInterface`.

This is ensured by the two possible ways to set this
property, the constructor and `addChildNode()`.

Used command(s):

```shell
vendor/bin/phpstan analyze --no-progress \
  --generate-baseline=phpstan-baseline.neon
```
