### PR TITLE
[FEATURE] JoinViewHelper

### DIFF
--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The JoinViewHelper combines elements from an array into a single string.
+ * You can specify both a general separator and a special one for the last
+ * element, which serves as the delimiter between the elements.
+ *
+ *
+ * Examples
+ * ========
+ *
+ * Simple join
+ * -----------
+ * ::
+ *
+ *    <f:join value="{0: '1', 1: '2', 2: '3'}" />
+ *
+ * .. code-block:: text
+ *
+ *    123
+ *
+ *
+ * Join with separator
+ * -------------------
+ *
+ * ::
+ *
+ *    <f:join value="{0: '1', 1: '2', 2: '3'}" separator=", " />
+ *
+ * .. code-block:: text
+ *
+ *    1, 2, 3
+ *
+ *
+ * Join with separator, and special one for the last
+ * -------------------------------------------------
+ *
+ * ::
+ *
+ *    <f:join value="{0: '1', 1: '2', 2: '3'}" separator=", " separatorLast=" and " />
+ *
+ * .. code-block:: text
+ *
+ *    1, 2 and 3
+ */
+final class JoinViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'array', 'An array', false);
+        $this->registerArgument('separator', 'string', 'The separator', false, '');
+        $this->registerArgument('separatorLast', 'string', 'The separator for the last pair.', false, null);
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string The concatenated string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $value = $arguments['value'] ?? null;
+        $separator = $arguments['separator'] ?? '';
+        $separatorLast = $arguments['separatorLast'] ?? null;
+
+        if ($value === null) {
+            $content = $renderChildrenClosure();
+            if (!is_array($content) && !$content instanceof \ArrayAccess && !$content instanceof \Traversable) {
+                $givenType = get_debug_type($content);
+                throw new \InvalidArgumentException(
+                    'The argument "value" was registered with type "array", but is of type "' .
+                    $givenType . '" in view helper "' . static::class . '".',
+                    1256475113
+                );
+            }
+            $value = $content;
+        }
+
+        $value = (array)$value;
+
+        if (\count($value) === 0) {
+            return '';
+        }
+
+        if ($separatorLast === null || $separatorLast === $separator) {
+            return implode($separator, $value);
+        }
+
+        if (\count($value) === 1) {
+            return (string)$value[0];
+        }
+
+        return implode($separator, \array_slice($value, 0, -1)) . $separatorLast . $value[\count($value) - 1];
+    }
+}

--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -74,7 +74,7 @@ final class JoinViewHelper extends AbstractViewHelper
      *
      * @return string The concatenated string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
     {
         $value = $arguments['value'] ?? $renderChildrenClosure();
         $separator = $arguments['separator'] ?? '';
@@ -91,16 +91,12 @@ final class JoinViewHelper extends AbstractViewHelper
 
         $value = self::iteratorToArray($value);
 
-        if (\count($value) === 0) {
-            return '';
+        if (\count($value) < 2) {
+            return (string)array_pop($value);
         }
 
         if ($separatorLast === null || $separatorLast === $separator) {
             return implode($separator, $value);
-        }
-
-        if (\count($value) === 1) {
-            return (string)$value[0];
         }
 
         return implode($separator, \array_slice($value, 0, -1)) . $separatorLast . $value[\count($value) - 1];

--- a/tests/Functional/ViewHelpers/JoinViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/JoinViewHelperTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class JoinViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderValidDataProvider(): \Generator
+    {
+        yield 'template with named layout' => [
+            'arguments' => [
+                'value' => [],
+            ],
+            'src' => '<f:join value="{value}" />',
+            'expectation' => '',
+        ];
+        yield 'empty value inline' => [
+            'arguments' => [
+                'value' => [],
+            ],
+            'src' => '{value -> f:join()}',
+            'expectation' => '',
+        ];
+        yield 'empty attribute value, with separator' => [
+            'arguments' => [
+                'value' => [],
+                'separator' => ',',
+            ],
+            'src' => '<f:join value="{value}" separator="{separator}" />',
+            'expectation' => '',
+        ];
+        yield 'empty attribute value, with separatorLast' => [
+            'arguments' => [
+                'value' => [],
+                'separatorLast' => ' and ',
+            ],
+            'src' => '<f:join value="{value}" separatorLast="{separatorLast}" />',
+            'expectation' => '',
+        ];
+        yield 'value attribute' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+            ],
+            'src' => '<f:join value="{value}" />',
+            'expectation' => '123',
+        ];
+        yield 'value attribute inline array' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+            ],
+            'src' => '<f:join value="{0: \'1\', 1: \'2\', 2: \'3\'}" />',
+            'expectation' => '123',
+        ];
+        yield 'value inline' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+            ],
+            'src' => '{value -> f:join()}',
+            'expectation' => '123',
+        ];
+        yield 'value inline and argument' => [
+            'arguments' => [
+                'valueInline' => [1, 2, 3],
+                'valueArgument' => [3, 2, 1]
+            ],
+            'src' => '{valueInline -> f:join(value: valueArgument)}',
+            'expectation' => '321',
+        ];
+        yield 'value and separator set' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+                'separator' => ', ',
+            ],
+            'src' => '<f:join value="{value}" separator="{separator}" />',
+            'expectation' => '1, 2, 3',
+        ];
+        yield 'value and separatorLast set' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+                'separatorLast' => ' and ',
+            ],
+            'src' => '<f:join value="{value}" separatorLast="{separatorLast}" />',
+            'expectation' => '12 and 3',
+        ];
+        yield 'value, separator and separatorLast set' => [
+            'arguments' => [
+                'value' => [1, 2, 3],
+                'separator' => ', ',
+                'separatorLast' => ' and ',
+            ],
+            'src' => '<f:join value="{value}" separator="{separator}" separatorLast="{separatorLast}" />',
+            'expectation' => '1, 2 and 3',
+        ];
+    }
+
+    #[DataProvider('renderValidDataProvider')]
+    #[Test]
+    public function renderValid(array $arguments, string $src, string $expectation): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        self::assertSame($expectation, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        self::assertSame($expectation, $view->render());
+    }
+
+    public static function renderInvalidDataProvider(): \Generator
+    {
+        yield 'invalid string content' => [
+            'arguments' => [
+            ],
+            'src' => '<f:join>SOME TEXT</f:join>',
+        ];
+        yield 'invalid string attribute' => [
+            'arguments' => [
+                'value' => 'string',
+            ],
+            'src' => '<f:join value="string" />',
+        ];
+        yield 'invalid string inline' => [
+            'arguments' => [
+                'value' => 'string',
+            ],
+            'src' => '{value -> f:join()}',
+        ];
+    }
+
+    #[DataProvider('renderInvalidDataProvider')]
+    #[Test]
+    public function renderInvalid(array $arguments, string $src): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        $view->render();
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        $view->render();
+    }
+}

--- a/tests/Functional/ViewHelpers/JoinViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/JoinViewHelperTest.php
@@ -34,6 +34,13 @@ final class JoinViewHelperTest extends AbstractFunctionalTestCase
             'src' => '{value -> f:join()}',
             'expectation' => '',
         ];
+        yield 'single item' => [
+            'arguments' => [
+                'value' => [1],
+            ],
+            'src' => '<f:join value="{value}" />',
+            'expectation' => '1',
+        ];
         yield 'empty attribute value, with separator' => [
             'arguments' => [
                 'value' => [],

--- a/tests/Functional/ViewHelpers/JoinViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/JoinViewHelperTest.php
@@ -12,6 +12,8 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class JoinViewHelperTest extends AbstractFunctionalTestCase
@@ -65,6 +67,13 @@ final class JoinViewHelperTest extends AbstractFunctionalTestCase
         yield 'value inline' => [
             'arguments' => [
                 'value' => [1, 2, 3],
+            ],
+            'src' => '{value -> f:join()}',
+            'expectation' => '123',
+        ];
+        yield 'value inline as iterable' => [
+            'arguments' => [
+                'value' => new IterableExample([1, 2, 3]),
             ],
             'src' => '{value -> f:join()}',
             'expectation' => '123',
@@ -140,6 +149,12 @@ final class JoinViewHelperTest extends AbstractFunctionalTestCase
             ],
             'src' => '{value -> f:join()}',
         ];
+        yield 'arrayaccess inline' => [
+            'arguments' => [
+                'value' => new ArrayAccessExample(['foo' => 'bar']),
+            ],
+            'src' => '{value -> f:join()}',
+        ];
     }
 
     #[DataProvider('renderInvalidDataProvider')]
@@ -147,6 +162,7 @@ final class JoinViewHelperTest extends AbstractFunctionalTestCase
     public function renderInvalid(array $arguments, string $src): void
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1256475113);
 
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
@@ -76,6 +76,7 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
      */
     public function throwsExceptionForInvalidArgument(string $template, array $variables, int $exceptionCode, string $exceptionMessage): void
     {
+        self::expectException(\InvalidArgumentException::class);
         self::expectExceptionCode($exceptionCode);
         self::expectExceptionMessage($exceptionMessage);
         $view = new TemplateView();


### PR DESCRIPTION
The JoinViewHelper combines elements from an array into a single string. You can specify both a general separator and a special one for the last element that is rendered between the elements.

## Examples

### Simple join

```html
<f:join value="{0: '1', 1: '2', 2: '3'}" />   
```

Results in the output:

```html
123
```

### Join with separator

```html
<f:join value="{0: '1', 1: '2', 2: '3'}" separator=", " />
```

Results in the output:

```html
1, 2, 3
```

### Join with separator, and special one for the last

```html
<f:join value="{0: '1', 1: '2', 2: '3'}" separator=", " separatorLast=" and " />
```

Results in the output:

```html
1, 2 and 3
```