### PR TITLE
[FEATURE] Nl2brViewHelper for StandaloneFluid

### DIFF
--- a/src/ViewHelpers/Format/Nl2brViewHelper.php
+++ b/src/ViewHelpers/Format/Nl2brViewHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Wrapper for PHPs :php:`nl2br` function.
+ * See https://www.php.net/manual/function.nl2br.php.
+ *
+ * Examples
+ * ========
+ *
+ * Default
+ * -------
+ *
+ * ::
+ *
+ *    <f:format.nl2br>{text_with_linebreaks}</f:format.nl2br>
+ *
+ * Text with line breaks replaced by ``<br />``
+ *
+ * Inline notation
+ * ---------------
+ *
+ * ::
+ *
+ *    {text_with_linebreaks -> f:format.nl2br()}
+ *
+ * Text with line breaks replaced by ``<br />``
+ */
+final class Nl2brViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'string to format');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        return nl2br((string)$renderChildrenClosure());
+    }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/Nl2brViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/Nl2brViewHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class Nl2brViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): array
+    {
+        return [
+            'viewHelperDoesNotModifyTextWithoutLineBreaks' => [
+                '<f:format.nl2br><p class="bodytext">Some Text without line breaks</p></f:format.nl2br>',
+                '<p class="bodytext">Some Text without line breaks</p>',
+            ],
+            'viewHelperConvertsLineBreaksToBRTags' => [
+                '<f:format.nl2br>' . 'Line 1' . chr(10) . 'Line 2' . '</f:format.nl2br>',
+                'Line 1<br />' . chr(10) . 'Line 2',
+            ],
+            'viewHelperConvertsWindowsLineBreaksToBRTags' => [
+                '<f:format.nl2br>' . 'Line 1' . chr(13) . chr(10) . 'Line 2' . '</f:format.nl2br>',
+                'Line 1<br />' . chr(13) . chr(10) . 'Line 2',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
Nl2brViewHelper doesn't have any dependencies to TYPO3, so it can be moved to Fluid Standalone.