### PR TITLE
[FEATURE] Add f:round, f:ceil and f:floor ViewHelpers

### DIFF
--- a/src/ViewHelpers/CeilViewHelper.php
+++ b/src/ViewHelpers/CeilViewHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The CeilViewHelper rounds up a float value to the next integer.
+ * The ViewHelper mimicks PHP's :php:`ceil()` function.
+ *
+ * Examples
+ * ========
+ *
+ * Value argument
+ * --------------
+ * ::
+ *
+ *    <f:ceil value="123.456" />
+ *
+ * .. code-block:: text
+ *
+ *    124
+ *
+ * Tag content as value
+ * --------------------
+ * ::
+ *
+ *    <f:ceil>123.456</f:ceil>
+ *
+ * .. code-block:: text
+ *
+ *    124
+ */
+final class CeilViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'float', 'The number that should be rounded up');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): float
+    {
+        $value = $arguments['value'] ?? (float) $renderChildrenClosure();
+        return ceil($value);
+    }
+}

--- a/src/ViewHelpers/FloorViewHelper.php
+++ b/src/ViewHelpers/FloorViewHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The FloorViewHelper rounds down a float value to the next integer.
+ * The ViewHelper mimicks PHP's :php:`floor()` function.
+ *
+ * Examples
+ * ========
+ *
+ * Value argument
+ * --------------
+ * ::
+ *
+ *    <f:floor value="123.456" />
+ *
+ * .. code-block:: text
+ *
+ *    123
+ *
+ * Tag content as value
+ * --------------------
+ * ::
+ *
+ *    <f:floor>123.456</f:floor>
+ *
+ * .. code-block:: text
+ *
+ *    123
+ */
+final class FloorViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'float', 'The number that should be rounded down');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): float
+    {
+        $value = $arguments['value'] ?? (float) $renderChildrenClosure();
+        return floor($value);
+    }
+}

--- a/src/ViewHelpers/RoundViewHelper.php
+++ b/src/ViewHelpers/RoundViewHelper.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * The RoundViewHelper rounds a float value with the specified precision.
+ * The ViewHelper mimicks PHP's :php:`round()` function.
+ *
+ * Examples
+ * ========
+ *
+ * Round with default precision
+ * ----------------------------
+ * ::
+ *
+ *    <f:round value="123.456" />
+ *
+ * .. code-block:: text
+ *
+ *    123.46
+ *
+ * Round with specific precision
+ * -----------------------------
+ * ::
+ *
+ *    <f:round value="123.456" precision="1" />
+ *
+ * .. code-block:: text
+ *
+ *    123.5
+ *
+ * Tag content as value
+ * --------------------
+ * ::
+ *
+ *    <f:round precision="1">123.456</f:round>
+ *
+ * .. code-block:: text
+ *
+ *    123.5
+ */
+final class RoundViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'float', 'The number that should be rounded');
+        $this->registerArgument('precision', 'int', 'Rounding precision', false, 2);
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): float
+    {
+        $value = $arguments['value'] ?? (float) $renderChildrenClosure();
+        return round($value, $arguments['precision']);
+    }
+}

--- a/tests/Functional/ViewHelpers/CeilViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CeilViewHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class CeilViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'with value argument' => [
+            '<f:ceil value="123.456" />',
+            124.0,
+        ];
+        yield 'with float as tag content' => [
+            '<f:ceil>5.66</f:ceil>',
+            6,
+        ];
+        yield 'with integer as tag content' => [
+            '<f:ceil>5</f:ceil>',
+            5.0,
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, float $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}

--- a/tests/Functional/ViewHelpers/FloorViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/FloorViewHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class FloorViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'with value argument' => [
+            '<f:floor value="123.456" />',
+            123.0,
+        ];
+        yield 'with float as tag content' => [
+            '<f:floor>5.66</f:floor>',
+            5.0,
+        ];
+        yield 'with integer as tag content' => [
+            '<f:floor>5</f:floor>',
+            5.0,
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, float $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}

--- a/tests/Functional/ViewHelpers/RoundViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RoundViewHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class RoundViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'with default precision' => [
+            '<f:round value="123.456" />',
+            123.46,
+        ];
+        yield 'with custom precision' => [
+            '<f:round value="123.456" precision="1" />',
+            123.5,
+        ];
+        yield 'with zero precision' => [
+            '<f:round value="123.456" precision="0" />',
+            123,
+        ];
+        yield 'with float as tag content' => [
+            '<f:round precision="1">5.66</f:round>',
+            5.7,
+        ];
+        yield 'with integer as tag content' => [
+            '<f:round precision="2">5</f:round>',
+            5.0,
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(string $template, float $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+}


### PR DESCRIPTION
RoundViewHelper, CeilViewHelper and FloorViewHelper provide three different ways of rounding to Fluid template.

## Examples

```xml
<f:round value="123.456" /> <!-- Outputs 123.46 -->
<f:ceil value="123.456" /> <!-- Outputs 124 -->
<f:floor value="123.456" /> <!-- Outputs 123 -->
```