### PR TITLE
[FEATURE] ReplaceViewHelper

### DIFF
--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The ReplaceViewHelper replaces one or multiple strings with other
+ * strings. This ViewHelper mimicks PHP's :php:`str_replace()` function.
+ * However, it's also possible to provide replace pairs as associative array
+ * via the "replace" argument.
+ *
+ *
+ * Examples
+ * ========
+ *
+ * Replace a single string
+ * -----------------------
+ * ::
+ *
+ *    <f:replace value="Hello World" search="World" replace="Fluid" />
+ *
+ * .. code-block:: text
+ *
+ *    Hello Fluid
+ *
+ *
+ * Replace multiple strings
+ * ------------------------
+ * ::
+ *
+ *    <f:replace value="Hello World" search="{0: 'World', 1: 'Hello'}" replace="{0: 'Fluid', 1: 'Hi'}" />
+ *
+ * .. code-block:: text
+ *
+ *    Hi Fluid
+ *
+ *
+ * Replace multiple strings using associative array
+ * ------------------------------------------------
+ * ::
+ *
+ *    <f:replace value="Hello World" replace="{'World': 'Fluid', 'Hello': 'Hi'}" />
+ *
+ * .. code-block:: text
+ *
+ *    Hi Fluid
+ */
+final class ReplaceViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', '', false);
+        $this->registerArgument('search', 'mixed', '', false);
+        $this->registerArgument('replace', 'mixed', '', true);
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    {
+        $value = $arguments['value'] ?? $renderChildrenClosure();
+        $search = $arguments['search'];
+        $replace = $arguments['replace'];
+
+        if ($value === null || (!is_scalar($value) && !$value instanceof \Stringable)) {
+            throw new \InvalidArgumentException('A stringable value must be provided.', 1710441987);
+        }
+
+        if ($search === null) {
+            if (!is_iterable($replace)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Argument "replace" must be iterable to be used without "search" argument, "%s" given instead.',
+                    get_debug_type($replace),
+                ), 1710441988);
+            }
+
+            $replace = self::iteratorToArray($replace);
+
+            $search = array_keys($replace);
+            $replace = array_values($replace);
+        } else {
+            if (!is_iterable($search) && !is_scalar($search)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Argument "search" must be either iterable or scalar, "%s" given instead.',
+                    get_debug_type($search),
+                ), 1710441989);
+            }
+            if (!is_iterable($replace) && !is_scalar($replace)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Argument "replace" must be either iterable or scalar, "%s" given instead.',
+                    get_debug_type($replace),
+                ), 1710441990);
+            }
+
+            $search = is_iterable($search) ? self::iteratorToArray($search) : [$search];
+            $replace = is_iterable($replace) ? self::iteratorToArray($replace) : [$replace];
+
+            if (\count($search) !== \count($replace)) {
+                throw new \InvalidArgumentException('Count of "search" and "replace" arguments must be the same.', 1710441991);
+            }
+        }
+
+        return str_replace($search, $replace, (string)$value);
+    }
+
+    /**
+     * This ensures compatibility with PHP 8.1
+     */
+    private static function iteratorToArray(\Traversable|array $iterator): array
+    {
+        return is_array($iterator) ? $iterator : iterator_to_array($iterator);
+    }
+}

--- a/tests/Functional/Fixtures/Various/ArrayAccessExample.php
+++ b/tests/Functional/Fixtures/Various/ArrayAccessExample.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+class ArrayAccessExample implements \ArrayAccess
+{
+    public function __construct(private array $data) {}
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->data[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->data[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->data[$offset]);
+    }
+}

--- a/tests/Functional/Fixtures/Various/IterableExample.php
+++ b/tests/Functional/Fixtures/Various/IterableExample.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+class IterableExample implements \Iterator
+{
+    public function __construct(private array $data) {}
+
+    public function current(): mixed
+    {
+        return current($this->data);
+    }
+
+    public function key(): mixed
+    {
+        return key($this->data);
+    }
+
+    public function next(): void
+    {
+        next($this->data);
+    }
+
+    public function rewind(): void
+    {
+        reset($this->data);
+    }
+
+    public function valid(): bool
+    {
+        return key($this->data) !== null;
+    }
+}

--- a/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function throwsExceptionForInvalidArgumentDataProvider(): iterable
+    {
+        yield 'without value' => [
+            '<f:replace search="foo" replace="bar" />',
+            [],
+            1710441987,
+            'A stringable value must be provided.',
+        ];
+        yield 'array as value' => [
+            '{value -> f:replace(search: \'foo\', replace: \'bar\')}',
+            ['value' => [1, 2, 3]],
+            1710441987,
+            'A stringable value must be provided.',
+        ];
+        yield 'no search and non-array replace' => [
+            '<f:replace value="abc" replace="a" />',
+            [],
+            1710441988,
+            'Argument "replace" must be iterable to be used without "search" argument, "string" given instead.',
+        ];
+        yield 'no search and replace as arrayaccess' => [
+            '<f:replace value="abc" replace="{replace}" />',
+            ['replace' => new ArrayAccessExample(['foo' => 'bar', 'abc' => 'def'])],
+            1710441988,
+            'Argument "replace" must be iterable to be used without "search" argument, "' . ArrayAccessExample::class . '" given instead.',
+        ];
+        yield 'search as arrayaccess' => [
+            '<f:replace value="{value}" search="{search}" replace="{replace}" />',
+            [
+                'value' => 'test foo abc',
+                'search' => new ArrayAccessExample(['foo', 'abc']),
+                'replace' => ['bar', 'def'],
+            ],
+            1710441989,
+            'Argument "search" must be either iterable or scalar, "' . ArrayAccessExample::class . '" given instead.',
+        ];
+        yield 'replace as arrayaccess' => [
+            '<f:replace value="{value}" search="{search}" replace="{replace}" />',
+            [
+                'value' => 'test foo abc',
+                'search' => ['foo', 'abc'],
+                'replace' => new ArrayAccessExample(['bar', 'def']),
+            ],
+            1710441990,
+            'Argument "replace" must be either iterable or scalar, "' . ArrayAccessExample::class . '" given instead.',
+        ];
+        yield 'non-matching search and replace count' => [
+            '<f:replace value="abc" search="{0: \'a\', 1: \'b\'}" replace="{0: \'c\'}" />',
+            [],
+            1710441991,
+            'Count of "search" and "replace" arguments must be the same.',
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider throwsExceptionForInvalidArgumentDataProvider
+     */
+    public function throwsExceptionForInvalidArgument(string $template, array $variables, int $exceptionCode, string $exceptionMessage): void
+    {
+        self::expectExceptionCode($exceptionCode);
+        self::expectExceptionMessage($exceptionMessage);
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $view->render();
+    }
+
+    public static function renderDataProvider(): iterable
+    {
+        yield 'search and replace as strings' => [
+            '<f:replace value="{value}" search="foo" replace="bar" />',
+            ['value' => 'test foo abc'],
+            'test bar abc',
+        ];
+        yield 'value from tag content' => [
+            '{value -> f:replace(search: \'foo\', replace: \'bar\')}',
+            ['value' => 'test foo abc'],
+            'test bar abc',
+        ];
+        yield 'replace as empty string' => [
+            '<f:replace value="{value}" search="foo" replace="" />',
+            ['value' => 'test foo abc'],
+            'test  abc',
+        ];
+        yield 'search and replace as array' => [
+            '<f:replace value="{value}" search="{0: \'foo\', 1: \'abc\'}" replace="{0: \'bar\', 1: \'def\'}" />',
+            ['value' => 'test foo abc'],
+            'test bar def',
+        ];
+        yield 'search and replace as iterator' => [
+            '<f:replace value="{value}" search="{search}" replace="{replace}" />',
+            [
+                'value' => 'test foo abc',
+                'search' => new IterableExample(['foo', 'abc']),
+                'replace' => new IterableExample(['bar', 'def']),
+            ],
+            'test bar def',
+        ];
+        yield 'replace key-value pairs' => [
+            '<f:replace value="{value}" replace="{\'foo\': \'bar\', \'abc\': \'def\'}" />',
+            ['value' => 'test foo abc'],
+            'test bar def',
+        ];
+        yield 'replace key-value pairs as iterator' => [
+            '<f:replace value="{value}" replace="{replace}" />',
+            ['value' => 'test foo abc', 'replace' => new IterableExample(['foo' => 'bar', 'abc' => 'def'])],
+            'test bar def',
+        ];
+        yield 'search and replace in empty string' => [
+            '<f:replace value="{value}" search="foo" replace="bar" />',
+            ['value' => ''],
+            '',
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, array $variables, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
The ReplaceViewHelper replaces one or multiple strings with other strings. This ViewHelper mimicks PHP's :php:`str_replace()` function. However, it's also possible to provide replace pairs as associative array via the "replace" argument.

Replace a single string:

```xml
<f:replace value="Hello World" search="World" replace="Fluid" /> <!-- Output: Hello Fluid -->
```

Replace multiple strings:

```xml
<f:replace value="Hello World" search="{0: 'World', 1: 'Hello'}" replace="{0: 'Fluid', 1: 'Hi'}" /> <!-- Output: Hi Fluid -->
```

Replace multiple strings using associative array:

```xml
<f:replace value="Hello World" replace="{'World': 'Fluid', 'Hello': 'Hi'}" /> <!-- Output: Hi Fluid -->
```