### PR TITLE
[FEATURE] NumberViewHelper for StandaloneFluid

### DIFF
--- a/src/ViewHelpers/Format/NumberViewHelper.php
+++ b/src/ViewHelpers/Format/NumberViewHelper.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Formats a number with custom precision, decimal point and grouped thousands.
+ * See https://www.php.net/manual/function.number-format.php.
+ *
+ * Examples
+ * ========
+ *
+ * Defaults
+ * --------
+ *
+ * ::
+ *
+ *    <f:format.number>423423.234</f:format.number>
+ *
+ * ``423,423.20``
+ *
+ * With all parameters
+ * -------------------
+ *
+ * ::
+ *
+ *    <f:format.number decimals="1" decimalSeparator="," thousandsSeparator=".">
+ *        423423.234
+ *    </f:format.number>
+ *
+ * ``423.423,2``
+ */
+final class NumberViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * Output is escaped already. We must not escape children, to avoid double encoding.
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('decimals', 'int', 'The number of digits after the decimal point', false, 2);
+        $this->registerArgument('decimalSeparator', 'string', 'The decimal point character', false, '.');
+        $this->registerArgument('thousandsSeparator', 'string', 'The character for grouping the thousand digits', false, ',');
+    }
+
+    /**
+     * Format the numeric value as a number with grouped thousands, decimal point and precision.
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        $decimals = (int)$arguments['decimals'];
+        $decimalSeparator = $arguments['decimalSeparator'];
+        $thousandsSeparator = $arguments['thousandsSeparator'];
+        $stringToFormat = $renderChildrenClosure();
+        return number_format((float)$stringToFormat, $decimals, $decimalSeparator, $thousandsSeparator);
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/NumberViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/NumberViewHelperTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class NumberViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): array
+    {
+        return [
+            'formatNumberDefaultsToEnglishNotationWithTwoDecimals' => [
+                '<f:format.number>3.1415926535898</f:format.number>',
+                '3.14',
+            ],
+            'formatNumberWithDecimalPoint' => [
+                '<f:format.number decimalSeparator=",">3.1415926535898</f:format.number>',
+                '3,14',
+            ],
+            'formatNumberWithDecimals' => [
+                '<f:format.number decimals="4">3.1415926535898</f:format.number>',
+                '3.1416',
+            ],
+            'formatNumberWithThousandsSeparator' => [
+                '<f:format.number thousandsSeparator=",">3141.5926535898</f:format.number>',
+                '3,141.59',
+            ],
+            'formatNumberWithEmptyInput' => [
+                '<f:format.number></f:format.number>',
+                '0.00',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
NumberViewHelper doesn't have any dependencies to TYPO3, so it can be moved to Fluid Standalone.