### PR TITLE
[TASK] Optimize compiled code of some VHs

### DIFF
--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -8,7 +8,6 @@
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -19,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  * CDATA tags to avoid this.
  *
  * Using this ViewHelper won't have a notable effect on performance,
- * especially once the template is parsed.  However it can lead to reduced
+ * especially once the template is parsed.  However, it can lead to reduced
  * readability. You can use layouts and partials to split a large template
  * into smaller parts. Using self-descriptive names for the partials can
  * make comments redundant.
@@ -73,17 +72,18 @@ class CommentViewHelper extends AbstractViewHelper
 
     public function render()
     {
-        return null;
+        return '';
     }
 
     /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @return string
+     * This VH does not ever output anything. We optimize compilation
+     * to always return an empty string.
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    final public function convert(TemplateCompiler $templateCompiler): array
     {
-        return '';
+        return [
+            'initialization' => '',
+            'execution' => '\'\'',
+        ];
     }
 }

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -42,7 +42,7 @@ class LayoutViewHelper extends AbstractViewHelper
 
     public function render()
     {
-        return null;
+        return '';
     }
 
     /**
@@ -54,6 +54,20 @@ class LayoutViewHelper extends AbstractViewHelper
     public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
     {
         return '';
+    }
+
+    /**
+     * This VH does not ever output anything as such: Layouts are
+     * handled differently in the compiler / parser and the f:render
+     * VH invokes section body execution.
+     * We optimize compilation to always return an empty here.
+     */
+    final public function convert(TemplateCompiler $templateCompiler): array
+    {
+        return [
+            'initialization' => '',
+            'execution' => '\'\'',
+        ];
     }
 
     /**

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -169,7 +169,7 @@ class RenderViewHelper extends AbstractViewHelper
         }
         // Replace empty content with default value. If default is
         // not set, NULL is returned and cast to a new, empty string
-        // outside of this ViewHelper.
+        // outside this ViewHelper.
         if ($content === '') {
             $content = $arguments['default'] ?: $tagContent ?: $renderChildrenClosure();
         }

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -98,14 +98,17 @@ class SectionViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @return string
+     * This VH does not ever output anything as such: Sections are
+     * handled differently in the compiler / parser and the f:render
+     * VH invokes section body execution.
+     * We optimize compilation to always return an empty here.
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    final public function convert(TemplateCompiler $templateCompiler): array
     {
-        return '';
+        return [
+            'initialization' => '',
+            'execution' => '\'\'',
+        ];
     }
 
     /**

--- a/tests/Functional/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CommentViewHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+class CommentViewHelperTest extends AbstractFunctionalTestCase
+{
+    /**
+     * @test
+     * @todo: That's a rather nasty side effect of f:comment. The parser
+     *        still parses f:comment body, so if the body contains
+     *        invalid stuff (e.g. a not closed VH tag), it explodes.
+     *        The workaround is to have a CDATA wrap, as in the test set
+     *        below. However, it might be possible to look into the parser
+     *        regexes to see if parsing of 'f:comment' content could be
+     *        suppressed somehow.
+     */
+    public function renderThrowsExceptionWhenEncapsulatingInvalidCode(): void
+    {
+        $this->expectException(Exception::class);
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:comment><f:render></f:comment>');
+        $view->render();
+    }
+
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'no output as self closing tag' => [
+            '<f:comment />',
+            '',
+        ];
+        yield 'no output when encapsulating something' => [
+            '<f:comment>notRendered</f:comment>',
+            '',
+        ];
+        yield 'before and after content is rendered' => [
+            'renderedBefore<f:comment>notRendered</f:comment>renderedAfter',
+            'renderedBeforerenderedAfter',
+        ];
+        yield 'does not choke with not closed tag wrapped in CDATA' => [
+            '<f:comment><![CDATA[<f:render>]]></f:comment>',
+            '',
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
There are a couple of view helpers that never
render the body closure as such. Those still
create unused code within compiled templates.

We can shortcut compilation in these VH's a
bit to create smaller compiled templates.

The patch has a huge positive effect on
compiled templates sizes especially due
to the f:section change, which until now
contained the entire body of each section
within the files twice.

f:comment - Obviously, comments are never rendered. f:layout - Layouts are resolved at a different
           level and the VH has no support for
           different children.
f:section - Sections are resolved at a different
            level and called via f:render. It's
            compiled variant does not need to
            take care of bodies itself.