### PR TITLE
[TASK] Add test to cover commas in vh and arrays

### DIFF
--- a/tests/Functional/Cases/Parsing/CommaToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/CommaToleranceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class CommaToleranceTest extends AbstractFunctionalTestCase
+{
+    public static function commaToleranceDataProvider(): array
+    {
+        return [
+            ['<f:variable name="result" value="{abc: 1, def: 2,}" />', ['abc' => 1, 'def' => 2]],
+            ['<f:variable name="result" value="{abc: 1, def: 2 ,}" />', ['abc' => 1, 'def' => 2]],
+            ['<f:variable name="result" value="{abc: 1, def: 2, }" />', ['abc' => 1, 'def' => 2]],
+            ['<f:variable name="result" value="{abc: 1, def: 2,,}" />', '{abc: 1, def: 2,,}'],
+            ['<f:variable name="result" value="{abc: 1,, def: 2}" />', '{abc: 1,, def: 2}'],
+            ['<f:variable name="result" value="{,abc: 1, def: 2}" />', '{,abc: 1, def: 2}'],
+            ['<f:variable name="result" value="{f:if(condition: 1, then: 1, else: 0,)}" />', 1],
+            ['<f:variable name="result" value="{f:if(condition: 1, then: 1, else: 0 ,)}" />', 1],
+            ['<f:variable name="result" value="{f:if(condition: 1, then: 1, else: 0, )}" />', 1],
+            ['<f:variable name="result" value="{f:if(condition: 1, then: 1, else: 0,,)}" />', '{f:if(condition: 1, then: 1, else: 0,,)}'],
+            ['<f:variable name="result" value="{f:if(condition: 1,, then: 1, else: 0)}" />', '{f:if(condition: 1,, then: 1, else: 0)}'],
+            ['<f:variable name="result" value="{f:if(,condition: 1, then: 1, else: 0)}" />', '{f:if(,condition: 1, then: 1, else: 0)}'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider commaToleranceDataProvider
+     */
+    public function commaTolerance(string $source, $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->render();
+        self::assertSame($view->getRenderingContext()->getVariableProvider()->get('result'), $expected);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->render();
+        self::assertSame($view->getRenderingContext()->getVariableProvider()->get('result'), $expected);
+    }
+}


### PR DESCRIPTION
While this is probably covered by lower-level test, it can’t hurt to list all variants in one location, similar to the whitespace test case.

(see also Core issue: https://forge.typo3.org/issues/93933)