### PR TITLE
Do not check for content to be null in OrViewHelper.php

### DIFF
--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -65,7 +65,7 @@ class OrViewHelper extends AbstractViewHelper
 
         $content = $renderChildrenClosure();
 
-        if (null === $content) {
+        if ('' === $content) {
             $content = $alternative;
         }
 


### PR DESCRIPTION
Defining an alternative and make a field (content) empty has not the expected result (we expect the alternative to be displayed). I found a condition that only checks if content is equal to null. But I never reach this, rather I reach an empty string.
The tests also have to be adapted. The TODO hint is correct.