### PR TITLE
[FEATURE] Attributes for RenderingContext

### DIFF
--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -111,6 +111,12 @@ class RenderingContext implements RenderingContextInterface
     ];
 
     /**
+     * Attributes can be used to attach additional data to the
+     * rendering context to be used e. g. in ViewHelpers.
+     */
+    protected array $attributes = [];
+
+    /**
      * Constructor
      *
      * Constructing a RenderingContext should result in an object containing instances
@@ -355,6 +361,35 @@ class RenderingContext implements RenderingContextInterface
         $escapeInterceptor = new Escape();
         $parserConfiguration->addEscapingInterceptor($escapeInterceptor);
         return $parserConfiguration;
+    }
+
+    /**
+     * Retrieve a single attribute.
+     *
+     * @see withAttribute()
+     * @param string $name The attribute name.
+     * @return object|null  null if the specified attribute hasn't been set
+     */
+    public function getAttribute(string $name): ?object
+    {
+        return $this->attributes[$name] ?? null;
+    }
+
+    /**
+     * Return an instance with the specified attribute.
+     *
+     * This method allows you to attach arbitrary objects to the
+     * rendering context to be used later e. g. in ViewHelpers.
+     *
+     * @param string $name The attribute name.
+     * @param object $value The value of the attribute.
+     * @return static
+     */
+    public function withAttribute(string $name, object $value): static
+    {
+        $clonedObject = clone $this;
+        $clonedObject->attributes[$name] = $value;
+        return $clonedObject;
     }
 
     /**

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -179,4 +179,25 @@ interface RenderingContextInterface
      * @param string $action
      */
     public function setControllerAction($action);
+
+    /**
+     * Retrieve a single attribute.
+     *
+     * @see withAttribute()
+     * @param string $name The attribute name.
+     * @return object|null  null if the specified attribute hasn't been set
+     */
+    public function getAttribute(string $name): ?object;
+
+    /**
+     * Return an instance with the specified attribute.
+     *
+     * This method allows you to attach arbitrary objects to the
+     * rendering context to be used later e. g. in ViewHelpers.
+     *
+     * @param string $name The attribute name.
+     * @param object $value The value of the attribute.
+     * @return static
+     */
+    public function withAttribute(string $name, object $value): RenderingContextInterface;
 }

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
+use stdClass;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
@@ -102,5 +103,19 @@ final class RenderingContextTest extends UnitTestCase
         $subject = new RenderingContext();
         $subject->setCache($this->createMock(FluidCacheInterface::class));
         self::assertTrue($subject->isCacheEnabled());
+    }
+
+    /**
+     * @test
+     */
+    public function withAndGetAttribute(): void
+    {
+        $object = new stdClass();
+        $object->test = 'value';
+
+        $subject = new RenderingContext();
+        $clonedSubject = $subject->withAttribute('test', $object);
+        self::assertNull($subject->getAttribute('test'));
+        self::assertEquals($object, $clonedSubject->getAttribute('test'));
     }
 }


### PR DESCRIPTION
This adds the ability to attach arbitrary attributes to the rendering context. All popular usages of Fluid out there extend the rendering context implementation of Fluid and don't actually implement the whole interface, so we should be able to change the interface as well.

As a result of this, TYPO3 CMS will be able to drop its own rendering context implementation, which will make the integration more straightforward.