### PR TITLE
[BUGFIX] Explicitly set variables should override local variables

### DIFF
--- a/Documentation/Usage/Syntax.rst
+++ b/Documentation/Usage/Syntax.rst
@@ -200,3 +200,15 @@ the scope:
         <f:variable name="lastItem" value="{item}" />
     </f:for>
     <!-- {lastItem} is "second" -->
+
+If a global variable is created inside a local scope and uses the same name as a local
+variable, it will still leak out of the scope and will also be valid inside the scope:
+
+.. code-block:: xml
+
+    <f:for each="{0: 'first', 1: 'second'}" as="item">
+        <!-- {item} is "first" or "second" -->
+        <f:variable name="item" value="overwritten" />
+        <!-- {item} is "overwritten" -->
+    </f:for>
+    <!-- {item} is "overwritten" -->

--- a/src/Core/Variables/ScopedVariableProvider.php
+++ b/src/Core/Variables/ScopedVariableProvider.php
@@ -42,6 +42,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     public function add($identifier, $value): void
     {
         $this->globalVariables->add($identifier, $value);
+        $this->localVariables->add($identifier, $value);
     }
 
     /**

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -179,6 +179,13 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
         ];
 
         $value = ['bar', 2];
+        yield 'local variables can be converted to global variables inside loop' => [
+            '<f:for each="{value}" as="item">{item}|<f:variable name="item" value="overwritten" />{item}|</f:for>{item}',
+            ['value' => $value],
+            'bar|overwritten|2|overwritten|overwritten',
+        ];
+
+        $value = ['bar', 2];
         yield 'variables set inside loop can be used after loop' => [
             '<f:for each="{value}" key="key" as="item"><f:variable name="foo" value="bar" /></f:for>{foo}',
             ['value' => $value],

--- a/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
@@ -283,7 +283,7 @@ final class ScopedVariableProviderTest extends UnitTestCase
         $variableProvider = new ScopedVariableProvider(new StandardVariableProvider(), new StandardVariableProvider());
         $variableProvider->add('globalVar', 'global');
         self::assertEquals('global', $variableProvider->getGlobalVariableProvider()->get('globalVar'));
-        self::assertNull($variableProvider->getLocalVariableProvider()->get('globalVar'));
+        self::assertEquals('global', $variableProvider->getLocalVariableProvider()->get('globalVar'));
     }
 
     /**


### PR DESCRIPTION
The default behavior of the newly introduced local and global variable scopes has been that existing local variables are preferred over global variables if both exist. While this makes sense in general, if a local variable gets overwritten by a VariableViewHelper, this value couldn't be used in the local context because the local variable still had its old value.

This change makes sure that both the local and the global variable get the new value. This eliminates the described inconsistencies when using a name of a local variable for a global variable.

Resolves #846