### PR TITLE
[FEATURE] Allow arbitrary arguments for TagBasedViewHelper

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -115,9 +115,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
         }
 
         foreach ($this->additionalArguments as $argumentName => $argumentValue) {
-            if (strpos($argumentName, 'data-') === 0 || strpos($argumentName, 'aria-') === 0) {
-                $this->tag->addAttribute($argumentName, $argumentValue);
-            }
+            $this->tag->addAttribute($argumentName, $argumentValue);
         }
 
         if (isset(self::$tagAttributes[get_class($this)])) {
@@ -138,6 +136,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      * @param bool $required set to TRUE if tag attribute is required. Defaults to FALSE.
      * @param mixed $defaultValue Optional, default value of attribute if one applies
      * @api
+     * @deprecated No longer necessary since arbitrary arguments are possible; will be removed with next major version
      */
     protected function registerTagAttribute($name, $type, $description, $required = false, $defaultValue = null)
     {
@@ -150,19 +149,9 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      * Should be used inside registerArguments();
      *
      * @api
+     * @deprecated No longer necessary since arbitrary arguments are possible; will be removed with next major version
      */
-    protected function registerUniversalTagAttributes()
-    {
-        $this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
-        $this->registerTagAttribute('dir', 'string', 'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)');
-        $this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
-        $this->registerTagAttribute('lang', 'string', 'Language for this element. Use short names specified in RFC 1766');
-        $this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
-        $this->registerTagAttribute('title', 'string', 'Tooltip text of element');
-        $this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
-        $this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
-        $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
-    }
+    protected function registerUniversalTagAttributes() {}
 
     public function handleAdditionalArguments(array $arguments)
     {
@@ -172,12 +161,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
 
     public function validateAdditionalArguments(array $arguments)
     {
-        foreach (array_keys($arguments) as $name) {
-            if (str_starts_with($name, 'data-') || str_starts_with($name, 'aria-')) {
-                unset($arguments[$name]);
-            }
-        }
-        parent::validateAdditionalArguments($arguments);
+        // Skip validation of additional arguments since we want to pass all arguments to the tag
     }
 
     /**

--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -159,7 +159,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
         parent::handleAdditionalArguments($arguments);
     }
 
-    public function validateAdditionalArguments(array $arguments)
+    public function validateAdditionalArguments(array $arguments): void
     {
         // Skip validation of additional arguments since we want to pass all arguments to the tag
     }

--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -322,10 +322,6 @@ final class ViewHelperEscapingTest extends BaseTestCase
         self::assertSame('<div foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test additionalAttributes="{foo: value}" />'), 'Tag additional attributes values are escaped');
         self::assertSame('<div data-&gt;' . self::ESCAPED . '&lt;="1" />', $this->renderCode($viewHelper, '<test:test data=\'{"><script>alert(1)</script><": 1}\' />'), 'Tag data attribute keys are escaped');
         self::assertSame('<div &gt;' . self::ESCAPED . '&lt;="1" />', $this->renderCode($viewHelper, '<test:test additionalAttributes=\'{"><script>alert(1)</script><": 1}\' />'), 'Tag additional attributes keys are escaped');
-
-        // Disabled: bug detected, handleAdditionalArguments on AbstractTagBasedViewHelper does assign the tag attribute, but following this call,
-        // the initialize() method is called which resets the TagBuilder and in turn removes the data- prefixed attributes which are then not re-assigned.
-        // Regression caused by https://github.com/TYPO3/Fluid/pull/419.
-        //$this->assertSame('<div data-foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test data-foo="{value}" />'), 'Tag unregistered data attribute is escaped');
+        self::assertSame('<div data-foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test data-foo="{value}" />'), 'Tag unregistered data attribute is escaped');
     }
 }

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -25,6 +25,10 @@ final class TagBasedTest extends AbstractFunctionalTestCase
                 '<test:tagBasedTest registeredTagAttribute="test" />',
                 '<div registeredTagAttribute="test" />',
             ],
+            'unregistered argument' => [
+                '<test:tagBasedTest foo="bar" />',
+                '<div foo="bar" />',
+            ],
             'data array' => [
                 '<test:tagBasedTest data="{foo: \'bar\', more: 1}" />',
                 '<div data-foo="bar" data-more="1" />',
@@ -104,10 +108,6 @@ final class TagBasedTest extends AbstractFunctionalTestCase
             'aria argument as string' => [
                 '<test:tagBasedTest aria="test" />',
                 \InvalidArgumentException::class,
-            ],
-            'undefined argument' => [
-                '<test:tagBasedTest undefinedArgument="test" />',
-                \TYPO3Fluid\Fluid\Core\ViewHelper\Exception::class,
             ],
         ];
     }

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -103,11 +103,9 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         return [
             'data argument as string' => [
                 '<test:tagBasedTest data="test" />',
-                \InvalidArgumentException::class,
             ],
             'aria argument as string' => [
                 '<test:tagBasedTest aria="test" />',
-                \InvalidArgumentException::class,
             ],
         ];
     }
@@ -116,9 +114,9 @@ final class TagBasedTest extends AbstractFunctionalTestCase
      * @test
      * @dataProvider throwsErrorForInvalidArgumentTypesDatProvider
      */
-    public function throwsErrorForInvalidArgumentTypes(string $source, string $exceptionClass): void
+    public function throwsErrorForInvalidArgumentTypes(string $source): void
     {
-        self::expectException($exceptionClass);
+        self::expectException(\InvalidArgumentException::class);
 
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/Fixtures/ViewHelpers/TagBasedTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/TagBasedTestViewHelper.php
@@ -18,6 +18,5 @@ class TagBasedTestViewHelper extends AbstractTagBasedViewHelper
         parent::initializeArguments();
         $this->registerArgument('registeredArgument', 'string', 'test argument');
         $this->registerTagAttribute('registeredTagAttribute', 'string', 'test argument');
-        $this->registerUniversalTagAttributes();
     }
 }

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -27,16 +25,5 @@ class AbstractTagBasedViewHelperTest extends UnitTestCase
         $subject = $this->getMockBuilder(AbstractTagBasedViewHelper::class)->onlyMethods([])->getMock();
         $subject->setTagBuilder($tagBuilder);
         self::assertEquals('foobar', $subject->render());
-    }
-
-    /**
-     * @test
-     */
-    public function validateAdditionalArgumentsThrowsExceptionIfContainingNonDataArguments(): void
-    {
-        $this->expectException(Exception::class);
-        $subject = $this->getMockBuilder(AbstractTagBasedViewHelper::class)->onlyMethods([])->getMock();
-        $subject->setRenderingContext(new RenderingContext());
-        $subject->validateAdditionalArguments(['foo' => 'bar']);
     }
 }


### PR DESCRIPTION
Tag based ViewHelpers can now receive arbitrary arguments which
will be added to the resulting HTML tag automatically. This offers
a much more readable option compared to the "additionalAttributes"
argument, which is still available for tag based ViewHelpers. Also,
both "data" and "aria" arguments are still available to supply multiple
data or aria attributes as an array.

As a result of this change, the following methods of
AbstractTagBasedViewHelper are deprecated and will be removed
with the next major version of Fluid:

* registerUniversalTagAttributes(): The method is now a no-op since
all previously registered universal attributes can now be used without
registration.

* registerTagAttribute(): The method still has the same functionality
since it also supports the required flag as well as default values, but
is no longer necessary in its current form. For edge cases when
the required flag is still necessary, registerArgument() can be used.