### PR TITLE
[TASK] Remove f:layout compile() method

### DIFF
--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -46,17 +46,6 @@ class LayoutViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
-    {
-        return '';
-    }
-
-    /**
      * This VH does not ever output anything as such: Layouts are
      * handled differently in the compiler / parser and the f:render
      * VH invokes section body execution.


### PR DESCRIPTION
The method is obsolete since convert()
is overridden, which does not call
compile() anymore.