### PR TITLE
[TASK] Deprecate StopCompilingChildrenException

### DIFF
--- a/src/Core/Compiler/StopCompilingChildrenException.php
+++ b/src/Core/Compiler/StopCompilingChildrenException.php
@@ -25,6 +25,11 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  * For example implemented in Cache/StaticViewHelper of Fluid.
  *
  * @api
+ * @deprecated This approach has been deprecated. If really needed, in
+ *             very rare cases, where a view helper takes care of
+ *             children on its own, AbstractViewHelper->convert() can
+ *             be overridden, when taking care of the risks commented
+ *             on the interface method.
  */
 class StopCompilingChildrenException extends \TYPO3Fluid\Fluid\Core\Exception
 {

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -602,6 +602,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
 
             $initializationPhpCode .= $accumulatedArgumentInitializationCode . chr(10) . $argumentInitializationCode . $viewHelperInitializationPhpCode;
         } catch (StopCompilingChildrenException $stopCompilingChildrenException) {
+            // @deprecated: Remove together with StopCompilingChildrenException and simplify surrounding code.
             $convertedViewHelperExecutionCode = '\'' . str_replace("'", "\'", $stopCompilingChildrenException->getReplacementString()) . '\'';
         }
         return [

--- a/src/ViewHelpers/Cache/StaticViewHelper.php
+++ b/src/ViewHelpers/Cache/StaticViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Cache;
 
-use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -88,23 +86,11 @@ class StaticViewHelper extends AbstractViewHelper
         return $this->renderChildren();
     }
 
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     */
-    public function compile(
-        $argumentsName,
-        $closureName,
-        &$initializationPhpCode,
-        ViewHelperNode $node,
-        TemplateCompiler $compiler
-    ) {
-        $renderedString = $node->evaluateChildNodes($this->renderingContext);
-        $stopCompilingChildrenException = new StopCompilingChildrenException();
-        $stopCompilingChildrenException->setReplacementString($renderedString);
-        throw $stopCompilingChildrenException;
+    final public function convert(TemplateCompiler $templateCompiler): array
+    {
+        return [
+            'initialization' => '// Rendering ViewHelper ' . $this->viewHelperNode->getViewHelperClassName() . chr(10),
+            'execution' => '\'' . str_replace("'", "\'", $this->viewHelperNode->evaluateChildNodes($this->renderingContext)) . '\'',
+        ];
     }
 }

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -12,6 +12,9 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
+/**
+ * @deprecated Remove together with StopCompilingChildrenException
+ */
 class StopCompilingChildrenExceptionTest extends UnitTestCase
 {
     /**


### PR DESCRIPTION
As established with 1f1dc5ac, we can stubstitute
this exception with a more simple solution.