### PR TITLE
[FEATURE] SplitViewHelper

### DIFF
--- a/src/ViewHelpers/SplitViewHelper.php
+++ b/src/ViewHelpers/SplitViewHelper.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The SplitViewHelper splits a string by the specified separator, which
+ * results in an array. The number of values in the resulting array can
+ * be limited with the limit parameter, which results in an array where
+ * the last item contains the remaining unsplit string.
+ *
+ * This ViewHelper mimicks PHP's :php:`explode()` function.
+ *
+ *
+ * Examples
+ * ========
+ *
+ * Split with a separator
+ * -----------------------
+ * ::
+ *
+ *    <f:split value="1,5,8" separator="," />
+ *
+ * .. code-block:: text
+ *
+ *    {0: '1', 1: '5', 2: '8'}
+ *
+ *
+ * Split using tag content as value
+ * --------------------------------
+ *
+ * ::
+ *
+ *    <f:split separator="-">1-5-8</f:split>
+ *
+ * .. code-block:: text
+ *
+ *    {0: '1', 1: '5', 2: '8'}
+ *
+ *
+ * Split with a limit
+ * -------------------
+ *
+ * ::
+ *
+ *    <f:split value="1,5,8" separator="," limit="2" />
+ *
+ * .. code-block:: text
+ *
+ *    {0: '1', 1: '5,8'}
+ */
+final class SplitViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'The string to explode');
+        $this->registerArgument('separator', 'string', 'Separator string to explode with', true);
+        $this->registerArgument('limit', 'int', 'If limit is positive, a maximum of $limit items will be returned. If limit is negative, all items except for the last $limit items will be returned. 0 will be treated as 1.', false, PHP_INT_MAX);
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): array
+    {
+        $value = $arguments['value'] ?? $renderChildrenClosure();
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('Value to be split must be a string: ' . $value, 1705250408);
+        }
+
+        return explode($arguments['separator'], $value, $arguments['limit']);
+    }
+}

--- a/tests/Functional/ViewHelpers/SplitViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SplitViewHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class SplitViewHelperTest extends AbstractFunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function throwsExceptionForInvalidValue(): void
+    {
+        self::expectExceptionCode(1705250408);
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:split separator="," />');
+        $view->render();
+    }
+
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'value as argument' => [
+            '<f:split value="{value}" separator="," />',
+            ['value' => 'foo,bar,4'],
+            ['foo', 'bar', '4'],
+        ];
+        yield 'value as tag content' => [
+            '<f:split separator=",">{value}</f:split>',
+            ['value' => 'foo,bar,4'],
+            ['foo', 'bar', '4'],
+        ];
+        yield 'limit items' => [
+            '<f:split separator="." limit="2">{value}</f:split>',
+            ['value' => 'foo.bar.baz'],
+            ['foo', 'bar.baz'],
+        ];
+        yield 'limit matches result' => [
+            '<f:split separator="," limit="3">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            ['foo', 'bar', 'baz'],
+        ];
+        yield 'limit exceeds result' => [
+            '<f:split separator="," limit="10">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            ['foo', 'bar', 'baz'],
+        ];
+        yield 'limit zero' => [
+            '<f:split separator="," limit="0">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            ['foo,bar,baz'],
+        ];
+        yield 'limit one' => [
+            '<f:split separator="," limit="1">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            ['foo,bar,baz'],
+        ];
+        yield 'negative limit' => [
+            '<f:split separator="," limit="-1">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            ['foo', 'bar'],
+        ];
+        yield 'exceeding negative limit' => [
+            '<f:split separator="," limit="-5">{value}</f:split>',
+            ['value' => 'foo,bar,baz'],
+            [],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, array $variables, $expected): void
+    {
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
This patch adds a new <f:format.split> ViewHelper to Fluid Standalone. It is named "split" instead of "explode" to be consistent with the naming of JavaScript.

The ViewHelper aims to support everything that TYPO3's utility functions "GeneralUtility::intExplode()" and
"GeneralUtility::trimExplode()" provide.

* items in the resulting array can be trimmed of whitespace
* items in the resulting array can be converted to integers
* empty items in the resulting array can be removed
* the "limit" option behaves similar to PHP's explode() behavior

In a following patch, its counterpart "join" will be added.