### PR TITLE
[BUGFIX] Allow override of universal attributes

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -151,7 +151,18 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      * @api
      * @deprecated No longer necessary since arbitrary arguments are possible; will be removed with next major version
      */
-    protected function registerUniversalTagAttributes() {}
+    protected function registerUniversalTagAttributes()
+    {
+        $this->registerTagAttribute('class', 'string', 'CSS class(es) for this element');
+        $this->registerTagAttribute('dir', 'string', 'Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)');
+        $this->registerTagAttribute('id', 'string', 'Unique (in this file) identifier for this HTML element.');
+        $this->registerTagAttribute('lang', 'string', 'Language for this element. Use short names specified in RFC 1766');
+        $this->registerTagAttribute('style', 'string', 'Individual CSS styles for this element');
+        $this->registerTagAttribute('title', 'string', 'Tooltip text of element');
+        $this->registerTagAttribute('accesskey', 'string', 'Keyboard shortcut to access this element');
+        $this->registerTagAttribute('tabindex', 'integer', 'Specifies the tab order of this element');
+        $this->registerTagAttribute('onclick', 'string', 'JavaScript evaluated for the onclick event');
+    }
 
     public function handleAdditionalArguments(array $arguments)
     {

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -73,6 +73,10 @@ final class TagBasedTest extends AbstractFunctionalTestCase
                 '<test:tagBasedTest additionalAttributes="{data-foo: \'additional\'}" data-foo="attribute" />',
                 '<div data-foo="attribute" />',
             ],
+            'override universal attribute' => [
+                '<test:overrideUniversalAttributeTest />',
+                '<div title="my default" />',
+            ],
         ];
     }
 

--- a/tests/Functional/Fixtures/ViewHelpers/OverrideUniversalAttributeTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/OverrideUniversalAttributeTestViewHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+class OverrideUniversalAttributeTestViewHelper extends AbstractTagBasedViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        parent::registerUniversalTagAttributes();
+        $this->overrideArgument('title', 'string', 'My custom description', false, 'my default');
+    }
+}


### PR DESCRIPTION
With the introduction of arbitrary attributes for TagBasedViewHelpers, the predefined universal tag attributes have been removed, since they will be added to the resulting HTML tag without any additional configuration. However, there are cases (vhs does this) where those global attributes are overridden by a concrete ViewHelper implementation. To make the change non-breaking, we restore those pre-defined attributes for now and remove them with the next major version of Fluid.