### PR TITLE
[TASK] Declare TemplateParser and TemplateCompiler @internal

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -15,8 +15,9 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
- * @todo: declare final with next major. Nobody should extend / override here
- *        since compile details can be done in nodes.
+ * @internal Nobody should need to override this class.
+ * @todo: declare final with next major. Nobody should extend / override
+ *        here since compile details can be done in nodes or single VHs.
  */
 class TemplateCompiler
 {

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -25,7 +25,12 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 
 /**
- * Template parser building up an object syntax tree
+ * Template parser building up an object syntax tree.
+ *
+ * @internal Nobody should need to override this class. There
+ *           are various different ways to extend Fluid, the main
+ *           syntax tree should not be tampered with.
+ * @todo: Declare final with next major.
  */
 class TemplateParser
 {


### PR DESCRIPTION
Neither TemplateParser nor TemplateCompiler
should be subclassed. This area is Fluid core
only, tampering with these classes can easily
result in security issues and the need to deal
with further internal handling and details of
parsing regexes.

Consuming projects have various ways to override
other details.

In practice, only Flow currently subclasses
TemplateParser. The case is obsolete, and has
been reported as issue to the project.