### PR TITLE
[TASK] Prepare fluid binary to support multiple commands

### DIFF
--- a/bin/fluid
+++ b/bin/fluid
@@ -23,5 +23,4 @@ try {
     echo $runner->handleCommand($argv);
 } catch (InvalidArgumentException $error) {
     echo PHP_EOL . 'ERROR! ' . $error->getMessage() . PHP_EOL . PHP_EOL;
-    echo $runner->dumpSupportedParameters();
 }


### PR DESCRIPTION
The fluid binary currently only supports one command: The execution of fluid code, supplied by various sources, like a file, interactively or via socket. To be able to add more features in the future, a command parameter has been introduced to differentiate various sub-commands.

The existing functionality is now available as a sub-command by executing "bin/fluid run". However, the "run" command is defined as default command in this first step, which means that the previous syntax still works and that this change should be non-breaking.

Since ConsoleRunner has been defined as @internal, it has been marked as final, also the visibility of methods, variables and constants has been set to private to reduce/clarify the API of the class.