### PR TITLE
[TASK] Apply single_line_empty_body from PER-CS2.0

### DIFF
--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -92,7 +92,5 @@ abstract class AbstractCompiledTemplate implements ParsedTemplateInterface
     /**
      * @param RenderingContextInterface $renderingContext
      */
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
-    {
-    }
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {}
 }

--- a/src/Core/Compiler/StopCompilingException.php
+++ b/src/Core/Compiler/StopCompilingException.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  *
  * @api
  */
-class StopCompilingException extends \TYPO3Fluid\Fluid\Core\Exception
-{
-}
+class StopCompilingException extends \TYPO3Fluid\Fluid\Core\Exception {}

--- a/src/Core/Compiler/UncompilableTemplateInterface.php
+++ b/src/Core/Compiler/UncompilableTemplateInterface.php
@@ -19,6 +19,4 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  * The result is that the template parser will always parse the
  * original template.
  */
-interface UncompilableTemplateInterface
-{
-}
+interface UncompilableTemplateInterface {}

--- a/src/Core/ErrorHandler/StandardErrorHandler.php
+++ b/src/Core/ErrorHandler/StandardErrorHandler.php
@@ -47,9 +47,7 @@ class StandardErrorHandler implements ErrorHandlerInterface
     /**
      * @param \TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error
      */
-    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error)
-    {
-    }
+    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error) {}
 
     /**
      * @param \TYPO3Fluid\Fluid\View\Exception $error

--- a/src/Core/Exception.php
+++ b/src/Core/Exception.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Exception
-{
-}
+class Exception extends \TYPO3Fluid\Fluid\Exception {}

--- a/src/Core/Parser/Exception.php
+++ b/src/Core/Parser/Exception.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Core\Exception
-{
-}
+class Exception extends \TYPO3Fluid\Fluid\Core\Exception {}

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -196,9 +196,7 @@ class ParsingState implements ParsedTemplateInterface
     /**
      * @param RenderingContextInterface $renderingContext
      */
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
-    {
-    }
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {}
 
     /**
      * @return bool

--- a/src/Core/Parser/SyntaxTree/ArrayNode.php
+++ b/src/Core/Parser/SyntaxTree/ArrayNode.php
@@ -23,9 +23,7 @@ class ArrayNode extends AbstractNode
      *
      * @param array $internalArray An associative array. Each key is a string. Each value is either a literal, or an AbstractNode.
      */
-    public function __construct(private readonly array $internalArray)
-    {
-    }
+    public function __construct(private readonly array $internalArray) {}
 
     /**
      * Evaluate the array and return an evaluated array

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionException.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
  *
  * @api
  */
-class ExpressionException extends \TYPO3Fluid\Fluid\Core\Exception
-{
-}
+class ExpressionException extends \TYPO3Fluid\Fluid\Core\Exception {}

--- a/src/Core/Parser/SyntaxTree/Expression/ParseTimeEvaluatedExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ParseTimeEvaluatedExpressionNodeInterface.php
@@ -22,6 +22,4 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression;
  *
  * @deprecated To be removed again in Fluid 3.0
  */
-interface ParseTimeEvaluatedExpressionNodeInterface extends ExpressionNodeInterface
-{
-}
+interface ParseTimeEvaluatedExpressionNodeInterface extends ExpressionNodeInterface {}

--- a/src/Core/Parser/SyntaxTree/TextNode.php
+++ b/src/Core/Parser/SyntaxTree/TextNode.php
@@ -18,9 +18,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class TextNode extends AbstractNode
 {
-    public function __construct(protected readonly string $text)
-    {
-    }
+    public function __construct(protected readonly string $text) {}
 
     /**
      * Return the text associated to the syntax tree. Text from child nodes is

--- a/src/Core/Parser/UnknownNamespaceException.php
+++ b/src/Core/Parser/UnknownNamespaceException.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
  *
  * @api
  */
-class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception
-{
-}
+class UnknownNamespaceException extends \TYPO3Fluid\Fluid\Core\Parser\Exception {}

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -277,9 +277,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      *
      * @api
      */
-    public function initialize()
-    {
-    }
+    public function initialize() {}
 
     /**
      * Helper method which triggers the rendering of everything between the
@@ -420,9 +418,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      *
      * @api
      */
-    public function initializeArguments()
-    {
-    }
+    public function initializeArguments() {}
 
     /**
      * Tests if the given $argumentName is set, and not NULL.
@@ -447,9 +443,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * @throws Exception
      * @param array<string, mixed> $arguments
      */
-    public function handleAdditionalArguments(array $arguments)
-    {
-    }
+    public function handleAdditionalArguments(array $arguments) {}
 
     /**
      * Default implementation of validating additional, undeclared arguments.
@@ -521,18 +515,14 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * @param array<string, TextNode> $arguments
      * @param VariableProviderInterface $variableContainer
      */
-    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer)
-    {
-    }
+    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer) {}
 
     /**
      * Resets the ViewHelper state.
      *
      * Overwrite this method if you need to get a clean state of your ViewHelper.
      */
-    public function resetState()
-    {
-    }
+    public function resetState() {}
 
     /**
      * @internal See interface description.

--- a/src/Core/ViewHelper/Exception.php
+++ b/src/Core/ViewHelper/Exception.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  *
  * @api
  */
-class Exception extends \TYPO3Fluid\Fluid\Core\Exception
-{
-}
+class Exception extends \TYPO3Fluid\Fluid\Core\Exception {}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -17,6 +17,4 @@ namespace TYPO3Fluid\Fluid;
  *
  * @api
  */
-class Exception extends \RuntimeException
-{
-}
+class Exception extends \RuntimeException {}

--- a/src/View/Exception.php
+++ b/src/View/Exception.php
@@ -14,6 +14,4 @@ use TYPO3Fluid\Fluid;
  *
  * @api
  */
-class Exception extends Fluid\Exception
-{
-}
+class Exception extends Fluid\Exception {}

--- a/src/View/Exception/InvalidSectionException.php
+++ b/src/View/Exception/InvalidSectionException.php
@@ -14,6 +14,4 @@ use TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class InvalidSectionException extends View\Exception
-{
-}
+class InvalidSectionException extends View\Exception {}

--- a/src/View/Exception/InvalidTemplateResourceException.php
+++ b/src/View/Exception/InvalidTemplateResourceException.php
@@ -14,6 +14,4 @@ use TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class InvalidTemplateResourceException extends View\Exception
-{
-}
+class InvalidTemplateResourceException extends View\Exception {}

--- a/src/View/TemplateView.php
+++ b/src/View/TemplateView.php
@@ -12,6 +12,4 @@ namespace TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class TemplateView extends AbstractTemplateView
-{
-}
+class TemplateView extends AbstractTemplateView {}

--- a/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContentOverriddenResolveContentArgumentNameMethodViewHelper.php
@@ -23,9 +23,7 @@ class CompileWithContentArgumentAndRenderStaticExplicitSetArgumentNameForContent
     // set to false because of json response, not test relevant
     protected $escapeChildren = false;
 
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function initializeArguments(): void
     {

--- a/tests/Unit/Core/Compiler/Fixtures/AbstractCompiledTemplateTestFixture.php
+++ b/tests/Unit/Core/Compiler/Fixtures/AbstractCompiledTemplateTestFixture.php
@@ -14,6 +14,4 @@ use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 /**
  * Subject fixture for AbstractCompiledTemplateTest
  */
-class AbstractCompiledTemplateTestFixture extends AbstractCompiledTemplate
-{
-}
+class AbstractCompiledTemplateTestFixture extends AbstractCompiledTemplate {}

--- a/tests/Unit/Core/Fixtures/TestViewHelper2.php
+++ b/tests/Unit/Core/Fixtures/TestViewHelper2.php
@@ -20,7 +20,5 @@ class TestViewHelper2 extends AbstractViewHelper
         $this->registerArgument('param2', 'string', 'P3 Stuff', false, 'default');
     }
 
-    public function render(): void
-    {
-    }
+    public function render(): void {}
 }

--- a/tests/Unit/Core/Variables/Fixtures/StandardVariableProviderModelFixture.php
+++ b/tests/Unit/Core/Variables/Fixtures/StandardVariableProviderModelFixture.php
@@ -16,9 +16,7 @@ class StandardVariableProviderModelFixture
 {
     public string $existingPublicProperty = 'existingPublicPropertyValue';
 
-    public function __construct(private readonly string $name)
-    {
-    }
+    public function __construct(private readonly string $name) {}
 
     public function getName(): string
     {

--- a/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/RenderMethodFreeDefaultRenderStaticViewHelper.php
@@ -18,6 +18,4 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
  *
  * See AbstractViewHelperTest->testCallRenderMethod* tests!
  */
-class RenderMethodFreeDefaultRenderStaticViewHelper extends AbstractViewHelper implements ViewHelperInterface
-{
-}
+class RenderMethodFreeDefaultRenderStaticViewHelper extends AbstractViewHelper implements ViewHelperInterface {}

--- a/tests/Unit/View/Fixtures/AbstractTemplateViewTestFixture.php
+++ b/tests/Unit/View/Fixtures/AbstractTemplateViewTestFixture.php
@@ -14,6 +14,4 @@ use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 /**
  * Fixture to test AbstractTemplateView
  */
-class AbstractTemplateViewTestFixture extends AbstractTemplateView
-{
-}
+class AbstractTemplateViewTestFixture extends AbstractTemplateView {}

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -17,6 +17,4 @@ namespace TYPO3Fluid\Fluid\Tests;
  * at some point, specific behavior needs to be implemented for unit tests, your test cases
  * will profit from it automatically.
  */
-abstract class UnitTestCase extends BaseTestCase
-{
-}
+abstract class UnitTestCase extends BaseTestCase {}


### PR DESCRIPTION
PER Coding Style 2.0, which fluid respects with its php-cs-fixer configuration, added a CGL rule to define empty classes, interfaces and functions in one line rather than each brace on its separate line. php-cs-fixer already enforces this, so this commit adjusts the existing code base.

Executed command:

composer cgl:fix