### PR TITLE
[TASK] Move convert code from ViewHelperNode to VH

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,11 +41,6 @@ parameters:
 			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php
 
 		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php
-
-		-
 			message: "#^Binary operation \"\\+\" between non\\-empty\\-string and 0 results in an error\\.$#"
 			count: 1
 			path: src/Core/Parser/TemplateParser.php
@@ -69,6 +64,11 @@ parameters:
 			message: "#^Property TYPO3Fluid\\\\Fluid\\\\Core\\\\Rendering\\\\RenderingContext\\:\\:\\$errorHandler \\(TYPO3Fluid\\\\Fluid\\\\Core\\\\ErrorHandler\\\\ErrorHandlerInterface\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: src/Core/Rendering/RenderingContext.php
+
+		-
+			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
+			count: 1
+			path: src/Core/ViewHelper/AbstractViewHelper.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between array\\|string and null will always evaluate to false\\.$#"

--- a/src/Core/Parser/SyntaxTree/NodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/NodeInterface.php
@@ -54,7 +54,7 @@ interface NodeInterface
      * - "execution" contains *a single PHP instruction* which needs to return the
      *               rendered output of the given element. Should NOT end with semicolon.
      *
-     * @return array<string, string>
+     * @return array{initialization: string, execution: string|number}
      * @internal There is a rather "hard" list of nodes within Fluid that are
      *           only hard to override by changing TemplateParser. As such,
      *           it's usually not needed to add new nodes that need different

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -7,7 +7,6 @@
 
 namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
-use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
@@ -148,78 +147,6 @@ class ViewHelperNode extends AbstractNode
 
     public function convert(TemplateCompiler $templateCompiler): array
     {
-        $initializationPhpCode = '// Rendering ViewHelper ' . $this->viewHelperClassName . chr(10);
-
-        // Build up $arguments array
-        $argumentsVariableName = $templateCompiler->variableName('arguments');
-        $renderChildrenClosureVariableName = $templateCompiler->variableName('renderChildrenClosure');
-        $viewHelperInitializationPhpCode = '';
-
-        try {
-            $convertedViewHelperExecutionCode = $this->uninitializedViewHelper->compile(
-                $argumentsVariableName,
-                $renderChildrenClosureVariableName,
-                $viewHelperInitializationPhpCode,
-                $this,
-                $templateCompiler
-            );
-
-            $accumulatedArgumentInitializationCode = '';
-            $argumentInitializationCode = sprintf('%s = [' . chr(10), $argumentsVariableName);
-
-            $arguments = $this->arguments;
-            $argumentDefinitions = $this->argumentDefinitions;
-            foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
-                if (!array_key_exists($argumentName, $arguments)) {
-                    // Argument *not* given to VH, use default value
-                    $defaultValue = $argumentDefinition->getDefaultValue();
-                    $argumentInitializationCode .= sprintf(
-                        '\'%s\' => %s,' . chr(10),
-                        $argumentName,
-                        is_array($defaultValue) && empty($defaultValue) ? '[]' : var_export($defaultValue, true)
-                    );
-                } else {
-                    // Argument *is* given to VH, resolve
-                    $argumentValue = $arguments[$argumentName];
-                    if ($argumentValue instanceof NodeInterface) {
-                        $converted = $argumentValue->convert($templateCompiler);
-                        if (!empty($converted['initialization'])) {
-                            $accumulatedArgumentInitializationCode .= $converted['initialization'];
-                        }
-                        $argumentInitializationCode .= sprintf(
-                            '\'%s\' => %s,' . chr(10),
-                            $argumentName,
-                            $converted['execution']
-                        );
-                    } else {
-                        $argumentInitializationCode .= sprintf(
-                            '\'%s\' => %s,' . chr(10),
-                            $argumentName,
-                            $argumentValue
-                        );
-                    }
-                }
-            }
-
-            $argumentInitializationCode .= '];' . chr(10);
-
-            // Build up closure which renders the child nodes
-            $initializationPhpCode .= sprintf(
-                '%s = %s;' . chr(10),
-                $renderChildrenClosureVariableName,
-                $templateCompiler->wrapChildNodesInClosure($this)
-            );
-
-            $initializationPhpCode .= $accumulatedArgumentInitializationCode . chr(10) . $argumentInitializationCode . $viewHelperInitializationPhpCode;
-        } catch (StopCompilingChildrenException $stopCompilingChildrenException) {
-            $convertedViewHelperExecutionCode = '\'' . str_replace("'", "\'", $stopCompilingChildrenException->getReplacementString()) . '\'';
-        }
-        $initializationArray = [
-            'initialization' => $initializationPhpCode,
-            // @todo: compile() *should* return strings, but it's not enforced in the interface.
-            //        The string cast is here to stay compatible in case something still returns for instance null.
-            'execution' => (string)$convertedViewHelperExecutionCode === '' ? "''" : $convertedViewHelperExecutionCode
-        ];
-        return $initializationArray;
+        return $this->uninitializedViewHelper->convert($templateCompiler);
     }
 }

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -13,9 +13,17 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
- * Interface ViewHelperInterface
+ * An interface all view helpers must implement.
  *
- * Implemented by all ViewHelpers
+ * @internal You may type hint this interface, but you should always
+ *           extend AbstractViewHelper or some other abstract that
+ *           extends AbstractViewHelper with own view helper
+ *           implementations.
+ *           This interface ships a couple of methods for internal use
+ *           which may change. Those methods are "correctly" implemented
+ *           in the AbstractViewHelper and maintained.
+ *           We'll try to resolve this restriction midterm, but you should
+ *           not fully implement ViewHelperInterface yourself for now.
  */
 interface ViewHelperInterface
 {
@@ -151,4 +159,29 @@ interface ViewHelperInterface
      * @param \Closure $renderChildrenClosure
      */
     public function setRenderChildrenClosure(\Closure $renderChildrenClosure);
+
+    /**
+     * Main method called at compile time to turn this ViewHelper
+     * into a PHP representation written to compiled templates cache.
+     *
+     * This method is a layer above / earlier than compile() and returns
+     * an array with identical structure as NodeInterface::convert().
+     *
+     * This method is considered Fluid internal, own view helpers should
+     * refrain from overriding this. Overriding this method is typically
+     * only needed when the compiled template code needs to be optimized
+     * in a way compile() does not allow.
+     *
+     * There are some caveats when overriding this method: First, this
+     * is not supported territory. Second, this may give additional
+     * headaches when a VH with this method "overrides" an existing
+     * VH via namespace declaration, since this adds a runtime dependency
+     * to compile time. Don't do it.
+     *
+     * @internal Do not override except you know exactly what you are doing.
+     *           Be prepared to maintain this in the future, it may break any time.
+     *           Also, both method signature and return array structure may change any time.
+     * @return array{initialization: string, execution: string}
+     */
+    public function convert(TemplateCompiler $templateCompiler): array;
 }


### PR DESCRIPTION
This aims to solve a class structure issue that
makes various things more complicated than they
should be, and prevents fixing various issues
with compiled templates.

When a template is parsed, view helpers are
represented by the ViewHelperNode in the
syntax tree.

At compile time, ViewHelperNode creates the PHP
representation of a view helper in convert().
convert() now creates the "outer" stuff - it
takes care of VH argument representation and
of embedding compiled children. For the "inner"
stuff, the specific ViewHelper compile()
method is called.

Various ViewHelpers thus override compile():
For instance, f:comment returns an empty string,
since it does not want anything to be rendered.

ViewHelperNode convert() however still compiles
children and adds them to the output, even though
this is not needed. This isn't great for f:comment, but it's a huge issue with f:if, which takes care
of children on it's own, but ViewHelperNode happily adds them a *second* time, which can be massive
with bigger f:then or f:else bodies.

There have been attempts to change this already:
The StopCompilingChildrenException can be thrown
in compile() in VH's, but then arguments
aren't compiled, either.

The true reason for these headaches is that the
"outer" stuff done in ViewHelperNode->convert()
does not belong there: Single VH's should
have full control over their compile representation, without ViewHelperNode->convert() assuming things.

The patch does exactly this: Move the convert()
body from ViewHelperNode to a new method in
AbstractViewHelper, which allows us to not only
solve the f:if / f:comment and friends issues
by overriding that method again, but also allows
us to phase out StopCompilingChildrenException
again.

Strictly speaking, this patch is breaking for two
reasons: First, we're changing ViewHelperInterface, and second, this fails when an existing VH currently has a method called "convert()" already.

We however consider this patch *not* being breaking *in practice* for these reasons, which is why we will add to next v2 minor:

First, we did not find a single Flow or TYPO3 related case where VH classes fully implement ViewHelperInterface on their own and do not extend AbstractViewHelper
directly or indirectly. We're now declaring
ViewHelperInterface @internal along the way and say that VH's *must* extend AbstractViewHelper. This should be ok and there are various internal ViewHelperInterface methods already.

Second, we could not find any public VH class with a method called "convert()" in neither Flow, nor
TYPO3 extensions. It seems this risk is very low.