### PR TITLE
[TASK] Optimize compiled code of condition VHs

### DIFF
--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -154,8 +154,7 @@ class BooleanNode extends AbstractNode
     public function convert(TemplateCompiler $templateCompiler): array
     {
         $stack = (new ArrayNode($this->getStack()))->convert($templateCompiler);
-        $initializationPhpCode = '// Rendering Boolean node' . chr(10);
-        $initializationPhpCode .= $stack['initialization'] . chr(10);
+        $initializationPhpCode = $stack['initialization'] . chr(10);
 
         $parser = new BooleanParser();
         $compiledExpression = $parser->compile(BooleanNode::reconcatenateExpression($this->getStack()));

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -95,6 +95,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  *     Otherwise, everything the value of the "else"-attribute is displayed.
  *
  * @api
+ * @todo: Declare final with next major
  */
 class IfViewHelper extends AbstractConditionViewHelper
 {


### PR DESCRIPTION
The AbstractConditionViewHelper based VH's take
care of children on their own. There is no need
to have them within compiled PHP code a second
time.

The patch adds a custom convert() method to
AbstractConditionViewHelper that optimizes
the generated PHP code accordingly.

This has a huge impact especially on f:if with
large bodies in practice, generated compiled
template code can shrink by half in size.

Resolves: #771