### PR TITLE
Illustration: Inconsistent ViewHelper behavior uncached vs. cached

### DIFF
--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -102,7 +102,6 @@ class ForViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $templateVariableContainer = $renderingContext->getVariableProvider();
         if (!isset($arguments['each'])) {
             return '';
         }
@@ -126,6 +125,9 @@ class ForViewHelper extends AbstractViewHelper
             ];
         }
 
+        $templateVariableContainer = $renderingContext->getVariableProvider();
+        $originalVariableContainer = clone $templateVariableContainer;
+
         $output = '';
         foreach ($arguments['each'] as $keyValue => $singleElement) {
             $templateVariableContainer->add($arguments['as'], $singleElement);
@@ -142,14 +144,16 @@ class ForViewHelper extends AbstractViewHelper
                 $iterationData['cycle']++;
             }
             $output .= $renderChildrenClosure();
-            $templateVariableContainer->remove($arguments['as']);
-            if (isset($arguments['key'])) {
-                $templateVariableContainer->remove($arguments['key']);
-            }
-            if (isset($arguments['iteration'])) {
-                $templateVariableContainer->remove($arguments['iteration']);
-            }
         }
+
+        $templateVariableContainer->add($arguments['as'], $originalVariableContainer->get($arguments['as']));
+        if (isset($arguments['key'])) {
+            $templateVariableContainer->add($arguments['key'], $originalVariableContainer->get($arguments['key']));
+        }
+        if (isset($arguments['iteration'])) {
+            $templateVariableContainer->add($arguments['iteration'], $originalVariableContainer->get($arguments['iteration']));
+        }
+
         return $output;
     }
 }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -7,10 +7,8 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Loop ViewHelper which can be used to iterate over arrays.
@@ -76,8 +74,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class ForViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -93,65 +89,58 @@ class ForViewHelper extends AbstractViewHelper
         $this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, total, isFirst, isLast, isEven, isOdd)');
     }
 
-    /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     * @throws ViewHelper\Exception
-     */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        if (!isset($arguments['each'])) {
+        if (!isset($this->arguments['each'])) {
             return '';
         }
-        if (is_object($arguments['each']) && !$arguments['each'] instanceof \Traversable) {
+        if (is_object($this->arguments['each']) && !$this->arguments['each'] instanceof \Traversable) {
             throw new ViewHelper\Exception('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
         }
 
-        if ($arguments['reverse'] === true) {
+        if ($this->arguments['reverse'] === true) {
             // array_reverse only supports arrays
-            if (is_object($arguments['each'])) {
-                $each = $arguments['each'];
-                $arguments['each'] = iterator_to_array($each);
+            if (is_object($this->arguments['each'])) {
+                $each = $this->arguments['each'];
+                $this->arguments['each'] = iterator_to_array($each);
             }
-            $arguments['each'] = array_reverse($arguments['each'], true);
+            $this->arguments['each'] = array_reverse($this->arguments['each'], true);
         }
-        if (isset($arguments['iteration'])) {
+        if (isset($this->arguments['iteration'])) {
             $iterationData = [
                 'index' => 0,
                 'cycle' => 1,
-                'total' => count($arguments['each'])
+                'total' => count($this->arguments['each'])
             ];
         }
 
-        $templateVariableContainer = $renderingContext->getVariableProvider();
+        $templateVariableContainer = $this->renderingContext->getVariableProvider();
         $originalVariableContainer = clone $templateVariableContainer;
 
         $output = '';
-        foreach ($arguments['each'] as $keyValue => $singleElement) {
-            $templateVariableContainer->add($arguments['as'], $singleElement);
-            if (isset($arguments['key'])) {
-                $templateVariableContainer->add($arguments['key'], $keyValue);
+        foreach ($this->arguments['each'] as $keyValue => $singleElement) {
+            $templateVariableContainer->add($this->arguments['as'], $singleElement);
+            if (isset($this->arguments['key'])) {
+                $templateVariableContainer->add($this->arguments['key'], $keyValue);
             }
-            if (isset($arguments['iteration'])) {
+            if (isset($this->arguments['iteration'])) {
                 $iterationData['isFirst'] = $iterationData['cycle'] === 1;
                 $iterationData['isLast'] = $iterationData['cycle'] === $iterationData['total'];
                 $iterationData['isEven'] = $iterationData['cycle'] % 2 === 0;
                 $iterationData['isOdd'] = !$iterationData['isEven'];
-                $templateVariableContainer->add($arguments['iteration'], $iterationData);
+                $templateVariableContainer->add($this->arguments['iteration'], $iterationData);
                 $iterationData['index']++;
                 $iterationData['cycle']++;
             }
-            $output .= $renderChildrenClosure();
+            $output .= $this->renderChildren();
         }
 
-        $templateVariableContainer->add($arguments['as'], $originalVariableContainer->get($arguments['as']));
-        if (isset($arguments['key'])) {
-            $templateVariableContainer->add($arguments['key'], $originalVariableContainer->get($arguments['key']));
+        $templateVariableContainer->add($this->arguments['as'], $originalVariableContainer->get($this->arguments['as']));
+        if (isset($this->arguments['key'])) {
+            $templateVariableContainer->add($this->arguments['key'], $originalVariableContainer->get($this->arguments['key']));
         }
-        if (isset($arguments['iteration'])) {
-            $templateVariableContainer->add($arguments['iteration'], $originalVariableContainer->get($arguments['iteration']));
+        if (isset($this->arguments['iteration'])) {
+            $templateVariableContainer->add($this->arguments['iteration'], $originalVariableContainer->get($this->arguments['iteration']));
         }
 
         return $output;

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -34,8 +33,8 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
      */
     public function renderThrowsExceptionIfSubjectIsInvalid(): void
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionCode(1248728393);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1256475113);
         $view = new TemplateView();
         $view->assignMultiple(['value' => new \stdClass()]);
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -163,6 +163,13 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
             'key: Fluid, item: FluidStandalone, index: 1, cycle: 2, total: 3, isFirst: , isLast: , isEven: 1, isOdd: ' . chr(10) .
             'key: TYPO3, item: rocks, index: 2, cycle: 3, total: 3, isFirst: , isLast: 1, isEven: , isOdd: 1' . chr(10)
         ];
+
+        $value = ['bar', 2];
+        yield 'variables are restored after loop' => [
+            '{key} {item} <f:for each="{value}" key="key" as="item">{key}: {item}, </f:for> {key} {item}',
+            ['value' => $value, 'key' => '[key before]', 'item' => '[item before]'],
+            '[key before] [item before] 0: bar, 1: 2,  [key before] [item before]',
+        ];
     }
 
     /**


### PR DESCRIPTION
**Note that this PR isn't intended to be merged, but to illustrate inconsistent ViewHelper behavior.**

Even after eliminating variable side-effects of the `ForViewHelper`, it still behaves inconsistently in uncached templates when it's implemented with `render()` instead of `renderStatic()`. The reason behind this is that there will only be one instance of the ViewHelper class if the ViewHelper is called recursively in a template. In the inner loop, `$this->arguments` of `ForViewHelper` will be set again, and these new arguments will leak out to the outer loop because they are not part of renderingContext but of the ViewHelper object.

This means that even with the current Fluid implementation, there can be edge cases where ViewHelper objects are reused in uncached templates. In my opinion, there are two alternatives to resolve this:

1. ViewHelper reuse should be officially supported, which means that the ViewHelper context would need to be reset at the appropriate places (similar to `ViewHelperNode::updateViewHelperNodeInViewHelper()`). This would also mean that ViewHelpers could be defined as `shared` in Symfony DI. I think that this is doable, but could be quite confusing in the code.
2. ViewHelpers shouldn't be reused at all, which is similar to the behavior of `renderStatic()` and of cached templates. Just to illustrate the problem, this would be a quick'n'dirty solution:

add `clone` in ViewHelperNode.php:

```php
return $renderingContext->getViewHelperInvoker()->invoke(clone $this->uninitializedViewHelper, $this->arguments, $renderingContext);
```