### PR TITLE
[FEATURE] UrlencodeViewHelper for StandaloneFluid

### DIFF
--- a/src/ViewHelpers/Format/UrlencodeViewHelper.php
+++ b/src/ViewHelpers/Format/UrlencodeViewHelper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
+use Stringable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
@@ -62,13 +63,16 @@ final class UrlencodeViewHelper extends AbstractViewHelper
      * Escapes special characters with their escaped counterparts as needed using PHPs rawurlencode() function.
      *
      * @see https://www.php.net/manual/function.rawurlencode.php
-     * @return mixed
+     * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
     {
         $value = $renderChildrenClosure();
-        if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
-            return $value;
+        if (is_array($value)) {
+            throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700821579);
+        }
+        if (is_object($value) && !($value instanceof Stringable)) {
+            throw new \InvalidArgumentException('Specified object cannot be converted to string.', 1700821578);
         }
         return rawurlencode((string)$value);
     }

--- a/src/ViewHelpers/Format/UrlencodeViewHelper.php
+++ b/src/ViewHelpers/Format/UrlencodeViewHelper.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+/**
+ * Encodes the given string according to http://www.faqs.org/rfcs/rfc3986.html
+ * Applying PHPs :php:`rawurlencode()` function.
+ * See https://www.php.net/manual/function.rawurlencode.php.
+ *
+ * .. note::
+ *    The output is not escaped. You may have to ensure proper escaping on your own.
+ *
+ * Examples
+ * ========
+ *
+ * Default notation
+ * ----------------
+ *
+ * ::
+ *
+ *    <f:format.urlencode>foo @+%/</f:format.urlencode>
+ *
+ * ``foo%20%40%2B%25%2F`` :php:`rawurlencode()` applied.
+ *
+ * Inline notation
+ * ---------------
+ *
+ * ::
+ *
+ *    {text -> f:format.urlencode()}
+ *
+ * Url encoded text :php:`rawurlencode()` applied.
+ */
+final class UrlencodeViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    /**
+     * Output is escaped already. We must not escape children, to avoid double encoding.
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'string to format');
+    }
+
+    /**
+     * Escapes special characters with their escaped counterparts as needed using PHPs rawurlencode() function.
+     *
+     * @see https://www.php.net/manual/function.rawurlencode.php
+     * @return mixed
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $value = $renderChildrenClosure();
+        if (!is_string($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            return $value;
+        }
+        return rawurlencode((string)$value);
+    }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class UrlencodeViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): array
+    {
+        return [
+            'renderUsesValueAsSourceIfSpecified' => [
+                '<f:format.urlencode value="Source" />',
+                'Source',
+            ],
+            'renderUsesChildnodesAsSourceIfSpecified' => [
+                '<f:format.urlencode>Source</f:format.urlencode>',
+                'Source',
+            ],
+            'renderDoesNotModifyValueIfItDoesNotContainSpecialCharacters' => [
+                '<f:format.urlencode>StringWithoutSpecialCharacters</f:format.urlencode>',
+                'StringWithoutSpecialCharacters',
+            ],
+            'renderEncodesString' => [
+                '<f:format.urlencode>Foo @+%/ "</f:format.urlencode>',
+                'Foo%20%40%2B%25%2F%20%22',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+
+    /**
+     * Ensures that objects are handled properly:
+     * + class having __toString() method gets tags stripped off
+     *
+     * @test
+     */
+    public function renderEscapesObjectIfPossible(): void
+    {
+        $toStringClass = new class () {
+            public function __toString(): string
+            {
+                return '<script>alert(\'"xss"\')</script>';
+            }
+        };
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.urlencode>{value}</f:format.urlencode>');
+        $view->assign('value', $toStringClass);
+        self::assertEquals('%3Cscript%3Ealert%28%27%22xss%22%27%29%3C%2Fscript%3E', $view->render());
+    }
+}

--- a/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use stdClass;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -72,5 +73,35 @@ final class UrlencodeViewHelperTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.urlencode>{value}</f:format.urlencode>');
         $view->assign('value', $toStringClass);
         self::assertEquals('%3Cscript%3Ealert%28%27%22xss%22%27%29%3C%2Fscript%3E', $view->render());
+    }
+
+    public static function throwsExceptionForInvalidInputDataProvider(): array
+    {
+        return [
+            'array input' => [
+                [1, 2, 3],
+                1700821579,
+                'Specified array cannot be converted to string.',
+            ],
+            'object input' => [
+                new stdClass(),
+                1700821578,
+                'Specified object cannot be converted to string.',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider throwsExceptionForInvalidInputDataProvider
+     */
+    public function throwsExceptionForInvalidInput(mixed $value, int $expectedExceptionCode, string $expectedExceptionMessage): void
+    {
+        self::expectExceptionCode($expectedExceptionCode);
+        self::expectExceptionMessage($expectedExceptionMessage);
+        $view = new TemplateView();
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.urlencode>{value}</f:format.urlencode>');
+        $view->assign('value', $value);
+        $view->render();
     }
 }


### PR DESCRIPTION
UrlencodeViewHelper doesn't have any dependencies to TYPO3, so it can be moved to Fluid Standalone.