### PR TITLE
[BUGFIX] Load variables from file with getByPath

### DIFF
--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -76,6 +76,16 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
     }
 
     /**
+     * @param string $path
+     * @return mixed
+     */
+    public function getByPath($path)
+    {
+        $this->load();
+        return parent::getByPath($path);
+    }
+
+    /**
      * @return array
      */
     public function getAllIdentifiers()

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -41,4 +41,44 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
             self::assertEquals($value, $provider->get($key));
         }
     }
+
+    /**
+     * @test
+     */
+    public function getAllLoadJsonFile(): void
+    {
+        $provider = new JSONVariableProvider();
+        $provider->setSource(__DIR__ . '/Fixtures/test.json');
+        self::assertEquals(['foo' => 'bar'], $provider->getAll());
+    }
+
+    /**
+     * @test
+     */
+    public function getAllIdentifiersLoadJsonFile(): void
+    {
+        $provider = new JSONVariableProvider();
+        $provider->setSource(__DIR__ . '/Fixtures/test.json');
+        self::assertEquals(['foo'], $provider->getAllIdentifiers());
+    }
+
+    /**
+     * @test
+     */
+    public function getLoadJsonFile(): void
+    {
+        $provider = new JSONVariableProvider();
+        $provider->setSource(__DIR__ . '/Fixtures/test.json');
+        self::assertEquals('bar', $provider->get('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function getByPathLoadJsonFile(): void
+    {
+        $provider = new JSONVariableProvider();
+        $provider->setSource(__DIR__ . '/Fixtures/test.json');
+        self::assertEquals('bar', $provider->getByPath('foo'));
+    }
 }


### PR DESCRIPTION
Currently, JSONVariableProvider doesn’t load the JSON file if getByPath() is used, in contrast to get(), getAll(), or getAllIdentifiers().