### PR TITLE
[BUGFIX] Throw array conversion exception in `AbstractNode->castToString()`

### DIFF
--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -70,6 +70,9 @@ abstract class AbstractNode implements NodeInterface
         if (is_object($value) && !method_exists($value, '__toString')) {
             throw new Parser\Exception('Cannot cast object of type "' . get_class($value) . '" to string.', 1273753083);
         }
+        if (is_array($value)) {
+            throw new Parser\Exception('Cannot cast an array to string.', 1698750868);
+        }
         $output = (string)$value;
         return $output;
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -43,18 +43,29 @@ class AbstractNodeTest extends UnitTestCase
 
     /**
      * @test
+     * @dataProvider getChildNodeThrowsExceptionFiChildNodeCannotBeCastToStringTestValues
      */
-    public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString(): void
+    public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString(mixed $value, string $exceptionClass, int $exceptionCode, string $exceptionMessage): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException($exceptionClass);
+        $this->expectExceptionCode($exceptionCode);
+        $this->expectExceptionMessage($exceptionMessage);
 
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $childNode = $this->createMock(NodeInterface::class);
-        $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn(new \DateTime('now'));
+        $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn($value);
         $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
         $subject->addChildNode($childNode);
         $method = new \ReflectionMethod($subject, 'evaluateChildNode');
         $method->invoke($subject, $childNode, $renderingContextMock, true);
+    }
+
+    public static function getChildNodeThrowsExceptionFiChildNodeCannotBeCastToStringTestValues(): array
+    {
+        return [
+            [new \DateTime('now'), Exception::class, 1273753083, 'Cannot cast object of type "' . \DateTime::class . '" to string.'],
+            [['some' => 'value'], Exception::class, 1698750868, 'Cannot cast an array to string.'],
+        ];
     }
 
     /**


### PR DESCRIPTION
`AbstractNode->castToString()` already checked for objects which could not
converted to a string representation due to missing `__toString()` method.
It's possible that the value could be an array, which per nature is not
really convertable to a string anyway. Older php versions simply converted
it to an `Array` string along with a notices, which has been raised to a
warning in newer PHP versions.

There is no way to properly convert an array, therefore the PHP warning
should always lead to an parser exception like for object not convertable.

This change now checks explicitly for an array and throws a corresponding
`TYPO3Fluid\Fluid\Core\Parser\Exception` with a meaningfull message.

Test is extended to cover this case.

Resolves: #826
