### PR TITLE
[FEATURE] StripTagsViewHelper for StandaloneFluid

### DIFF
--- a/src/ViewHelpers/Format/StripTagsViewHelper.php
+++ b/src/ViewHelpers/Format/StripTagsViewHelper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
+use Stringable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
@@ -91,14 +92,18 @@ final class StripTagsViewHelper extends AbstractViewHelper
      * Applies strip_tags() on the specified value if it's string-able.
      *
      * @see https://www.php.net/manual/function.strip-tags.php
-     * @return mixed
+     * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
     {
         $value = $renderChildrenClosure();
         $allowedTags = $arguments['allowedTags'];
-        if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
-            return $value;
+
+        if (is_array($value)) {
+            throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700819707);
+        }
+        if (is_object($value) && !($value instanceof Stringable)) {
+            throw new \InvalidArgumentException('Specified object cannot be converted to string.', 1700819706);
         }
         return strip_tags((string)$value, $allowedTags);
     }

--- a/src/ViewHelpers/Format/StripTagsViewHelper.php
+++ b/src/ViewHelpers/Format/StripTagsViewHelper.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Removes tags from the given string (applying PHPs :php:`strip_tags()` function)
+ * See https://www.php.net/manual/function.strip-tags.php.
+ *
+ * Examples
+ * ========
+ *
+ * Default notation
+ * ----------------
+ *
+ * ::
+ *
+ *    <f:format.stripTags>Some Text with <b>Tags</b> and an &Uuml;mlaut.</f:format.stripTags>
+ *
+ * Some Text with Tags and an &Uuml;mlaut. :php:`strip_tags()` applied.
+ *
+ * .. note::
+ *    Encoded entities are not decoded.
+ *
+ * Default notation with allowedTags
+ * ---------------------------------
+ *
+ * ::
+ *
+ *    <f:format.stripTags allowedTags="<p><span><div><script>">
+ *        <p>paragraph</p><span>span</span><div>divider</div><iframe>iframe</iframe><script>script</script>
+ *    </f:format.stripTags>
+ *
+ * Output::
+ *
+ *    <p>paragraph</p><span>span</span><div>divider</div>iframe<script>script</script>
+ *
+ * Inline notation
+ * ---------------
+ *
+ * ::
+ *
+ *    {text -> f:format.stripTags()}
+ *
+ * Text without tags :php:`strip_tags()` applied.
+ *
+ * Inline notation with allowedTags
+ * --------------------------------
+ *
+ * ::
+ *
+ *    {text -> f:format.stripTags(allowedTags: "<p><span><div><script>")}
+ *
+ * Text with p, span, div and script Tags inside, all other tags are removed.
+ */
+final class StripTagsViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * No output escaping as some tags may be allowed
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'string to format');
+        $this->registerArgument('allowedTags', 'string', 'Optional string of allowed tags as required by PHPs strip_tags() function');
+    }
+
+    /**
+     * To ensure all tags are removed, child node's output must not be escaped
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * Applies strip_tags() on the specified value if it's string-able.
+     *
+     * @see https://www.php.net/manual/function.strip-tags.php
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $value = $renderChildrenClosure();
+        $allowedTags = $arguments['allowedTags'];
+        if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            return $value;
+        }
+        return strip_tags((string)$value, $allowedTags);
+    }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): array
+    {
+        return [
+            'renderUsesValueAsSourceIfSpecified' => [
+                '<f:format.stripTags value="Some string" />',
+                'Some string',
+            ],
+            'renderUsesChildnodesAsSourceIfSpecified' => [
+                '<f:format.stripTags>Some string</f:format.stripTags>',
+                'Some string',
+            ],
+            'no special chars' => [
+                '<f:format.stripTags>This is a sample text without special characters.</f:format.stripTags>',
+                'This is a sample text without special characters.',
+            ],
+            'some tags' => [
+                '<f:format.stripTags>This is a sample text <b>with <i>some</i> tags</b>.</f:format.stripTags>',
+                'This is a sample text with some tags.',
+            ],
+            'some umlauts' => [
+                '<f:format.stripTags>This text contains some &quot;&Uuml;mlaut&quot;.</f:format.stripTags>',
+                'This text contains some &quot;&Uuml;mlaut&quot;.',
+            ],
+            'allowed tags' => [
+                '<f:format.stripTags allowedTags="<strong>">This text <i>contains</i> some <strong>allowed</strong> tags.</f:format.stripTags>',
+                'This text contains some <strong>allowed</strong> tags.',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+
+    /**
+     * Ensures that objects are handled properly:
+     * + class having __toString() method gets tags stripped off
+     *
+     * @test
+     */
+    public function renderEscapesObjectIfPossible(): void
+    {
+        $toStringClass = new class () {
+            public function __toString(): string
+            {
+                return '<script>alert(\'"xss"\')</script>';
+            }
+        };
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.stripTags>{value}</f:format.stripTags>');
+        $view->assign('value', $toStringClass);
+        self::assertEquals('alert(\'"xss"\')', $view->render());
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use stdClass;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -20,6 +21,10 @@ final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
             'renderUsesValueAsSourceIfSpecified' => [
                 '<f:format.stripTags value="Some string" />',
                 'Some string',
+            ],
+            'int as input' => [
+                '<f:format.stripTags value="123" />',
+                '123',
             ],
             'renderUsesChildnodesAsSourceIfSpecified' => [
                 '<f:format.stripTags>Some string</f:format.stripTags>',
@@ -80,5 +85,35 @@ final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.stripTags>{value}</f:format.stripTags>');
         $view->assign('value', $toStringClass);
         self::assertEquals('alert(\'"xss"\')', $view->render());
+    }
+
+    public static function throwsExceptionForInvalidInputDataProvider(): array
+    {
+        return [
+            'array input' => [
+                [1, 2, 3],
+                1700819707,
+                'Specified array cannot be converted to string.',
+            ],
+            'object input' => [
+                new stdClass(),
+                1700819706,
+                'Specified object cannot be converted to string.',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider throwsExceptionForInvalidInputDataProvider
+     */
+    public function throwsExceptionForInvalidInput(mixed $value, int $expectedExceptionCode, string $expectedExceptionMessage): void
+    {
+        self::expectExceptionCode($expectedExceptionCode);
+        self::expectExceptionMessage($expectedExceptionMessage);
+        $view = new TemplateView();
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.stripTags>{value}</f:format.stripTags>');
+        $view->assign('value', $value);
+        $view->render();
     }
 }


### PR DESCRIPTION
StripTagsViewHelper doesn't have any dependencies to TYPO3, so it can be moved to Fluid Standalone.