### PR TITLE
[BUGFIX] Prevent php warning when passing array as tag attribute

### DIFF
--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -181,7 +181,10 @@ class TagBuilder
      * Adds an attribute to the $attributes-collection
      *
      * @param string $attributeName name of the attribute to be added to the tag
-     * @param string|\Traversable|array|null $attributeValue attribute value
+     * @param string|\Traversable|array|null $attributeValue attribute value, can only be array or traversable
+     *                                                       if the attribute name is either "data" or "area". In
+     *                                                       that special case, multiple attributes will be created
+     *                                                       with either "data-" or "area-" as prefix
      * @param bool $escapeSpecialCharacters apply htmlspecialchars to attribute value
      * @api
      */
@@ -190,9 +193,14 @@ class TagBuilder
         if ($escapeSpecialCharacters) {
             $attributeName = htmlspecialchars($attributeName);
         }
-        if (in_array($attributeName, ['data', 'aria'], true)
-            && (is_array($attributeValue) || $attributeValue instanceof \Traversable)
-        ) {
+        if (is_array($attributeValue) || $attributeValue instanceof \Traversable) {
+            if (!in_array($attributeName, ['data', 'aria'], true)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Value of tag attribute "%s" cannot be of type array.', $attributeName),
+                    1709565127
+                );
+            }
+
             foreach ($attributeValue as $name => $value) {
                 $this->addAttribute($attributeName . '-' . $name, $value, $escapeSpecialCharacters);
             }

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -124,6 +124,29 @@ final class TagBuilderTest extends UnitTestCase
     /**
      * @test
      */
+    public function arrayAttributesAreProperlyRendered(): void
+    {
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('data', ['attribute1' => 'data1', 'attribute2' => 'data2']);
+        $tagBuilder->addAttribute('aria', ['attribute1' => 'aria1']);
+        self::assertEquals('<tag data-attribute1="data1" data-attribute2="data2" aria-attribute1="aria1" />', $tagBuilder->render());
+    }
+
+    /**
+     * @test
+     */
+    public function customArrayAttributesThrowException(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionCode(1709565127);
+        self::expectExceptionMessage('Value of tag attribute "custom" cannot be of type array.');
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute('custom', ['attribute1' => 'data1', 'attribute2' => 'data2']);
+    }
+
+    /**
+     * @test
+     */
     public function attributeValuesAreEscapedByDefault(): void
     {
         $tagBuilder = new TagBuilder('tag');


### PR DESCRIPTION
TagBuilder::addAttribute() allows both strings and array/traversables as attribute value. However, in the implementation only "data" and "aria" are properly handled as arrays. For other attribute names, this leads to a type conversion warning.

With this patch, that edge case is properly handled with an exception. Also, test coverage is added both for data/aria and the exception.

Resolves: #857