### PR TITLE
[TASK] Use xxh3 instead of sha1

### DIFF
--- a/examples/src/CustomVariableProvider.php
+++ b/examples/src/CustomVariableProvider.php
@@ -37,7 +37,7 @@ class CustomVariableProvider extends StandardVariableProvider implements Variabl
     public function getByPath($path)
     {
         if ($path === 'random') {
-            return 'random' . sha1(rand(0, 999999999));
+            return 'random' . hash('xxh3', (string)rand(0, 999999999));
         }
         if ($path === 'incrementer') {
             return ++$this->incrementer;

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -234,11 +234,7 @@ class TemplateCompiler
         return 'return (string)\'' . $storedLayoutNameArgument . '\'';
     }
 
-    /**
-     * @param ParsingState $parsingState
-     * @return string
-     */
-    protected function generateSectionCodeFromParsingState(ParsingState $parsingState)
+    protected function generateSectionCodeFromParsingState(ParsingState $parsingState): string
     {
         $generatedRenderFunctions = '';
         if ($parsingState->getVariableContainer()->exists('1457379500_sections')) {
@@ -249,7 +245,7 @@ class TemplateCompiler
                     // @todo: Verify this is *always* an instance of RootNode
                     //        and call $node->convert($this) directly.
                     $this->convertSubNodes($sectionRootNode->getChildNodes()),
-                    'section_' . sha1($sectionName),
+                    'section_' . hash('xxh3', $sectionName),
                     'section ' . $sectionName,
                 );
             }

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -244,7 +244,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
         }
 
         if ($parsedTemplate->isCompiled()) {
-            $methodNameOfSection = 'section_' . sha1($sectionName);
+            $methodNameOfSection = 'section_' . hash('xxh3', (string)$sectionName);
             if (!method_exists($parsedTemplate, $methodNameOfSection)) {
                 if ($ignoreUnknown) {
                     return '';

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -556,7 +556,7 @@ class TemplatePaths
     public function getTemplateIdentifier($controller = 'Default', $action = 'Default')
     {
         if ($this->templateSource !== null) {
-            return 'source_' . sha1($this->templateSource) . '_' . $controller . '_' . $action . '_' . $this->getFormat();
+            return 'source_' . hash('xxh3', (string)$this->templateSource) . '_' . $controller . '_' . $action . '_' . $this->getFormat();
         }
         $templatePathAndFilename = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action);
         $prefix = ltrim($controller . '_action_' . $action, '_');
@@ -610,7 +610,7 @@ class TemplatePaths
 
     /**
      * Returns a unique identifier for the given file in the format
-     * <PackageKey>_<SubPackageKey>_<ControllerName>_<prefix>_<SHA1>
+     * <PackageKey>_<SubPackageKey>_<ControllerName>_<prefix>_<hash>
      * The SH1 hash is a checksum that is based on the file path and last modification date
      *
      * @param string|null $pathAndFilename
@@ -621,7 +621,7 @@ class TemplatePaths
     {
         $pathAndFilename = (string)$pathAndFilename;
         $templateModifiedTimestamp = $pathAndFilename !== 'php://stdin' && file_exists($pathAndFilename) ? filemtime($pathAndFilename) : 0;
-        return sprintf('%s_%s', $prefix, sha1($pathAndFilename . '|' . $templateModifiedTimestamp));
+        return sprintf('%s_%s', $prefix, hash('xxh3', $pathAndFilename . '|' . $templateModifiedTimestamp));
     }
 
     /**

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractFunctionalTestCase extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$cachePath = sys_get_temp_dir() . '/' . 'fluid-functional-tests-' . sha1(__CLASS__);
+        self::$cachePath = sys_get_temp_dir() . '/' . 'fluid-functional-tests-' . hash('xxh3', __CLASS__);
         mkdir(self::$cachePath);
         self::$cache = (new SimpleFileCache(self::$cachePath));
     }

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -223,7 +223,7 @@ final class TemplatePathsTest extends BaseTestCase
     {
         $instance = new TemplatePaths();
         $instance->setTemplateSource('foobar');
-        self::assertSame('source_8843d7f92416211de9ebb963ff4ce28125932878_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
+        self::assertSame('source_d78fda63144c5c84_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
     }
 
     /**


### PR DESCRIPTION
64bit xxh3 hash is significantly quicker. This is a micro optimization especially when creating hashes from template contents for caching.