### PR TITLE
[FEATURE] Add f:constant ViewHelper

### DIFF
--- a/src/ViewHelpers/ConstantViewHelper.php
+++ b/src/ViewHelpers/ConstantViewHelper.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Wrapper for PHPs :php:`constant` function.
+ * See https://www.php.net/manual/function.constant.php.
+ *
+ * Examples
+ * ========
+ *
+ * Get built-in PHP constant
+ * -------------------------
+ *
+ * ::
+ *
+ *    {f:constant(value: 'PHP_INT_MAX')}
+ *
+ * Output::
+ *
+ *    9223372036854775807
+ *    (Depending on CPU architecture).
+ *
+ * Get class constant
+ * ------------------
+ *
+ * ::
+ *
+ *    {f:constant(value: '\Vendor\Package\Class::CONSTANT')}
+ *
+ * Get enum value
+ * --------------
+ *
+ * ::
+ *
+ *    {f:constant(value: '\Vendor\Package\Enum::CASE')}
+ */
+class ConstantViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('name', 'string', 'String representation of a PHP constant or enum');
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed
+    {
+        $name = $arguments['name'] ?? $renderChildrenClosure();
+        return constant($name);
+    }
+}

--- a/tests/Functional/Fixtures/Various/BackedEnumExample.php
+++ b/tests/Functional/Fixtures/Various/BackedEnumExample.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+enum BackedEnumExample: string
+{
+    case BAR = 'bar';
+}

--- a/tests/Functional/Fixtures/Various/ClassConstantsExample.php
+++ b/tests/Functional/Fixtures/Various/ClassConstantsExample.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+class ClassConstantsExample
+{
+    public const FOO = 'foo';
+}

--- a/tests/Functional/Fixtures/Various/EnumExample.php
+++ b/tests/Functional/Fixtures/Various/EnumExample.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+enum EnumExample
+{
+    case FOO;
+}

--- a/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ConstantViewHelperTest extends AbstractFunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function renderThrowsExceptionOnNonStringValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $name = new \stdClass();
+        $view = new TemplateView();
+        $view->assignMultiple(['name' => $name]);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:constant name="{name}" />');
+        $view->render();
+    }
+
+    /**
+     * @test
+     */
+    public function renderThrowsErrorOnUndefinedConstant(): void
+    {
+        $this->expectException(\Error::class);
+        $name = 'FOO';
+        $view = new TemplateView();
+        $view->assignMultiple(['name' => $name]);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:constant name="{name}" />');
+        $view->render();
+    }
+
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'Name is built-in PHP constant' => [
+            'PHP_INT_MAX',
+            PHP_INT_MAX,
+        ];
+
+        yield 'Name is class constant w/out leading slash' => [
+            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample::FOO',
+            ClassConstantsExample::FOO,
+        ];
+
+        yield 'Name is class constant with leading slash' => [
+            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample::FOO',
+            ClassConstantsExample::FOO,
+        ];
+
+        yield 'Name is backed enum case w/out leading slash' => [
+            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample::BAR',
+            BackedEnumExample::BAR,
+        ];
+
+        yield 'Name is backed enum case with leading slash' => [
+            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample::BAR',
+            BackedEnumExample::BAR,
+        ];
+
+        yield 'Name is enum case w/out leading slash' => [
+            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample::FOO',
+            EnumExample::FOO,
+        ];
+
+        yield 'Name is enum case with leading slash' => [
+            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample::FOO',
+            EnumExample::FOO,
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider renderDataProvider
+     */
+    public function render(mixed $name, mixed $expected): void
+    {
+        $templateSources = [
+            '<f:constant name="{name}" />',
+            '<f:constant>{name}</f:constant>',
+            '{f:constant(name: \'{name}\')}',
+        ];
+
+        foreach ($templateSources as $templateSource) {
+            $view = new TemplateView();
+            $view->assignMultiple(['name' => $name]);
+            $view->getRenderingContext()->setCache(self::$cache);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($templateSource);
+            self::assertSame($expected, $view->render());
+
+            $view = new TemplateView();
+            $view->assignMultiple(['name' => $name]);
+            $view->getRenderingContext()->setCache(self::$cache);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($templateSource);
+            self::assertSame($expected, $view->render());
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the `f:constant` ViewHelper allowing to use native PHP constants and enums in Fluid context.

Fixes: #873