### PR TITLE
[TASK] Make test classes `final`

### DIFF
--- a/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CompileWithContentArgumentAndRenderStaticTest extends AbstractFunctionalTestCase
+final class CompileWithContentArgumentAndRenderStaticTest extends AbstractFunctionalTestCase
 {
     public static function compileWithContentArgumentAndRenderStaticDataProvider(): array
     {

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Conditions;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class BasicConditionsTest extends AbstractFunctionalTestCase
+final class BasicConditionsTest extends AbstractFunctionalTestCase
 {
     public static function basicConditionDataProvider(): array
     {

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class VariableConditionsTest extends AbstractFunctionalTestCase
+final class VariableConditionsTest extends AbstractFunctionalTestCase
 {
     public static function variableConditionDataProvider(): array
     {

--- a/tests/Functional/Cases/CycleTest.php
+++ b/tests/Functional/Cases/CycleTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CycleTest extends AbstractFunctionalTestCase
+final class CycleTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/Cases/Errors/ParsingErrorsTest.php
+++ b/tests/Functional/Cases/Errors/ParsingErrorsTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class ParsingErrorsTest extends AbstractFunctionalTestCase
+final class ParsingErrorsTest extends AbstractFunctionalTestCase
 {
     public static function getTemplateCodeFixturesAndExpectations(): array
     {

--- a/tests/Functional/Cases/Escaping/EscapingTest.php
+++ b/tests/Functional/Cases/Escaping/EscapingTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class EscapingTest extends AbstractFunctionalTestCase
+final class EscapingTest extends AbstractFunctionalTestCase
 {
     public static function getTemplateCodeFixturesAndExpectations(): array
     {

--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -20,7 +20,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\MutableTestViewHelper
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class ViewHelperEscapingTest extends BaseTestCase
+final class ViewHelperEscapingTest extends BaseTestCase
 {
     private const UNESCAPED = '<script>alert(1)</script>';
     private const ESCAPED = '&lt;script&gt;alert(1)&lt;/script&gt;';

--- a/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
+++ b/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class NamespaceRegistrationTest extends AbstractFunctionalTestCase
+final class NamespaceRegistrationTest extends AbstractFunctionalTestCase
 {
     public static function getTemplateCodeFixturesAndExpectations(): array
     {

--- a/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class WhitespaceToleranceTest extends AbstractFunctionalTestCase
+final class WhitespaceToleranceTest extends AbstractFunctionalTestCase
 {
     public static function whitespaceToleranceDataProvider(): array
     {

--- a/tests/Functional/Cases/Rendering/DataAccessorTest.php
+++ b/tests/Functional/Cases/Rendering/DataAccessorTest.php
@@ -16,7 +16,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering\Fixtures\Objects\WithPrope
 use TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering\Fixtures\Objects\WithUpperCaseGetter;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class DataAccessorTest extends AbstractFunctionalTestCase
+final class DataAccessorTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): array
     {

--- a/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
+++ b/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class NestedFluidTemplatesWithLayoutTest extends AbstractFunctionalTestCase
+final class NestedFluidTemplatesWithLayoutTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
+++ b/tests/Functional/Cases/Rendering/RecursiveSectionRenderingTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class RecursiveSectionRenderingTest extends AbstractFunctionalTestCase
+final class RecursiveSectionRenderingTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/Cases/SwitchTest.php
+++ b/tests/Functional/Cases/SwitchTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class SwitchTest extends AbstractFunctionalTestCase
+final class SwitchTest extends AbstractFunctionalTestCase
 {
     public static function ignoreTextAndWhitespacesDataProvider(): array
     {

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
 
-class TagBasedTest extends BaseTestCase
+final class TagBasedTest extends BaseTestCase
 {
     /**
      * @test

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 
-class CommandTest extends BaseTestCase
+final class CommandTest extends BaseTestCase
 {
     public static function getCommandTestValues(): array
     {

--- a/tests/Functional/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Functional/Core/Cache/SimpleFileCacheTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Cache\StandardCacheWarmer;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
-class SimpleFileCacheTest extends AbstractFunctionalTestCase
+final class SimpleFileCacheTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Functional/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\SyntaxTree\Expression;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class TernaryExpressionNodeTest extends AbstractFunctionalTestCase
+final class TernaryExpressionNodeTest extends AbstractFunctionalTestCase
 {
     public static function variableConditionDataProvider(): array
     {

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
+final class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
 {
     public static function preProcessSourceExtractsNamespacesDataProvider(): array
     {

--- a/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits\Fixtures\CompileWithContentArgumentAndRenderStaticTestTraitViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class CompileWithContentArgumentAndRenderStaticTest extends UnitTestCase
+final class CompileWithContentArgumentAndRenderStaticTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
-class ExamplesTest extends AbstractFunctionalTestCase
+final class ExamplesTest extends AbstractFunctionalTestCase
 {
     public static function exampleScriptValuesDataProvider(): array
     {

--- a/tests/Functional/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/AliasViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class AliasViewHelperTest extends AbstractFunctionalTestCase
+final class AliasViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/Cache/DisableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/DisableViewHelperTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Cache\DisableViewHelper;
 
-class DisableViewHelperTest extends AbstractFunctionalTestCase
+final class DisableViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/Cache/StaticViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/StaticViewHelperTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Cache\StaticViewHelper;
 
-class StaticViewHelperTest extends AbstractFunctionalTestCase
+final class StaticViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/Cache/WarmupViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/WarmupViewHelperTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Cache\WarmupViewHelper;
 
-class WarmupViewHelperTest extends AbstractFunctionalTestCase
+final class WarmupViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CommentViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CommentViewHelperTest extends AbstractFunctionalTestCase
+final class CommentViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CountViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CountViewHelperTest extends AbstractFunctionalTestCase
+final class CountViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/CycleViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CycleViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CycleViewHelperTest extends AbstractFunctionalTestCase
+final class CycleViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/DebugViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class DebugViewHelperTest extends AbstractFunctionalTestCase
+final class DebugViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class ForViewHelperTest extends AbstractFunctionalTestCase
+final class ForViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/Format/CdataViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/CdataViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class CdataViewHelperTest extends AbstractFunctionalTestCase
+final class CdataViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Format\HtmlspecialcharsViewHelper;
 
-class HtmlspecialcharsViewHelperTest extends AbstractFunctionalTestCase
+final class HtmlspecialcharsViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/Format/PrintfViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/PrintfViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class PrintfViewHelperTest extends AbstractFunctionalTestCase
+final class PrintfViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/RawViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper;
 
-class RawViewHelperTest extends AbstractFunctionalTestCase
+final class RawViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\GroupedForViewHelper;
 
-class GroupedForViewHelperTest extends AbstractFunctionalTestCase
+final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
+final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/InlineViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/InlineViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class InlineViewHelperTest extends AbstractFunctionalTestCase
+final class InlineViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/LayoutViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class LayoutViewHelperTest extends AbstractFunctionalTestCase
+final class LayoutViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/OrViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class OrViewHelperTest extends AbstractFunctionalTestCase
+final class OrViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RenderViewHelperTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class RenderViewHelperTest extends AbstractFunctionalTestCase
+final class RenderViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SectionViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class SectionViewHelperTest extends AbstractFunctionalTestCase
+final class SectionViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/SpacelessViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SpacelessViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class SpacelessViewHelperTest extends AbstractFunctionalTestCase
+final class SpacelessViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCase
+final class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
      * @test

--- a/tests/Functional/ViewHelpers/VariableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/VariableViewHelperTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-class VariableViewHelperTest extends AbstractFunctionalTestCase
+final class VariableViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function renderDataProvider(): \Generator
     {

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class FluidCacheWarmupResultTest extends UnitTestCase
+final class FluidCacheWarmupResultTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -19,7 +19,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-class StandardCacheWarmerTest extends UnitTestCase
+final class StandardCacheWarmerTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class FailedCompilingStateTest extends UnitTestCase
+final class FailedCompilingStateTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * @deprecated Remove together with StopCompilingChildrenException
  */
-class StopCompilingChildrenExceptionTest extends UnitTestCase
+final class StopCompilingChildrenExceptionTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class TemplateCompilerTest extends UnitTestCase
+final class TemplateCompilerTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class BooleanParserTest extends UnitTestCase
+final class BooleanParserTest extends UnitTestCase
 {
     public static function getSomeEvaluationTestValues(): array
     {

--- a/tests/Unit/Core/Parser/ConfigurationTest.php
+++ b/tests/Unit/Core/Parser/ConfigurationTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ConfigurationTest extends UnitTestCase
+final class ConfigurationTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class EscapeTest extends UnitTestCase
+final class EscapeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ParsingStateTest extends UnitTestCase
+final class ParsingStateTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -21,7 +21,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class BooleanNodeTest extends UnitTestCase
+final class BooleanNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class EscapingNodeTest extends UnitTestCase
+final class EscapingNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -16,7 +16,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToArray;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class CastingExpressionNodeTest extends UnitTestCase
+final class CastingExpressionNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class MathExpressionNodeTest extends UnitTestCase
+final class MathExpressionNodeTest extends UnitTestCase
 {
     public static function getEvaluateExpressionTestValues(): array
     {

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class NumericNodeTest extends UnitTestCase
+final class NumericNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ObjectAccessorNodeTest extends UnitTestCase
+final class ObjectAccessorNodeTest extends UnitTestCase
 {
     public static function getEvaluateTestValues(): array
     {

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class RootNodeTest extends UnitTestCase
+final class RootNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class TextNodeTest extends UnitTestCase
+final class TextNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ViewHelperNodeTest extends UnitTestCase
+final class ViewHelperNodeTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class TemplateParserPatternTest extends UnitTestCase
+final class TemplateParserPatternTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -38,7 +38,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
  * This is to at least half a system test, as it compares rendered results to
  * expectations, and does not strictly check the parsing...
  */
-class TemplateParserTest extends UnitTestCase
+final class TemplateParserTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProce
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class EscapingModifierTemplateProcessorTest extends UnitTestCase
+final class EscapingModifierTemplateProcessorTest extends UnitTestCase
 {
     public static function getEscapingTestValues(): array
     {

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -22,7 +22,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-class RenderingContextTest extends UnitTestCase
+final class RenderingContextTest extends UnitTestCase
 {
     public static function gettersReturnPreviouslySetValuesDataProvider(): array
     {

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Variables\ChainedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ChainedVariableProviderTest extends UnitTestCase
+final class ChainedVariableProviderTest extends UnitTestCase
 {
     public static function getGetTestValues(): array
     {

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -12,7 +12,10 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 use TYPO3Fluid\Fluid\Core\Variables\JSONVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
-class JSONVariableProviderTest extends AbstractFunctionalTestCase
+/**
+ * @todo Validate if extending AbstractFunctionalTestCase is needed. If so, move to `Tests/Functional/*`
+ */
+final class JSONVariableProviderTest extends AbstractFunctionalTestCase
 {
     public static function provideVariablesDataProvider(): array
     {

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\StandardVariableProviderModelFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class StandardVariableProviderTest extends UnitTestCase
+final class StandardVariableProviderTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -15,7 +15,7 @@ use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithMagicGetter;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class VariableExtractorTest extends UnitTestCase
+final class VariableExtractorTest extends UnitTestCase
 {
     public static function getPathTestValues(): array
     {

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ArgumentDefinitionTest extends UnitTestCase
+final class ArgumentDefinitionTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class TagBuilderTest extends UnitTestCase
+final class TagBuilderTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 /**
  * @deprecated remove together with ParserRuntimeOnly.
  */
-class ParserRuntimeOnlyTest extends UnitTestCase
+final class ParserRuntimeOnlyTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ViewHelperInvokerTest extends UnitTestCase
+final class ViewHelperInvokerTest extends UnitTestCase
 {
     public static function getInvocationTestValues(): array
     {

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
 
-class ViewHelperResolverTest extends UnitTestCase
+final class ViewHelperResolverTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -14,7 +14,7 @@ use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
-class ViewHelperVariableContainerTest extends UnitTestCase
+final class ViewHelperVariableContainerTest extends UnitTestCase
 {
     /**
      * @test

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -13,7 +13,7 @@ use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-class TemplatePathsTest extends BaseTestCase
+final class TemplatePathsTest extends BaseTestCase
 {
     public static function sanitizePathDataProvider(): array
     {


### PR DESCRIPTION
It's recommend that test classes should not
extend from each other. This is not the case,
so mark all tests final.
