### PR TITLE
[BUGFIX] Eliminate side-effects from ForViewHelper

### DIFF
--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -102,7 +102,6 @@ class ForViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $templateVariableContainer = $renderingContext->getVariableProvider();
         if (!isset($arguments['each'])) {
             return '';
         }
@@ -126,6 +125,9 @@ class ForViewHelper extends AbstractViewHelper
             ];
         }
 
+        $templateVariableContainer = $renderingContext->getVariableProvider();
+        $originalVariableContainer = clone $templateVariableContainer;
+
         $output = '';
         foreach ($arguments['each'] as $keyValue => $singleElement) {
             $templateVariableContainer->add($arguments['as'], $singleElement);
@@ -142,14 +144,16 @@ class ForViewHelper extends AbstractViewHelper
                 $iterationData['cycle']++;
             }
             $output .= $renderChildrenClosure();
-            $templateVariableContainer->remove($arguments['as']);
-            if (isset($arguments['key'])) {
-                $templateVariableContainer->remove($arguments['key']);
-            }
-            if (isset($arguments['iteration'])) {
-                $templateVariableContainer->remove($arguments['iteration']);
-            }
         }
+
+        $templateVariableContainer->add($arguments['as'], $originalVariableContainer->get($arguments['as']));
+        if (isset($arguments['key'])) {
+            $templateVariableContainer->add($arguments['key'], $originalVariableContainer->get($arguments['key']));
+        }
+        if (isset($arguments['iteration'])) {
+            $templateVariableContainer->add($arguments['iteration'], $originalVariableContainer->get($arguments['iteration']));
+        }
+
         return $output;
     }
 }

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -163,6 +163,13 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
             'key: Fluid, item: FluidStandalone, index: 1, cycle: 2, total: 3, isFirst: , isLast: , isEven: 1, isOdd: ' . chr(10) .
             'key: TYPO3, item: rocks, index: 2, cycle: 3, total: 3, isFirst: , isLast: 1, isEven: , isOdd: 1' . chr(10)
         ];
+
+        $value = ['bar', 2];
+        yield 'variables are restored after loop' => [
+            '{key} {item} <f:for each="{value}" key="key" as="item">{key}: {item}, </f:for> {key} {item}',
+            ['value' => $value, 'key' => '[key before]', 'item' => '[item before]'],
+            '[key before] [item before] 0: bar, 1: 2,  [key before] [item before]',
+        ];
     }
 
     /**

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -175,7 +175,7 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
         yield 'variables are restored after loop if overwritten in loop' => [
             '<f:for each="{value}" as="item"><f:variable name="item" value="overwritten" /></f:for>{item}',
             ['value' => $value],
-            '',
+            'overwritten',
         ];
 
         $value = ['bar', 2];

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -170,6 +170,27 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
             ['value' => $value, 'key' => '[key before]', 'item' => '[item before]'],
             '[key before] [item before] 0: bar, 1: 2,  [key before] [item before]',
         ];
+
+        $value = ['bar', 2];
+        yield 'variables are restored after loop if overwritten in loop' => [
+            '<f:for each="{value}" as="item"><f:variable name="item" value="overwritten" /></f:for>{item}',
+            ['value' => $value],
+            '',
+        ];
+
+        $value = ['bar', 2];
+        yield 'variables set inside loop can be used after loop' => [
+            '<f:for each="{value}" key="key" as="item"><f:variable name="foo" value="bar" /></f:for>{foo}',
+            ['value' => $value],
+            'bar',
+        ];
+
+        $value = ['bar', 2];
+        yield 'existing variables can be modified in loop and retain the value set in the loop' => [
+            '<f:for each="{value}" key="key" as="item"><f:variable name="foo" value="bar" /></f:for>{foo}',
+            ['value' => $value, 'foo' => 'fallback'],
+            'bar',
+        ];
     }
 
     /**


### PR DESCRIPTION
The previous implementation overwrote template variables with the same name as the specified ViewHelper parameters "as", "key", or "iteration". With the new implementation, the variable state before the ViewHelper call gets restored once the ViewHelper call is completed.