### PR TITLE
Revert "[TASK] Improve performance of Escape interceptor (#716)"

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22,7 +22,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: src/Core/Parser/Interceptor/Escape.php
 
 		-

--- a/src/Core/Parser/Interceptor/Escape.php
+++ b/src/Core/Parser/Interceptor/Escape.php
@@ -21,12 +21,19 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 class Escape implements InterceptorInterface
 {
     /**
-     * A counter of ViewHelperNodes which currently disable the interceptor.
+     * Is the interceptor enabled right now for child nodes?
+     *
+     * @var bool
+     */
+    protected $childrenEscapingEnabled = true;
+
+    /**
+     * A stack of ViewHelperNodes which currently disable the interceptor.
      * Needed to enable the interceptor again.
      *
-     * @var int
+     * @var NodeInterface[]
      */
-    protected $viewHelperNodesWhichDisableTheInterceptor = 0;
+    protected $viewHelperNodesWhichDisableTheInterceptor = [];
 
     /**
      * Adds a ViewHelper node using the Format\HtmlspecialcharsViewHelper to the given node.
@@ -42,18 +49,21 @@ class Escape implements InterceptorInterface
         if ($interceptorPosition === InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER) {
             /** @var ViewHelperNode $node */
             if (!$node->getUninitializedViewHelper()->isChildrenEscapingEnabled()) {
-                ++$this->viewHelperNodesWhichDisableTheInterceptor;
+                $this->childrenEscapingEnabled = false;
+                $this->viewHelperNodesWhichDisableTheInterceptor[] = $node;
             }
         } elseif ($interceptorPosition === InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER) {
-            /** @var ViewHelperNode $node */
-            if (!$node->getUninitializedViewHelper()->isChildrenEscapingEnabled()) {
-                --$this->viewHelperNodesWhichDisableTheInterceptor;
+            if (end($this->viewHelperNodesWhichDisableTheInterceptor) === $node) {
+                array_pop($this->viewHelperNodesWhichDisableTheInterceptor);
+                if (count($this->viewHelperNodesWhichDisableTheInterceptor) === 0) {
+                    $this->childrenEscapingEnabled = true;
+                }
             }
-
-            if ($this->viewHelperNodesWhichDisableTheInterceptor === 0 && $node->getUninitializedViewHelper()->isOutputEscapingEnabled()) {
+            /** @var ViewHelperNode $node */
+            if ($this->childrenEscapingEnabled && $node->getUninitializedViewHelper()->isOutputEscapingEnabled()) {
                 $node = new EscapingNode($node);
             }
-        } elseif ($this->viewHelperNodesWhichDisableTheInterceptor === 0 && ($node instanceof ObjectAccessorNode || $node instanceof ExpressionNodeInterface)) {
+        } elseif ($this->childrenEscapingEnabled && ($node instanceof ObjectAccessorNode || $node instanceof ExpressionNodeInterface)) {
             $node = new EscapingNode($node);
         }
         return $node;

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -30,10 +30,10 @@ final class EscapeTest extends UnitTestCase
         $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
         $viewHelperNodeMock->expects(self::once())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
         $subject = new Escape();
-        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
-        self::assertSame(0, $property->getValue($subject));
+        $property = new \ReflectionProperty($subject, 'childrenEscapingEnabled');
+        self::assertTrue($property->getValue($subject));
         $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, new ParsingState());
-        self::assertSame(0, $property->getValue($subject));
+        self::assertTrue($property->getValue($subject));
     }
 
     /**
@@ -46,26 +46,10 @@ final class EscapeTest extends UnitTestCase
         $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
         $viewHelperNodeMock->expects(self::once())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
         $subject = new Escape();
-        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
-        self::assertSame(0, $property->getValue($subject));
+        $property = new \ReflectionProperty($subject, 'childrenEscapingEnabled');
+        self::assertTrue($property->getValue($subject));
         $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER, new ParsingState());
-        self::assertSame(1, $property->getValue($subject));
-    }
-
-    /**
-     * @test
-     */
-    public function processReenablesEscapingInterceptorOnClosingViewHelperTagIfItWasDisabledBefore(): void
-    {
-        $viewHelperMock = $this->createMock(AbstractViewHelper::class);
-        $viewHelperMock->expects(self::once())->method('isOutputEscapingEnabled')->willReturn(false);
-        $viewHelperNodeMock = $this->createMock(ViewHelperNode::class);
-        $viewHelperNodeMock->expects(self::any())->method('getUninitializedViewHelper')->willReturn($viewHelperMock);
-        $subject = new Escape();
-        $property = new \ReflectionProperty($subject, 'viewHelperNodesWhichDisableTheInterceptor');
-        $property->setValue($subject, 1);
-        $subject->process($viewHelperNodeMock, InterceptorInterface::INTERCEPT_CLOSING_VIEWHELPER, new ParsingState());
-        self::assertSame(0, $property->getValue($subject));
+        self::assertFalse($property->getValue($subject));
     }
 
     /**


### PR DESCRIPTION
This reverts commit a1d2da5d871d865db7a61cf0e48b1ca1446e6948.

The patch has side effects when the node being escaped is changed to an instance of EscapingNode, so especially the check

if (end($this->viewHelperNodesWhichDisableTheInterceptor) === $node) {

needs to be kept.

Reverts #715