### PR TITLE
[TASK] Better readable TemplateCompiler

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -134,15 +134,15 @@ class TernaryExpressionNode extends AbstractExpressionNode
 
         $functionName = $templateCompiler->variableName('ternaryExpression');
         $initializationPhpCode .= sprintf(
-            '%s = function($context, $renderingContext) {
-                $check = %s;
-                $parser = new \TYPO3Fluid\Fluid\Core\Parser\BooleanParser();
-                $checkResult = $parser->evaluate($check, $context);
-                if ($checkResult) {
-                    return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
-                }
-                return %s::getTemplateVariableOrValueItself(%s, $renderingContext);
-			};' . chr(10),
+            '%s = function($context, $renderingContext) {' . chr(10) .
+            '    $check = %s;' . chr(10) .
+            '    $parser = new \TYPO3Fluid\Fluid\Core\Parser\BooleanParser();' . chr(10) .
+            '    $checkResult = $parser->evaluate($check, $context);' . chr(10) .
+            '    if ($checkResult) {' . chr(10) .
+            '        return %s::getTemplateVariableOrValueItself(%s, $renderingContext);' . chr(10) .
+            '    }' . chr(10) .
+            '    return %s::getTemplateVariableOrValueItself(%s, $renderingContext);' . chr(10) .
+            '};' . chr(10),
             $functionName,
             var_export($check, true),
             static::class,


### PR DESCRIPTION
The patch changes string representation in
TemplateCompiler and TernaryExpressionNode
to make both the code and the generated
template code better readable.