### PR TITLE
[BUGFIX] Fix memory overhead of getScopedCopy()

### DIFF
--- a/src/Core/Variables/ScopedVariableProvider.php
+++ b/src/Core/Variables/ScopedVariableProvider.php
@@ -109,11 +109,14 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param array|\ArrayAccess $variables
      */
-    public function getScopeCopy($variables): ScopedVariableProvider
+    public function getScopeCopy($variables): VariableProviderInterface
     {
-        return new ScopedVariableProvider(
-            $this->globalVariables->getScopeCopy($variables),
-            clone $this->localVariables
-        );
+        // Instead of cloning the instance of ScopedVariableProvider,
+        // only the instance holding global variables can be used here.
+        // Local variables are irrelevant for partials and sections
+        // because all variables are provided explicity via $variables.
+        // "settings" should leak down into partials and sections, but
+        // this is already implemented in StandardVariableProvider
+        return $this->globalVariables->getScopeCopy($variables);
     }
 }

--- a/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
@@ -271,4 +271,30 @@ final class ScopedVariableProviderTest extends UnitTestCase
         self::assertNull($variableProvider->getGlobalVariableProvider()->get('globalVar'));
         self::assertNull($variableProvider->getLocalVariableProvider()->get('globalVar'));
     }
+
+    /**
+     * @test
+     */
+    public function getScopedCopy(): void
+    {
+        $variableProvider = new ScopedVariableProvider(
+            new StandardVariableProvider(['myVar' => 'global', 'globalVariable' => 'global', 'settings' => ['test' => 'global']]),
+            new StandardVariableProvider(['myVar' => 'local', 'localVariable' => 'local']),
+        );
+
+        $copy = $variableProvider->getScopeCopy(['myVar' => 'scoped']);
+        self::assertNull($copy->get('globalVariable'));
+        self::assertNull($copy->get('localVariable'));
+        self::assertEquals('scoped', $copy->get('myVar'));
+        self::assertEquals('global', $copy->get('settings.test'));
+
+        $variableProvider->getGlobalVariableProvider()->add('addedGlobalVariable', 'added');
+        $variableProvider->getLocalVariableProvider()->add('addedLocalVariable', 'added');
+        self::assertNull($copy->get('addedGlobalVariable'));
+        self::assertNull($copy->get('addedLocalVariable'));
+
+        $copy->add('addedVariable', 'added');
+        self::assertEquals('added', $copy->get('addedVariable'));
+        self::assertNull($variableProvider->get('addedVariable'));
+    }
 }


### PR DESCRIPTION
The previous implementation of getScopedCopy() in the new ScopedVariableProvider copied both local and global variables. This is not necessary because all variables (except for settings) are provided explicitly and thus existing data in the data structure is irrelevant.

The new implementation reduces that unnecessary overhead by returning a StandardVariableProvider instead.