### PR TITLE
[TASK] Remove constructor from variable provider interface

### DIFF
--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -21,22 +21,6 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
 interface VariableProviderInterface extends \ArrayAccess
 {
     /**
-     * Variables, if any, with which to initialize this
-     * VariableProvider.
-     *
-     * @param array $variables
-     * @todo: This must be removed from the interface! At the moment,
-     *        StandardVariableProvider accepts variables as constructor
-     *        arguments, while ChainedVariableProvider expects an array
-     *        of sub providers as constructor argument.
-     *        Thus, setSource() should be the only way to set variables
-     *        and StandardVariableProvider *must not* accept current
-     *        variables as constructor argument.
-     *        Adding variables as constructor must not be relied on!
-     */
-    public function __construct(array $variables = []);
-
-    /**
      * Gets a fresh instance of this type of VariableProvider
      * and fills it with the variables passed in $variables.
      *


### PR DESCRIPTION
Currently, the VariableProviderInterface suggests that its implementations can receive an array of variables as a constructor argument to be used as initial state of the provider instance. However, this assumption is already not correct anymore because ChainedVariableProvider receives an array of VariableProvider instances instead. In addition, this restricts possible other implementations of the interface.

Noteworthy in the code and relevant projects using Fluid:

* Neos implements its own VariableProvider which extends StandardVariableProvider. The change has no effect there. https://github.com/neos/fluidadaptor/blob/8.3/Classes/Core/ViewHelper/TemplateVariableContainer.php

* Fluid uses the constructor mostly with concrete implementations (mostly StandardVariableProvider, but also ChainedVariableProvider).

* ConsoleRunner uses a dynamic class name, but no constructor arguments. https://github.com/TYPO3/Fluid/blob/main/src/Tools/ConsoleRunner.php#L116C68-L116C68

* flux, vhs and fluid-parameters only use StandardVariableProvider

* Fluid Components and Fluid Styleguide only use StandardVariableProvider