### PR TITLE
[TASK] Mark SyntaxTree nodes as internal

### DIFF
--- a/src/Core/Parser/SyntaxTree/ArrayNode.php
+++ b/src/Core/Parser/SyntaxTree/ArrayNode.php
@@ -14,6 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * Array Syntax Tree Node. Handles JSON-like arrays.
  *
  * @internal
+ * @todo Make class final.
  */
 class ArrayNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -13,6 +13,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * A node which is used inside boolean arguments
+ *
+ * @internal
+ * @todo Make class final.
  */
 class BooleanNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -13,6 +13,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Escaping Node - wraps all content that must be escaped before output.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class EscapingNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
@@ -12,6 +12,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Type Casting Expression
  * Allows casting variables to specific types, for example `{myVariable as boolean}`
+ *
+ * @internal
+ * @todo Make class final.
  */
 class CastingExpressionNode extends AbstractExpressionNode
 {

--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -11,6 +11,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Math Expression Syntax Node - is a container for numeric values.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class MathExpressionNode extends AbstractExpressionNode
 {

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -14,6 +14,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Ternary Condition Node - allows the shorthand version
  * of a condition to be written as `{var ? thenvar : elsevar}`
+ *
+ * @internal
+ * @todo Make class final.
  */
 class TernaryExpressionNode extends AbstractExpressionNode
 {

--- a/src/Core/Parser/SyntaxTree/NumericNode.php
+++ b/src/Core/Parser/SyntaxTree/NumericNode.php
@@ -13,6 +13,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Numeric Syntax Tree Node - is a container for numeric values.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class NumericNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -12,6 +12,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * A node which handles object access. This means it handles structures like {object.accessor.bla}
+ *
+ * @internal
+ * @todo Make class final.
  */
 class ObjectAccessorNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/RootNode.php
+++ b/src/Core/Parser/SyntaxTree/RootNode.php
@@ -12,6 +12,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Root node of every syntax tree.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class RootNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/TextNode.php
+++ b/src/Core/Parser/SyntaxTree/TextNode.php
@@ -13,6 +13,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Text Syntax Tree Node - is a container for strings.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class TextNode extends AbstractNode
 {

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -15,6 +15,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 
 /**
  * Node which will call a ViewHelper associated with this node.
+ *
+ * @internal
+ * @todo Make class final.
  */
 class ViewHelperNode extends AbstractNode
 {


### PR DESCRIPTION
Concrete SyntaxTree node implementations can
be considered internal. Therefore, mark them
as such and add todo's to make them final.
