### PR TITLE
[BUGFIX] Choose global/local variable based on primary identifier

### DIFF
--- a/src/Core/Variables/ScopedVariableProvider.php
+++ b/src/Core/Variables/ScopedVariableProvider.php
@@ -96,7 +96,10 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     public function getByPath($path): mixed
     {
         $path = $this->resolveSubVariableReferences($path);
-        return $this->localVariables->getByPath($path) ?? $this->globalVariables->getByPath($path);
+        $identifier = explode('.', $path, 2)[0];
+        return $this->localVariables->exists($identifier)
+            ? $this->localVariables->getByPath($path)
+            : $this->globalVariables->getByPath($path);
     }
 
     public function getAllIdentifiers(): array

--- a/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
@@ -176,6 +176,13 @@ final class ScopedVariableProviderTest extends UnitTestCase
             'local',
         ];
 
+        yield 'local undefined subkey overrides global set subkey' => [
+            ['myVar' => ['myKey' => 'global']],
+            ['myVar' => ['myKey' => null]],
+            'myVar.myKey',
+            null,
+        ];
+
         yield 'variable variables using only globals' => [
             ['myVar' => ['sub' => 'global'], 'path' => 'sub'],
             [],


### PR DESCRIPTION
With the previous implementation of ScopedVariableProvider, variables that contained arrays or object structures could behave incorrectly in a scoped context. When accessing a object path in a fluid template (e. g. myVar.subKey), the value of that "sub variable" was considered for the decision which variable (global or local) should be used.

This behavior is incorrect, only the "primary" variable name should determine if a local variable is set or not (and should fall back to a global variable). This would mean that a non-existing sub value in a local variable would trigger a fallback to the global variable.

This change restores the correct behavior: Only the "primary" variable name is checked initially. If the variable exists in the local variables, those will be used, even if the requested sub value doesn't exist there. Only if the "primary" variable name doesn't exist in local variables, global variables will be used instead.

Resolves #848