### PR TITLE
[TASK] Migrate to phpunit attributes

### DIFF
--- a/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Cases/CompileWithContentArgumentAndRenderStaticTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -84,10 +86,8 @@ final class CompileWithContentArgumentAndRenderStaticTest extends AbstractFuncti
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider compileWithContentArgumentAndRenderStaticDataProvider
-     */
+    #[DataProvider('compileWithContentArgumentAndRenderStaticDataProvider')]
+    #[Test]
     public function compileWithContentArgumentAndRenderStatic(string $source, array $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Conditions;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -47,10 +49,8 @@ final class BasicConditionsTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider basicConditionDataProvider
-     */
+    #[DataProvider('basicConditionDataProvider')]
+    #[Test]
     public function basicCondition(string $source, bool $expected): void
     {
         $source = '<f:if condition="' . $source . '" then="yes" else="no" />';

--- a/tests/Functional/Cases/Conditions/VariableConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/VariableConditionsTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Conditions;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -89,10 +91,8 @@ final class VariableConditionsTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider variableConditionDataProvider
-     */
+    #[DataProvider('variableConditionDataProvider')]
+    #[Test]
     public function basicCondition(string $source, bool $expected, array $variables): void
     {
         $source = '<f:if condition="' . $source . '" then="yes" else="no" />';

--- a/tests/Functional/Cases/CycleTest.php
+++ b/tests/Functional/Cases/CycleTest.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class CycleTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function cycleValuesInArray(): void
     {
         $source = '<f:for each="{items}" as="item"><f:cycle values="{cycles}" as="cycled">{cycled}</f:cycle></f:for>';

--- a/tests/Functional/Cases/Errors/ParsingErrorsTest.php
+++ b/tests/Functional/Cases/Errors/ParsingErrorsTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Errors;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
@@ -46,10 +48,8 @@ final class ParsingErrorsTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getTemplateCodeFixturesAndExpectations
-     */
+    #[DataProvider('getTemplateCodeFixturesAndExpectations')]
+    #[Test]
     public function testTemplateCodeFixture(string $source, string $expectedException): void
     {
         $this->expectException($expectedException);

--- a/tests/Functional/Cases/Escaping/EscapingTest.php
+++ b/tests/Functional/Cases/Escaping/EscapingTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Escaping;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -111,10 +113,8 @@ final class EscapingTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getTemplateCodeFixturesAndExpectations
-     */
+    #[DataProvider('getTemplateCodeFixturesAndExpectations')]
+    #[Test]
     public function testTemplateCodeFixture(string $source, string $expected, string $notExpected): void
     {
         $variables = ['settings' => ['test' => '<strong>Bla</strong>']];
@@ -138,9 +138,7 @@ final class EscapingTest extends AbstractFunctionalTestCase
         self::assertNotEquals($notExpected, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function disablingEscapingTwiceInTemplateThrowsParsingException(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Functional/Cases/Parsing/CommaToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/CommaToleranceTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -32,10 +34,8 @@ final class CommaToleranceTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider commaToleranceDataProvider
-     */
+    #[DataProvider('commaToleranceDataProvider')]
+    #[Test]
     public function commaTolerance(string $source, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
+++ b/tests/Functional/Cases/Parsing/NamespaceRegistrationTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -30,10 +32,8 @@ final class NamespaceRegistrationTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getTemplateCodeFixturesAndExpectations
-     */
+    #[DataProvider('getTemplateCodeFixturesAndExpectations')]
+    #[Test]
     public function testTemplateCodeFixture(string $source, string $expectedInOutput, string $notExpectedInOutput): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
+++ b/tests/Functional/Cases/Parsing/WhitespaceToleranceTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -47,10 +49,8 @@ final class WhitespaceToleranceTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider whitespaceToleranceDataProvider
-     */
+    #[DataProvider('whitespaceToleranceDataProvider')]
+    #[Test]
     public function whitespaceTolerance(string $source): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Cases/Rendering/DataAccessorTest.php
+++ b/tests/Functional/Cases/Rendering/DataAccessorTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering\Fixtures\Objects\WithCamelCaseGetter;
 use TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering\Fixtures\Objects\WithEverything;
@@ -86,10 +88,8 @@ final class DataAccessorTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, array $expected): void
     {
         $view = new TemplateView();
@@ -105,9 +105,7 @@ final class DataAccessorTest extends AbstractFunctionalTestCase
         self::assertSame($expected, json_decode($view->render(), true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionAccessingPrivateProperty(): void
     {
         $this->expectException(\Throwable::class);

--- a/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
+++ b/tests/Functional/Cases/Rendering/NestedFluidTemplatesWithLayoutTest.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class NestedFluidTemplatesWithLayoutTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function nestedTemplateRenderingWithDifferentLayoutPaths(): void
     {
         $source = '<f:layout name="Layout"/><f:section name="main"><f:format.raw>{anotherFluidTemplateContent}</f:format.raw></f:section>';

--- a/tests/Functional/Cases/Rendering/RecursiveRenderingTest.php
+++ b/tests/Functional/Cases/Rendering/RecursiveRenderingTest.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Rendering;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class RecursiveRenderingTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function recursiveSectionRenderingClonesVariableStorageAndRestoresAfterLoop(): void
     {
         $source = file_get_contents(__DIR__ . '/../../Fixtures/Templates/RecursiveSectionRendering.html');
@@ -71,9 +70,7 @@ final class RecursiveRenderingTest extends AbstractFunctionalTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function recursivePartialRenderingClonesVariableStorageAndRestoresAfterLoop(): void
     {
         $partialPath = __DIR__ . '/../../Fixtures/Partials/';

--- a/tests/Functional/Cases/SwitchTest.php
+++ b/tests/Functional/Cases/SwitchTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -36,10 +38,8 @@ final class SwitchTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider ignoreTextAndWhitespacesDataProvider
-     */
+    #[DataProvider('ignoreTextAndWhitespacesDataProvider')]
+    #[Test]
     public function ignoreTextAndWhitespaces(string $source, string $notExpected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -80,10 +82,8 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderTagBasedViewHelperDataProvider
-     */
+    #[DataProvider('renderTagBasedViewHelperDataProvider')]
+    #[Test]
     public function renderTagBasedViewHelper(string $source, string $expected): void
     {
         $view = new TemplateView();
@@ -114,10 +114,8 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider throwsErrorForInvalidArgumentTypesDatProvider
-     */
+    #[DataProvider('throwsErrorForInvalidArgumentTypesDatProvider')]
+    #[Test]
     public function throwsErrorForInvalidArgumentTypes(string $source): void
     {
         self::expectException(\InvalidArgumentException::class);

--- a/tests/Functional/Core/Cache/SimpleFileCacheTest.php
+++ b/tests/Functional/Core/Cache/SimpleFileCacheTest.php
@@ -9,24 +9,21 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Cache\StandardCacheWarmer;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
 final class SimpleFileCacheTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getCacheWarmerReturnsStandardCacheWarmer(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
         self::assertInstanceOf(StandardCacheWarmer::class, $cache->getCacheWarmer());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getReturnsFalseWhenNotFound(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
@@ -34,9 +31,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getReturnsTrueWhenFound(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
@@ -44,9 +39,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         self::assertTrue($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addToCacheCreatesFile(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
@@ -54,9 +47,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         self::assertFileExists(self::$cachePath . '/' . 'test.php');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLoadsFile(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
@@ -65,9 +56,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         self::assertTrue(class_exists('MyCachedClass', false));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushWithoutNameCallsGetCachedFilenamesAndFlushByFilename(): void
     {
         $cache = $this->getMockBuilder(SimpleFileCache::class)
@@ -79,9 +68,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         $cache->flush();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushWithNameCallsFlushByName(): void
     {
         $cache = $this->getMockBuilder(SimpleFileCache::class)
@@ -93,9 +80,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         $cache->flush('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flushByNameDeletesSingleFile(): void
     {
         $cache = new SimpleFileCache(self::$cachePath);
@@ -106,9 +91,7 @@ final class SimpleFileCacheTest extends AbstractFunctionalTestCase
         self::assertFileDoesNotExist(self::$cachePath . '/' . 'test.php');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setThrowsRuntimeExceptionOnInvalidDirectory(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Functional/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
+++ b/tests/Functional/Core/Parser/SyntaxTree/Expression/TernaryExpressionNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\SyntaxTree\Expression;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -245,10 +247,8 @@ final class TernaryExpressionNodeTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider variableConditionDataProvider
-     */
+    #[DataProvider('variableConditionDataProvider')]
+    #[Test]
     public function variableCondition(string $source, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\TemplateProcessor;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
@@ -94,10 +96,8 @@ final class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider preProcessSourceExtractsNamespacesDataProvider
-     * @test
-     */
+    #[DataProvider('preProcessSourceExtractsNamespacesDataProvider')]
+    #[Test]
     public function preProcessSourceExtractsNamespaces(string $templateSource, array $expectedNamespaces, string $expectedSource): void
     {
         $viewHelperResolver = new ViewHelperResolver();

--- a/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
@@ -9,15 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits\Fixtures\CompileWithContentArgumentAndRenderStaticTestTraitViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class CompileWithContentArgumentAndRenderStaticTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveContentArgumentNameThrowsExceptionIfNoArgumentsAvailable(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\FluidExamples\Helper\ExampleHelper;
 
 final class ExamplesTest extends AbstractFunctionalTestCase
@@ -207,10 +209,8 @@ final class ExamplesTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider exampleScriptValuesDataProvider
-     */
+    #[DataProvider('exampleScriptValuesDataProvider')]
+    #[Test]
     public function exampleScriptValues(string $script, array $expectedOutputs): void
     {
         $scriptFile = __DIR__ . '/../../examples/' . $script;

--- a/tests/Functional/ViewHelpers/AliasViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/AliasViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -65,10 +67,8 @@ final class AliasViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Cache/DisableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/DisableViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -16,18 +17,14 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\DisableViewHelper;
 
 final class DisableViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperCanBeInstantiated(): void
     {
         $subject = new DisableViewHelper();
         self::assertInstanceOf(AbstractViewHelper::class, $subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function templateUsingViewHelperCanBeRendered(): void
     {
         $template = '<f:cache.disable>foo</f:cache.disable>';

--- a/tests/Functional/ViewHelpers/Cache/StaticViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/StaticViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -16,18 +17,14 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\StaticViewHelper;
 
 final class StaticViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperCanBeInstantiated(): void
     {
         $subject = new StaticViewHelper();
         self::assertInstanceOf(AbstractViewHelper::class, $subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function templateUsingViewHelperCanBeRendered(): void
     {
         $template = '<f:cache.static>foo</f:cache.static>';

--- a/tests/Functional/ViewHelpers/Cache/WarmupViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Cache/WarmupViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -16,18 +17,14 @@ use TYPO3Fluid\Fluid\ViewHelpers\Cache\WarmupViewHelper;
 
 final class WarmupViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperCanBeInstantiated(): void
     {
         $subject = new WarmupViewHelper();
         self::assertInstanceOf(AbstractViewHelper::class, $subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function templateUsingViewHelperCanBeRendered(): void
     {
         $template = '<f:cache.warmup variables="{name: \'bar\'}">' .

--- a/tests/Functional/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CommentViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -16,7 +18,6 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 final class CommentViewHelperTest extends AbstractFunctionalTestCase
 {
     /**
-     * @test
      * @todo: That's a rather nasty side effect of f:comment. The parser
      *        still parses f:comment body, so if the body contains
      *        invalid stuff (e.g. a not closed VH tag), it explodes.
@@ -25,6 +26,7 @@ final class CommentViewHelperTest extends AbstractFunctionalTestCase
      *        regexes to see if parsing of 'f:comment' content could be
      *        suppressed somehow.
      */
+    #[Test]
     public function renderThrowsExceptionWhenEncapsulatingInvalidCode(): void
     {
         $this->expectException(Exception::class);
@@ -54,10 +56,8 @@ final class CommentViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample;
@@ -17,9 +19,7 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class ConstantViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionOnNonStringValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -31,9 +31,7 @@ final class ConstantViewHelperTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsErrorOnUndefinedConstant(): void
     {
         $this->expectException(\Error::class);
@@ -83,10 +81,8 @@ final class ConstantViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(mixed $name, mixed $expected): void
     {
         $templateSources = [

--- a/tests/Functional/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CountViewHelperTest.php
@@ -9,14 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class CountViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfSubjectIsNotCountable(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -61,10 +61,8 @@ final class CountViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/CycleViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CycleViewHelperTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class CycleViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfSubjectIsNotIterable(): void
     {
         $this->expectException(Exception::class);
@@ -64,10 +64,8 @@ final class CycleViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/DebugViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/DebugViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -249,10 +251,8 @@ final class DebugViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class ForViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfSubjectIsNotTraversable(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -29,9 +29,7 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfSubjectIsInvalid(): void
     {
         $this->expectException(Exception::class);
@@ -200,10 +198,8 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/CaseViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -65,10 +67,8 @@ final class CaseViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderConvertsAValueDataProvider
-     */
+    #[DataProvider('renderConvertsAValueDataProvider')]
+    #[Test]
     public function renderConvertsAValue(string $template, string $expected): void
     {
         $view = new TemplateView();
@@ -82,9 +82,7 @@ final class CaseViewHelperTest extends AbstractFunctionalTestCase
         self::assertSame($expected, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperThrowsExceptionIfIncorrectModeIsGiven(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Functional/ViewHelpers/Format/CdataViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/CdataViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -26,10 +28,8 @@ final class CdataViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
@@ -17,9 +19,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\Format\HtmlspecialcharsViewHelper;
 
 final class HtmlspecialcharsViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString(): void
     {
         $user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
@@ -30,9 +30,7 @@ final class HtmlspecialcharsViewHelperTest extends AbstractFunctionalTestCase
         self::assertSame($user, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperDeactivatesEscapingInterceptor(): void
     {
         self::assertFalse((new HtmlspecialcharsViewHelper())->isOutputEscapingEnabled());
@@ -152,10 +150,8 @@ final class HtmlspecialcharsViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/JsonViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/JsonViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -38,10 +40,8 @@ final class JsonViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/Nl2brViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/Nl2brViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -32,10 +34,8 @@ final class Nl2brViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/NumberViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/NumberViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -40,10 +42,8 @@ final class NumberViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/PrintfViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/PrintfViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -26,10 +28,8 @@ final class PrintfViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/RawViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/RawViewHelperTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\ViewHelpers\Format\RawViewHelper;
 
 final class RawViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperDeactivatesEscapingInterceptor(): void
     {
         self::assertFalse((new RawViewHelper())->isOutputEscapingEnabled());
@@ -35,10 +35,8 @@ final class RawViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use stdClass;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -49,10 +51,8 @@ final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();
@@ -69,9 +69,8 @@ final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
     /**
      * Ensures that objects are handled properly:
      * + class having __toString() method gets tags stripped off
-     *
-     * @test
      */
+    #[Test]
     public function renderEscapesObjectIfPossible(): void
     {
         $toStringClass = new class () {
@@ -103,10 +102,8 @@ final class StripTagsViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider throwsExceptionForInvalidInputDataProvider
-     */
+    #[DataProvider('throwsExceptionForInvalidInputDataProvider')]
+    #[Test]
     public function throwsExceptionForInvalidInput(mixed $value, int $expectedExceptionCode, string $expectedExceptionMessage): void
     {
         self::expectExceptionCode($expectedExceptionCode);

--- a/tests/Functional/ViewHelpers/Format/TrimViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/TrimViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -87,10 +89,8 @@ final class TrimViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderConvertsAValueDataProvider
-     */
+    #[DataProvider('renderConvertsAValueDataProvider')]
+    #[Test]
     public function renderTrimAValue(string $template, $expected): void
     {
         $view = new TemplateView();
@@ -104,9 +104,7 @@ final class TrimViewHelperTest extends AbstractFunctionalTestCase
         self::assertSame($expected, $view->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function viewHelperThrowsExceptionIfIncorrectModeIsGiven(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use stdClass;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -37,10 +39,8 @@ final class UrlencodeViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();
@@ -57,9 +57,8 @@ final class UrlencodeViewHelperTest extends AbstractFunctionalTestCase
     /**
      * Ensures that objects are handled properly:
      * + class having __toString() method gets tags stripped off
-     *
-     * @test
      */
+    #[Test]
     public function renderEscapesObjectIfPossible(): void
     {
         $toStringClass = new class () {
@@ -91,10 +90,8 @@ final class UrlencodeViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider throwsExceptionForInvalidInputDataProvider
-     */
+    #[DataProvider('throwsExceptionForInvalidInputDataProvider')]
+    #[Test]
     public function throwsExceptionForInvalidInput(mixed $value, int $expectedExceptionCode, string $expectedExceptionMessage): void
     {
         self::expectExceptionCode($expectedExceptionCode);

--- a/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
@@ -17,9 +19,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\GroupedForViewHelper;
 
 final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderStaticThrowsExceptionWhenEachIsNotTraversable(): void
     {
         $this->expectException(Exception::class);
@@ -33,9 +33,7 @@ final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
         GroupedForViewHelper::renderStatic($arguments, function () {}, new RenderingContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderStaticThrowsExceptionWhenEachIsOneDimensionalArray(): void
     {
         $this->expectException(Exception::class);
@@ -49,9 +47,7 @@ final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
         GroupedForViewHelper::renderStatic($arguments, function () {}, new RenderingContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderStaticReturnsEmptyStringWhenEachIsNull(): void
     {
         $arguments = [
@@ -380,10 +376,8 @@ final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -490,10 +492,8 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/InlineViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/InlineViewHelperTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class InlineViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfInlineFluidCodeIsInvalid(): void
     {
         $this->expectException(Exception::class);
@@ -80,10 +80,8 @@ final class InlineViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/LayoutViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/LayoutViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -26,10 +28,8 @@ final class LayoutViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/OrViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/OrViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -48,10 +50,8 @@ final class OrViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RenderViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
@@ -16,9 +18,7 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class RenderViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionForOptionalSetToFalseAndNoTargetGiven(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -29,9 +29,7 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionForInvalidDelegate(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -42,9 +40,7 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionForMissingPartial(): void
     {
         $this->expectException(InvalidTemplateResourceException::class);
@@ -57,9 +53,7 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function exceptionForMissingSection(): void
     {
         $this->expectException(InvalidSectionException::class);
@@ -125,10 +119,8 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $arguments, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -70,10 +72,8 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider throwsExceptionForInvalidArgumentDataProvider
-     */
+    #[DataProvider('throwsExceptionForInvalidArgumentDataProvider')]
+    #[Test]
     public function throwsExceptionForInvalidArgument(string $template, array $variables, int $exceptionCode, string $exceptionMessage): void
     {
         self::expectException(\InvalidArgumentException::class);
@@ -134,10 +134,8 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/SectionViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SectionViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -40,10 +42,8 @@ final class SectionViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/SpacelessViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SpacelessViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -30,10 +32,8 @@ final class SpacelessViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/SplitViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SplitViewHelperTest.php
@@ -9,14 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class SplitViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function throwsExceptionForInvalidValue(): void
     {
         self::expectExceptionCode(1705250408);
@@ -75,10 +75,8 @@ final class SplitViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -18,9 +19,7 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  */
 final class NotSharedStaticCompilableViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderWithNotSharedCompilableViewHelper(): void
     {
         // @todo If the test with the mocked ViewHelperResolver is executed standalone, it fails and shows the broken

--- a/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable\Fixtures\ViewHelpers\CompilableViewHelper;
@@ -19,9 +20,7 @@ use TYPO3Fluid\Fluid\View\TemplateView;
  */
 final class SharedStaticCompilableViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderWithSharedCompilableViewHelper(): void
     {
         // TYPO3 implements a custom ViewHelperResolver to provide DI-able ViewHelper instances. This allows

--- a/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/SwitchCaseDefaultCaseViewHelperTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfCaseIsOutsideOfSwitch(): void
     {
         $this->expectException(Exception::class);
@@ -28,9 +28,7 @@ final class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCa
         $view->render();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderThrowsExceptionIfDefaultCaseIsOutsideOfSwitch(): void
     {
         $this->expectException(Exception::class);
@@ -82,10 +80,8 @@ final class SwitchCaseDefaultCaseViewHelperTest extends AbstractFunctionalTestCa
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, array $variables, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/VariableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/VariableViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -34,10 +36,8 @@ final class VariableViewHelperTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider renderDataProvider
-     */
+    #[DataProvider('renderDataProvider')]
+    #[Test]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheWarmupResult;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class FluidCacheWarmupResultTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeCombinesTwoResults(): void
     {
         $result1 = new FluidCacheWarmupResult();
@@ -45,9 +44,7 @@ final class FluidCacheWarmupResultTest extends UnitTestCase
         self::assertSame($expected, $subject->getResults());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function mergeOverridesExistingResult(): void
     {
         $result1 = new FluidCacheWarmupResult();
@@ -68,9 +65,7 @@ final class FluidCacheWarmupResultTest extends UnitTestCase
         self::assertSame($expected, $subject->getResults());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addWorksWithParsedTemplate(): void
     {
         $parsedTemplateMock = $this->createMock(ParsedTemplateInterface::class);
@@ -91,9 +86,7 @@ final class FluidCacheWarmupResultTest extends UnitTestCase
         self::assertSame($expected, $subject->getResults());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addWorksWithFailedCompilingState(): void
     {
         $failedCompilingStateMock = $this->createMock(FailedCompilingState::class);

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Cache\StandardCacheWarmer;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
@@ -21,9 +23,7 @@ use TYPO3Fluid\Fluid\View\TemplatePaths;
 
 final class StandardCacheWarmerTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testDetectControllerNamesInTemplateRootPaths(): void
     {
         $subject = new StandardCacheWarmer();
@@ -48,10 +48,8 @@ final class StandardCacheWarmerTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider warmupSingleFileHandlesExceptionDataProvider
-     * @test
-     */
+    #[DataProvider('warmupSingleFileHandlesExceptionDataProvider')]
+    #[Test]
     public function warmupSingleFileHandlesException(\RuntimeException $error): void
     {
         $templateParserMock = $this->createMock(TemplateParser::class);
@@ -66,9 +64,7 @@ final class StandardCacheWarmerTest extends UnitTestCase
         self::assertNotEmpty($result->getMitigations());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCreateClosureCreatesFileReadingClosure(): void
     {
         $subject = new StandardCacheWarmer();

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler\Fixtures\AbstractCompiledTemplateTestFixture;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractCompiledTemplateTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setIdentifierDoesNotChangeObject(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
@@ -27,72 +26,56 @@ class AbstractCompiledTemplateTest extends UnitTestCase
         self::assertEquals($before, $subject);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierReturnsClassName(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertEquals($subject->getIdentifier(), get_class($subject));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getVariableContainerReturnsStandardVariableProvider(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertInstanceOf(StandardVariableProvider::class, $subject->getVariableContainer());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsEmptyString(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertEquals('', $subject->render(new RenderingContext()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLayoutNameReturnsEmptyString(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertEquals('', $subject->getLayoutName(new RenderingContext()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasLayoutReturnsFalse(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertFalse($subject->hasLayout());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isCompilableReturnsFalse(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertFalse($subject->isCompilable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isCompiledReturnsTrue(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();
         self::assertTrue($subject->isCompiled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addCompiledNamespacesDoesNothing(): void
     {
         $subject = new AbstractCompiledTemplateTestFixture();

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class FailedCompilingStateTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getFailureReasonReturnsPreviouslySetFailureReason(): void
     {
         $subject = new FailedCompilingState();
@@ -24,9 +23,7 @@ final class FailedCompilingStateTest extends UnitTestCase
         self::assertSame('failed', $subject->getFailureReason());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getMitigationsReturnsPreviouslySetMitigation(): void
     {
         $subject = new FailedCompilingState();
@@ -34,9 +31,7 @@ final class FailedCompilingStateTest extends UnitTestCase
         self::assertSame(['m1', 'm2'], $subject->getMitigations());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addMitigationAddsAnotherMitigation(): void
     {
         $subject = new FailedCompilingState();

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
@@ -17,9 +18,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
  */
 final class StopCompilingChildrenExceptionTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function setAndGetReplacementString(): void
     {
         $subject = new StopCompilingChildrenException();

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
@@ -20,9 +21,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class TemplateCompilerTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function isWarmupModeReturnsTrueAfterEnterWarmupModeHasBeenCalled(): void
     {
         $subject = new TemplateCompiler();
@@ -31,9 +30,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertTrue($subject->isWarmupMode());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRenderingContextReturnsPreviouslySetRenderingContext(): void
     {
         $subject = new TemplateCompiler();
@@ -42,9 +39,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertSame($renderingContextMock, $subject->getRenderingContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasReturnsFalseWithoutCache(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -55,9 +50,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertFalse($subject->has('test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasReturnsTrueWithCache(): void
     {
         $cacheMock = $this->createMock(SimpleFileCache::class);
@@ -70,9 +63,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertTrue($subject->has('test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function wrapViewHelperNodeArgumentEvaluationInClosureCreatesExpectedString(): void
     {
         $arguments = ['value' => new TextNode('sometext')];
@@ -86,9 +77,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertEquals($expected, $subject->wrapViewHelperNodeArgumentEvaluationInClosure($viewHelperNodeMock, 'value'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function storeReturnsNullIfDisabled(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -98,9 +87,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertNull($subject->store('foobar', new ParsingState()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testStoreSavesUncompilableState(): void
     {
         $cacheMock = $this->createMock(SimpleFileCache::class);
@@ -115,18 +102,14 @@ final class TemplateCompilerTest extends UnitTestCase
         $subject->store('fakeidentifier', $parsingStateMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function disableThrowsException(): void
     {
         $this->expectException(StopCompilingException::class);
         (new TemplateCompiler())->disable();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getRenderingContextGetsPreviouslySetRenderingContext(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -135,9 +118,7 @@ final class TemplateCompilerTest extends UnitTestCase
         self::assertSame($renderingContextMock, $subject->getRenderingContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function variableNameReturnsIncrementedName(): void
     {
         $subject = new TemplateCompiler();

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
@@ -107,10 +109,8 @@ final class BooleanParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getSomeEvaluationTestValues
-     */
+    #[DataProvider('getSomeEvaluationTestValues')]
+    #[Test]
     public function testSomeEvaluations(string $comparison, bool $expected, array $variables = []): void
     {
         $renderingContext = new RenderingContext();
@@ -131,10 +131,8 @@ final class BooleanParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider invalidEvaluationsDataProvider
-     */
+    #[DataProvider('invalidEvaluationsDataProvider')]
+    #[Test]
     public function invalidEvaluations(string $comparison, array $variables = []): void
     {
         $this->expectException(Exception::class);

--- a/tests/Unit/Core/Parser/ConfigurationTest.php
+++ b/tests/Unit/Core/Parser/ConfigurationTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class ConfigurationTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testAddInterceptor(): void
     {
         $interceptor = new Escape();
@@ -28,9 +27,7 @@ final class ConfigurationTest extends UnitTestCase
         self::assertContains($interceptor, $interceptors);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAddEscapingInterceptor(): void
     {
         $interceptor = new Escape();

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\Interceptor;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
@@ -20,9 +21,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class EscapeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function processDoesNotDisableEscapingInterceptorByDefault(): void
     {
         $viewHelperMock = $this->createMock(AbstractViewHelper::class);
@@ -36,9 +35,7 @@ final class EscapeTest extends UnitTestCase
         self::assertTrue($property->getValue($subject));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processDisablesEscapingInterceptorIfViewHelperDisablesIt(): void
     {
         $viewHelperMock = $this->createMock(AbstractViewHelper::class);
@@ -52,9 +49,7 @@ final class EscapeTest extends UnitTestCase
         self::assertFalse($property->getValue($subject));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function processWrapsCurrentViewHelperInEscapeNode(): void
     {
         $mockNode = $this->createMock(ObjectAccessorNode::class);

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -17,9 +18,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class ParsingStateTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getIdentifierReturnsPreviouslySetIdentifier(): void
     {
         $subject = new ParsingState();
@@ -27,9 +26,7 @@ final class ParsingStateTest extends UnitTestCase
         self::assertSame('foo', $subject->getIdentifier());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setRootNodeCanBeReadOutAgain(): void
     {
         $subject = new ParsingState();
@@ -38,9 +35,7 @@ final class ParsingStateTest extends UnitTestCase
         self::assertSame($rootNode, $subject->getRootNode());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function pushAndGetFromStackWorks(): void
     {
         $subject = new ParsingState();
@@ -50,9 +45,7 @@ final class ParsingStateTest extends UnitTestCase
         self::assertSame($rootNode, $subject->popNodeFromStack());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderCallsTheRightMethodsOnTheRootNode(): void
     {
         $subject = new ParsingState();
@@ -64,9 +57,7 @@ final class ParsingStateTest extends UnitTestCase
         self::assertSame('T3DD09 Rock!', $renderedValue);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLayoutNameReturnsLayoutNameFromVariableProvider(): void
     {
         $subject = new ParsingState();
@@ -74,9 +65,7 @@ final class ParsingStateTest extends UnitTestCase
         self::assertEquals('test', $subject->getLayoutName(new RenderingContext()));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isCompilableReturnsPreviouslySetCompilableState(): void
     {
         $subject = new ParsingState();

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
@@ -18,9 +20,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateChildNodesPassesRenderingContextToChildNodes(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -31,9 +31,7 @@ class AbstractNodeTest extends UnitTestCase
         $subject->evaluateChildNodes($renderingContextMock);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateChildNodesReturnsNullIfNoChildNodesExist(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -41,10 +39,8 @@ class AbstractNodeTest extends UnitTestCase
         self::assertNull($subject->evaluateChildNodes($renderingContextMock));
     }
 
-    /**
-     * @test
-     * @dataProvider getChildNodeThrowsExceptionFiChildNodeCannotBeCastToStringTestValues
-     */
+    #[DataProvider('getChildNodeThrowsExceptionFiChildNodeCannotBeCastToStringTestValues')]
+    #[Test]
     public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString(mixed $value, string $exceptionClass, int $exceptionCode, string $exceptionMessage): void
     {
         $this->expectException($exceptionClass);
@@ -68,9 +64,7 @@ class AbstractNodeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateChildNodeCanCastToString(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -84,9 +78,7 @@ class AbstractNodeTest extends UnitTestCase
         self::assertEquals('foobar', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateChildNodesConcatenatesOutputs(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -102,9 +94,7 @@ class AbstractNodeTest extends UnitTestCase
         self::assertEquals('foobar', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function childNodeCanBeReadOutAgain(): void
     {
         $childNode = $this->createMock(NodeInterface::class);

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
@@ -23,9 +25,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class BooleanNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function convertToBooleanProperlyConvertsValuesOfTypeBoolean(): void
     {
         $renderingContext = new RenderingContext();
@@ -33,9 +33,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::convertToBoolean(true, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertToBooleanProperlyConvertsValuesOfTypeString(): void
     {
         $renderingContext = new RenderingContext();
@@ -60,18 +58,16 @@ final class BooleanNodeTest extends UnitTestCase
 
     /**
      * @param mixed $number
-     * @test
-     * @dataProvider getNumericBooleanTestValues
      */
+    #[DataProvider('getNumericBooleanTestValues')]
+    #[Test]
     public function convertToBooleanProperlyConvertsNumericValues($number, bool $expected): void
     {
         $renderingContext = new RenderingContext();
         self::assertEquals($expected, BooleanNode::convertToBoolean($number, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertToBooleanProperlyConvertsValuesOfTypeArray(): void
     {
         $renderingContext = new RenderingContext();
@@ -80,9 +76,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::convertToBoolean(['foo' => 'bar'], $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function convertToBooleanProperlyConvertsObjects(): void
     {
         $renderingContext = new RenderingContext();
@@ -108,10 +102,10 @@ final class BooleanNodeTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider getCreateFromNodeAndEvaluateTestValues
      * @param bool $expected
-     * @test
      */
+    #[DataProvider('getCreateFromNodeAndEvaluateTestValues')]
+    #[Test]
     public function testCreateFromNodeAndEvaluate(NodeInterface $node, bool $expected): void
     {
         $renderingContext = new RenderingContext();
@@ -119,9 +113,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingNestedComparisonsWorks(): void
     {
         $renderingContext = new RenderingContext();
@@ -136,9 +128,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingEqualNumbersReturnsTrue(): void
     {
         $renderingContext = new RenderingContext();
@@ -150,9 +140,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingUnequalNumbersReturnsFalse(): void
     {
         $renderingContext = new RenderingContext();
@@ -164,9 +152,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingEqualIdentityReturnsTrue(): void
     {
         $renderingContext = new RenderingContext();
@@ -178,9 +164,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingUnequalIdentityReturnsFalse(): void
     {
         $renderingContext = new RenderingContext();
@@ -192,9 +176,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notEqualReturnsFalseIfNumbersAreEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -206,9 +188,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notEqualReturnsTrueIfNumbersAreNotEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -220,9 +200,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function oddNumberModulo2ReturnsTrue(): void
     {
         $renderingContext = new RenderingContext();
@@ -234,9 +212,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evenNumberModulo2ReturnsFalse(): void
     {
         $renderingContext = new RenderingContext();
@@ -248,9 +224,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function greaterThanReturnsTrueIfNumberIsReallyGreater(): void
     {
         $renderingContext = new RenderingContext();
@@ -262,9 +236,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function greaterThanReturnsFalseIfNumberIsEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -276,9 +248,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function greaterOrEqualsReturnsTrueIfNumberIsReallyGreater(): void
     {
         $renderingContext = new RenderingContext();
@@ -290,9 +260,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function greaterOrEqualsReturnsTrueIfNumberIsEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -303,9 +271,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function greaterOrEqualsReturnFalseIfNumberIsSmaller(): void
     {
         $renderingContext = new RenderingContext();
@@ -316,9 +282,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessThanReturnsTrueIfNumberIsReallyless(): void
     {
         $renderingContext = new RenderingContext();
@@ -329,9 +293,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessThanReturnsFalseIfNumberIsEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -342,9 +304,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessOrEqualsReturnsTrueIfNumberIsReallyLess(): void
     {
         $renderingContext = new RenderingContext();
@@ -355,9 +315,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessOrEqualsReturnsTrueIfNumberIsEqual(): void
     {
         $renderingContext = new RenderingContext();
@@ -368,9 +326,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessOrEqualsReturnFalseIfNumberIsBigger(): void
     {
         $renderingContext = new RenderingContext();
@@ -381,9 +337,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function lessOrEqualsReturnFalseIfComparingWithANegativeNumber(): void
     {
         $renderingContext = new RenderingContext();
@@ -400,9 +354,7 @@ final class BooleanNodeTest extends UnitTestCase
         return $renderingContext;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingVariableWithMatchedQuotedString(): void
     {
         $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
@@ -413,9 +365,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingVariableWithUnmatchedQuotedString(): void
     {
         $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
@@ -426,9 +376,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingNotEqualsVariableWithMatchedQuotedString(): void
     {
         $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
@@ -439,9 +387,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingNotEqualsVariableWithUnmatchedQuotedString(): void
     {
         $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
@@ -452,9 +398,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function comparingEqualsVariableWithMatchedQuotedStringInSingleTextNode(): void
     {
         $renderingContext = $this->getDummyRenderingContextWithVariables(['test' => 'somevalue']);
@@ -464,9 +408,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notEqualReturnsFalseIfComparingMatchingStrings(): void
     {
         $renderingContext = new RenderingContext();
@@ -475,9 +417,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notEqualReturnsTrueIfComparingNonMatchingStrings(): void
     {
         $renderingContext = new RenderingContext();
@@ -486,9 +426,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsFalseIfComparingNonMatchingStrings(): void
     {
         $renderingContext = new RenderingContext();
@@ -497,9 +435,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsTrueIfComparingMatchingStrings(): void
     {
         $renderingContext = new RenderingContext();
@@ -508,9 +444,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsTrueIfComparingMatchingStringsWithEscapedQuotes(): void
     {
         $renderingContext = new RenderingContext();
@@ -519,9 +453,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsFalseIfComparingStringWithNonZero(): void
     {
         $renderingContext = new RenderingContext();
@@ -530,9 +462,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsTrueIfComparingStringWithZero(): void
     {
         $renderingContext = new RenderingContext();
@@ -543,9 +473,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertSame($expected, BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function equalsReturnsFalseIfComparingStringZeroWithZero(): void
     {
         $renderingContext = new RenderingContext();
@@ -554,9 +482,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertTrue(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function objectsAreComparedStrictly(): void
     {
         $renderingContext = new RenderingContext();
@@ -579,9 +505,7 @@ final class BooleanNodeTest extends UnitTestCase
         self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function objectsAreComparedStrictlyInUnequalComparison(): void
     {
         $renderingContext = new RenderingContext();
@@ -620,10 +544,8 @@ final class BooleanNodeTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getStandardInputTypes
-     */
+    #[DataProvider('getStandardInputTypes')]
+    #[Test]
     public function acceptsStandardTypesAsInput(mixed $input, bool $expected): void
     {
         $renderingContext = new RenderingContext();

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class EscapingNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testEscapesNodeInConstructor(): void
     {
         $string = '<strong>escape me</strong>';
@@ -28,9 +27,7 @@ final class EscapingNodeTest extends UnitTestCase
         self::assertEquals($node->evaluate($renderingContext), htmlspecialchars($string, ENT_QUOTES));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testEscapesNodeOverriddenWithAddChildNode(): void
     {
         $string1 = '<strong>escape me</strong>';

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Expression;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -18,9 +20,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class CastingExpressionNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testEvaluateDelegatesToEvaluteExpression(): void
     {
         $subject = new CastingExpressionNode('{test as string}', ['test as string']);
@@ -30,9 +30,7 @@ final class CastingExpressionNodeTest extends UnitTestCase
         self::assertSame('10', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testEvaluateInvalidExpressionThrowsException(): void
     {
         $this->expectException(ExpressionException::class);
@@ -72,10 +70,10 @@ final class CastingExpressionNodeTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider getEvaluateExpressionTestValues
      * @param mixed $expected
-     * @test
      */
+    #[DataProvider('getEvaluateExpressionTestValues')]
+    #[Test]
     public function testEvaluateExpression(string $expression, array $variables, $expected): void
     {
         $renderingContext = new RenderingContext();

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Expression;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
@@ -44,10 +46,10 @@ final class MathExpressionNodeTest extends UnitTestCase
     }
 
     /**
-     * @dataProvider getEvaluateExpressionTestValues
      * @param mixed $expected
-     * @test
      */
+    #[DataProvider('getEvaluateExpressionTestValues')]
+    #[Test]
     public function testEvaluateExpression(string $expression, array $variables, $expected): void
     {
         $renderingContext = new RenderingContext();

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class NumericNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsProperIntegerGivenInConstructor(): void
     {
         $renderingContext = new RenderingContext();
@@ -27,9 +26,7 @@ final class NumericNodeTest extends UnitTestCase
         self::assertEquals($node->evaluate($renderingContext), 1, 'The rendered value of a numeric node does not match the string given in the constructor.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsProperFloatGivenInConstructor(): void
     {
         $renderingContext = new RenderingContext();
@@ -38,18 +35,14 @@ final class NumericNodeTest extends UnitTestCase
         self::assertEquals($node->evaluate($renderingContext), 1.1, 'The rendered value of a numeric node does not match the string given in the constructor.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function constructorThrowsExceptionIfNoNumericGiven(): void
     {
         $this->expectException(Exception::class);
         new NumericNode('foo');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addChildNodeThrowsException(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
@@ -30,10 +32,10 @@ final class ObjectAccessorNodeTest extends UnitTestCase
     }
 
     /**
-     * @test
-     * @dataProvider getEvaluateTestValues
      * @param mixed $expected
      */
+    #[DataProvider('getEvaluateTestValues')]
+    #[Test]
     public function testEvaluateGetsExpectedValue(array $variables, string $path, $expected): void
     {
         $node = new ObjectAccessorNode($path);
@@ -44,9 +46,7 @@ final class ObjectAccessorNodeTest extends UnitTestCase
         self::assertEquals($expected, $value);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testEvaluatedUsesVariableProviderGetByPath(): void
     {
         $node = new ObjectAccessorNode('foo.bar');

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -9,15 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class RootNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testEvaluateCallsEvaluateChildNodes(): void
     {
         $subject = $this->getMockBuilder(RootNode::class)->onlyMethods(['evaluateChildNodes'])->getMock();

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -9,15 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class TextNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsSameStringAsGivenInConstructor(): void
     {
         $string = 'I can work quite effectively in a train!';

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -19,9 +20,7 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class ViewHelperNodeTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getArgumentsReturnsArgumentsSetByConstructor(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
@@ -35,9 +34,7 @@ final class ViewHelperNodeTest extends UnitTestCase
         self::assertSame($arguments, $subject->getArguments());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function evaluateCallsViewHelperInvoker(): void
     {
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class TemplateParserPatternTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testSCAN_PATTERN_NAMESPACEDECLARATION(): void
     {
         self::assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '{namespace acme=Acme.MyPackage\Bla\blubb}'), 1, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did not match a namespace declaration (1).');
@@ -28,9 +28,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals(preg_match(NamespaceDetectionTemplateProcessor::NAMESPACE_DECLARATION, '\{namespace typo3 = TYPO3.TYPO3\Bla3\Blubb }'), 0, 'The SCAN_PATTERN_NAMESPACEDECLARATION pattern did match a namespace declaration even if it was escaped. (2)');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSPLIT_PATTERN_DYNAMICTAGS(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_TEMPLATE_DYNAMICTAGS;
@@ -77,9 +75,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_DYNAMICTAGS pattern did not split the input string correctly with custom multi-part namespace identifier.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSCAN_PATTERN_DYNAMICTAG(): void
     {
         $pattern = Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG;
@@ -160,9 +156,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals($expected, $matches, 'The SCAN_PATTERN_DYNAMICTAG does not match correctly with complex attributes and > inside the attributes.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSCAN_PATTERN_CLOSINGDYNAMICTAG(): void
     {
         $pattern = Patterns::$SCAN_PATTERN_TEMPLATE_CLOSINGVIEWHELPERTAG;
@@ -171,9 +165,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals(preg_match($pattern, '</t:bla>'), 1, 'The SCAN_PATTERN_CLOSINGDYNAMICTAG does not match a unknown namespace tag it should match.');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSPLIT_PATTERN_TAGARGUMENTS(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_TAGARGUMENTS;
@@ -182,9 +174,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals('data-foo', $matches[3]['Argument']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSPLIT_PATTERN_SHORTHANDSYNTAX(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX;
@@ -234,9 +224,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals(preg_split($pattern, $source, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY), $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX pattern did not split the input string correctly with a custom multi-part namespace identifier.(10)');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER;
@@ -313,9 +301,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals($matches, $expected, 'The SPLIT_PATTERN_SHORTHANDSYNTAX_VIEWHELPER');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS(): void
     {
         $pattern = Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_OBJECTACCESSORS;
@@ -372,10 +358,8 @@ final class TemplateParserPatternTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
-     * @test
-     */
+    #[DataProvider('dataProviderSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS')]
+    #[Test]
     public function testSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS(string $string): void
     {
         $success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
@@ -392,19 +376,15 @@ final class TemplateParserPatternTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS
-     * @test
-     */
+    #[DataProvider('dataProviderInvalidSCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS')]
+    #[Test]
     public function SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS_doesNotMatchInvalidSyntax(string $string): void
     {
         $success = preg_match(Patterns::$SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS, $string, $matches) === 1;
         self::assertFalse($success);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
@@ -444,9 +424,7 @@ final class TemplateParserPatternTest extends UnitTestCase
         self::assertEquals($expected, $matches, 'The regular expression splitting the array apart does not work!');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_matchesQuotedKeys(): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
@@ -584,10 +562,8 @@ final class TemplateParserPatternTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderValidArrayExpressionsBeginningAndEndingOnDigits
-     * @test
-     */
+    #[DataProvider('dataProviderValidArrayExpressionsBeginningAndEndingOnDigits')]
+    #[Test]
     public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_matchesKeysEndingInDigits(string $expression, array $expected): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
@@ -609,10 +585,8 @@ final class TemplateParserPatternTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS
-     * @test
-     */
+    #[DataProvider('dataProviderInvalidSPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS')]
+    #[Test]
     public function SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS_doesNotMatchInvalidSyntax(string $string): void
     {
         $pattern = Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS;
@@ -622,9 +596,8 @@ final class TemplateParserPatternTest extends UnitTestCase
 
     /**
      * Test the SCAN_PATTERN_CDATA which should detect <![CDATA[...]]> (with no leading or trailing spaces!)
-     *
-     * @test
      */
+    #[Test]
     public function testSCAN_PATTERN_CDATA(): void
     {
         $pattern = Patterns::$SCAN_PATTERN_CDATA;

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
@@ -40,9 +42,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
  */
 final class TemplateParserTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testInitializeViewHelperAndAddItToStackReturnsFalseIfNamespaceIgnored(): void
     {
         $resolver = $this->createMock(ViewHelperResolver::class);
@@ -56,9 +56,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testInitializeViewHelperAndAddItToStackThrowsExceptionIfNamespaceInvalid(): void
     {
         $this->expectException(UnknownNamespaceException::class);
@@ -74,9 +72,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertNull($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testClosingViewHelperTagHandlerReturnsFalseIfNamespaceIgnored(): void
     {
         $resolver = $this->createMock(ViewHelperResolver::class);
@@ -90,9 +86,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testClosingViewHelperTagHandlerThrowsExceptionIfNamespaceInvalid(): void
     {
         $this->expectException(UnknownNamespaceException::class);
@@ -108,9 +102,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertFalse($result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isEscapingEnabledReturnsPreviouslySetEscapingEnabled(): void
     {
         $subject = new TemplateParser();
@@ -121,9 +113,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertTrue($subject->isEscapingEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testBuildObjectTreeThrowsExceptionOnUnclosedViewHelperTag(): void
     {
         $this->expectException(Exception::class);
@@ -135,9 +125,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, ['<f:render>'], TemplateParser::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testParseCallsPreProcessOnTemplateProcessors(): void
     {
         $subject = new TemplateParser();
@@ -153,9 +141,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertEquals('final', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getOrParseAndStoreTemplateSetsAndStoresUncompilableStateInCache(): void
     {
         $parsedTemplate = new ParsingState();
@@ -180,9 +166,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertFalse($parsedTemplate->isCompilable());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function parseThrowsExceptionWhenStringArgumentMissing(): void
     {
         $this->expectException(\Exception::class);
@@ -201,10 +185,8 @@ final class TemplateParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider quotedStrings
-     * @test
-     */
+    #[DataProvider('quotedStrings')]
+    #[Test]
     public function unquoteStringReturnsUnquotedStrings(string $quoted, string $unquoted): void
     {
         $subject = new TemplateParser();
@@ -220,10 +202,8 @@ final class TemplateParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider templatesToSplit
-     * @test
-     */
+    #[DataProvider('templatesToSplit')]
+    #[Test]
     public function splitTemplateAtDynamicTagsReturnsCorrectlySplitTemplate(string $templateName): void
     {
         $template = file_get_contents(__DIR__ . '/Fixtures/' . $templateName . '.html');
@@ -233,9 +213,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertSame($expectedResult, $method->invoke($subject, $template));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildObjectTreeCreatesRootNodeAndSetsUpParsingState(): void
     {
         $context = new RenderingContext();
@@ -246,9 +224,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertInstanceOf(ParsingState::class, $method->invoke($subject, [], TemplateParser::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function closingViewHelperTagHandlerThrowsExceptionBecauseOfClosingTagWhichWasNeverOpened(): void
     {
         $this->expectException(\Exception::class);
@@ -261,9 +237,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $mockState, 'f', 'render');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function closingViewHelperTagHandlerThrowsExceptionBecauseOfWrongTagNesting(): void
     {
         $this->expectException(\Exception::class);
@@ -274,9 +248,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $mockState, 'f', 'render');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function objectAccessorHandlerCreatesObjectAccessorNodeWithExpectedValueAndAddsItToStack(): void
     {
         $mockNodeOnStack = $this->createMock(NodeInterface::class);
@@ -288,9 +260,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $mockState, 'objectAccessorString', '', '', '');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valuesFromObjectAccessorsAreRunThroughEscapingInterceptorsByDefault(): void
     {
         $objectAccessorNodeInterceptor = $this->createMock(InterceptorInterface::class);
@@ -310,9 +280,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $mockState, 'objectAccessorString', '', '', '');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valuesFromObjectAccessorsAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled(): void
     {
         $parserConfiguration = $this->createMock(Configuration::class);
@@ -329,9 +297,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $mockState, 'objectAccessorString', '', '', '');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function valuesFromObjectAccessorsAreRunThroughInterceptors(): void
     {
         $objectAccessorNodeInterceptor = $this->createMock(InterceptorInterface::class);
@@ -361,10 +327,8 @@ final class TemplateParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider parseArgumentsWorksAsExpectedDataProvider
-     */
+    #[DataProvider('parseArgumentsWorksAsExpectedDataProvider')]
+    #[Test]
     public function parseArgumentsWorksAsExpected(string $argumentsString, array $expected): void
     {
         $context = new RenderingContext();
@@ -377,9 +341,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertSame($expected, $method->invoke($subject, $argumentsString, $viewHelper));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildArgumentObjectTreeReturnsTextNodeForSimplyString(): void
     {
         $subject = new TemplateParser();
@@ -387,9 +349,7 @@ final class TemplateParserTest extends UnitTestCase
         $this->assertInstanceof(TextNode::class, $method->invoke($subject, 'a very plain string'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function buildArgumentObjectTreeBuildsObjectTreeForComplexString(): void
     {
         $objectTree = $this->createMock(ParsingState::class);
@@ -403,9 +363,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertEquals('theRootNode', $method->invoke($subject, 'a <very> {complex} string'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayHandlerAddsArrayNodeWithProperContentToStack(): void
     {
         $nodeMock = $this->createMock(NodeInterface::class);
@@ -418,9 +376,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $parsingStateMock, ['arrayText']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function textNodesAreRunThroughEscapingInterceptorsByDefault(): void
     {
         $textInterceptor = $this->createMock(InterceptorInterface::class);
@@ -439,9 +395,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $parsingStateMock, 'string');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function textNodesAreNotRunThroughEscapingInterceptorsIfEscapingIsDisabled(): void
     {
         $parserConfiguration = $this->createMock(Configuration::class);
@@ -574,10 +528,8 @@ final class TemplateParserTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderRecursiveArrayHandler
-     * @test
-     */
+    #[DataProvider('dataProviderRecursiveArrayHandler')]
+    #[Test]
     public function testRecursiveArrayHandler(string $string, array $expected): void
     {
         $state = new ParsingState();
@@ -594,9 +546,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function abortIfRequiredArgumentsAreMissingThrowsException(): void
     {
         $this->expectException(Exception::class);
@@ -609,9 +559,7 @@ final class TemplateParserTest extends UnitTestCase
         $method->invoke($subject, $expected, []);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function abortIfRequiredArgumentsAreMissingDoesNotThrowExceptionIfRequiredArgumentExists(): void
     {
         $expectedArguments = [
@@ -628,9 +576,7 @@ final class TemplateParserTest extends UnitTestCase
         self::assertTrue(true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function booleanArgumentsMustBeConvertedIntoBooleanNodes(): void
     {
         $argumentDefinitions = [

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProcessor;
@@ -36,10 +38,8 @@ final class EscapingModifierTemplateProcessorTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getEscapingTestValues
-     * @test
-     */
+    #[DataProvider('getEscapingTestValues')]
+    #[Test]
     public function testSetsEscapingToExpectedValueAndStripsModifier(string $templateSource, bool $expected): void
     {
         $subject = new EscapingModifierTemplateProcessor();
@@ -70,10 +70,8 @@ final class EscapingModifierTemplateProcessorTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getErrorTestValues
-     * @test
-     */
+    #[DataProvider('getErrorTestValues')]
+    #[Test]
     public function testThrowsExceptionOnMultipleDefinitions(string $templateSource): void
     {
         $this->expectException(Exception::class);

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use stdClass;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
@@ -34,10 +36,8 @@ final class RenderingContextTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider gettersReturnPreviouslySetValuesDataProvider
-     */
+    #[DataProvider('gettersReturnPreviouslySetValuesDataProvider')]
+    #[Test]
     public function gettersReturnPreviouslySetValues(string $property, string|array $expected): void
     {
         $subject = new RenderingContext();
@@ -61,10 +61,8 @@ final class RenderingContextTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider gettersReturnPreviouslySetObjectsDataProvider
-     */
+    #[DataProvider('gettersReturnPreviouslySetObjectsDataProvider')]
+    #[Test]
     public function gettersReturnPreviouslySetObjects(string $property, string $expected): void
     {
         $expected = $this->createMock($expected);
@@ -75,9 +73,7 @@ final class RenderingContextTest extends UnitTestCase
         self::assertSame($expected, $subject->$getter());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getTemplateProcessorsReturnsPreviouslySetTemplateProcessor(): void
     {
         $processors = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
@@ -86,18 +82,14 @@ final class RenderingContextTest extends UnitTestCase
         self::assertSame($processors, $subject->getTemplateProcessors());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isCacheEnabledReturnsFalse(): void
     {
         $subject = new RenderingContext();
         self::assertFalse($subject->isCacheEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function isCacheEnabledReturnsTrueIfCacheIsEnabled(): void
     {
         $subject = new RenderingContext();
@@ -105,9 +97,7 @@ final class RenderingContextTest extends UnitTestCase
         self::assertTrue($subject->isCacheEnabled());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function withAndGetAttribute(): void
     {
         $object = new stdClass();

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Variables\ChainedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
@@ -29,10 +31,8 @@ final class ChainedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getGetTestValues
-     * @test
-     */
+    #[DataProvider('getGetTestValues')]
+    #[Test]
     public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
@@ -40,10 +40,8 @@ final class ChainedVariableProviderTest extends UnitTestCase
         self::assertEquals($expected, $subject->get($path));
     }
 
-    /**
-     * @dataProvider getGetTestValues
-     * @test
-     */
+    #[DataProvider('getGetTestValues')]
+    #[Test]
     public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
@@ -63,10 +61,8 @@ final class ChainedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAllReturnsPreviouslySetSourceVariablesDataProvider
-     * @test
-     */
+    #[DataProvider('getAllReturnsPreviouslySetSourceVariablesDataProvider')]
+    #[Test]
     public function getAllReturnsPreviouslySetSourceVariables(array $local, array $chain, array $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
@@ -86,10 +82,8 @@ final class ChainedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getAllIdentifiersReturnsPreviouslySetSourceIdentifiersDataProvider
-     * @test
-     */
+    #[DataProvider('getAllIdentifiersReturnsPreviouslySetSourceIdentifiersDataProvider')]
+    #[Test]
     public function getAllIdentifiersReturnsPreviouslySetSourceIdentifiers(array $local, array $chain, array $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
@@ -97,9 +91,7 @@ final class ChainedVariableProviderTest extends UnitTestCase
         self::assertEquals($expected, $subject->getAllIdentifiers());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getScopeCopyKeepsExistingVariableProviders(): void
     {
         $chain = [new StandardVariableProvider(['a' => 'a']), new StandardVariableProvider()];

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Variables\JSONVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
@@ -26,10 +28,8 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider provideVariablesDataProvider
-     */
+    #[DataProvider('provideVariablesDataProvider')]
+    #[Test]
     public function provideVariables(string $input, array $expected): void
     {
         $provider = new JSONVariableProvider();
@@ -42,9 +42,7 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllLoadJsonFile(): void
     {
         $provider = new JSONVariableProvider();
@@ -52,9 +50,7 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
         self::assertEquals(['foo' => 'bar'], $provider->getAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllIdentifiersLoadJsonFile(): void
     {
         $provider = new JSONVariableProvider();
@@ -62,9 +58,7 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
         self::assertEquals(['foo'], $provider->getAllIdentifiers());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLoadJsonFile(): void
     {
         $provider = new JSONVariableProvider();
@@ -72,9 +66,7 @@ final class JSONVariableProviderTest extends AbstractFunctionalTestCase
         self::assertEquals('bar', $provider->get('foo'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getByPathLoadJsonFile(): void
     {
         $provider = new JSONVariableProvider();

--- a/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
@@ -42,10 +44,8 @@ final class ScopedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getAllDataProvider
-     */
+    #[DataProvider('getAllDataProvider')]
+    #[Test]
     public function getAllVariables(array $globalVariables, array $localVariables, array $result): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -82,10 +82,8 @@ final class ScopedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getAllIdentifiersDataProvider
-     */
+    #[DataProvider('getAllIdentifiersDataProvider')]
+    #[Test]
     public function getAllIdentifiers(array $globalVariables, array $localVariables, array $result): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -126,10 +124,8 @@ final class ScopedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getVariableDataProvider
-     */
+    #[DataProvider('getVariableDataProvider')]
+    #[Test]
     public function getVariable(array $globalVariables, array $localVariables, string $identifier, $result): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -212,10 +208,8 @@ final class ScopedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getVariableByPathDataProvider
-     */
+    #[DataProvider('getVariableByPathDataProvider')]
+    #[Test]
     public function getVariableByPath(array $globalVariables, array $localVariables, string $path, $result): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -256,10 +250,8 @@ final class ScopedVariableProviderTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider variableExistsDataProvider
-     */
+    #[DataProvider('variableExistsDataProvider')]
+    #[Test]
     public function variableExists(array $globalVariables, array $localVariables, string $identifier, bool $exists): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -269,9 +261,7 @@ final class ScopedVariableProviderTest extends UnitTestCase
         self::assertEquals($exists, $variableProvider->exists($identifier));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setVariableInConstructor()
     {
         $variableProvider = new ScopedVariableProvider(
@@ -282,9 +272,7 @@ final class ScopedVariableProviderTest extends UnitTestCase
         self::assertNull($variableProvider->getLocalVariableProvider()->get('globalVar'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addVariable()
     {
         $variableProvider = new ScopedVariableProvider(new StandardVariableProvider(), new StandardVariableProvider());
@@ -293,9 +281,7 @@ final class ScopedVariableProviderTest extends UnitTestCase
         self::assertEquals('global', $variableProvider->getLocalVariableProvider()->get('globalVar'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeVariable(): void
     {
         $variableProvider = new ScopedVariableProvider(
@@ -307,9 +293,7 @@ final class ScopedVariableProviderTest extends UnitTestCase
         self::assertNull($variableProvider->getLocalVariableProvider()->get('globalVar'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getScopedCopy(): void
     {
         $variableProvider = new ScopedVariableProvider(

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -9,24 +9,22 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\StandardVariableProviderModelFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class StandardVariableProviderTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getSourceReturnsEmptyArray(): void
     {
         $subject = new StandardVariableProvider();
         self::assertSame([], $subject->getSource());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSourceReturnsPreviouslySetSource(): void
     {
         $subject = new StandardVariableProvider();
@@ -34,9 +32,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['foo' => 'bar'], $subject->getSource());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getSourceReturnsPreviouslyAddedVariables(): void
     {
         $subject = new StandardVariableProvider();
@@ -45,18 +41,14 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['name' => 'Simon', 'org' => 'TYPO3'], $subject->getSource());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllReturnsEmptyArray(): void
     {
         $subject = new StandardVariableProvider();
         self::assertSame([], $subject->getAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllReturnsPreviouslySetSource(): void
     {
         $subject = new StandardVariableProvider();
@@ -64,9 +56,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['foo' => 'bar'], $subject->getAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllReturnsPreviouslyAddedVariables(): void
     {
         $subject = new StandardVariableProvider();
@@ -75,18 +65,14 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['name' => 'Simon', 'org' => 'TYPO3'], $subject->getAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllIdentifiersReturnsEmptyArray(): void
     {
         $subject = new StandardVariableProvider();
         self::assertSame([], $subject->getAllIdentifiers());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllIdentifiersReturnsKeysOfPreviouslySetSource(): void
     {
         $subject = new StandardVariableProvider();
@@ -94,9 +80,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['foo'], $subject->getAllIdentifiers());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllIdentifiersReturnsKeysOfPreviouslyAddedVariables(): void
     {
         $subject = new StandardVariableProvider();
@@ -105,18 +89,14 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['name', 'org'], $subject->getAllIdentifiers());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getReturnsNullWithNotExistingVariable(): void
     {
         $variableProvider = new StandardVariableProvider();
         self::assertNull($variableProvider->get('nonexistent'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getReturnsPreviouslyAddedVariable(): void
     {
         $subject = new StandardVariableProvider();
@@ -124,9 +104,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame($subject->get('variable'), 'someString');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAsArrayAccessReturnsPreviouslySetVariable(): void
     {
         $subject = new StandardVariableProvider();
@@ -134,9 +112,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame($subject['variable'], 'someString');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existsReturnsTrueWithPreviouslyAddedVariable(): void
     {
         $subject = new StandardVariableProvider();
@@ -144,9 +120,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertTrue($subject->exists('variable'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existsAsArrayAccessReturnsTrueWithPreviouslyAddedVariable(): void
     {
         $subject = new StandardVariableProvider();
@@ -154,9 +128,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertTrue(isset($subject['variable']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function unsetAsArrayAccessRemovesVariable(): void
     {
         $subject = new StandardVariableProvider();
@@ -165,9 +137,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertFalse($subject->exists('variable'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function removeReallyRemovesVariables(): void
     {
         $subject = new StandardVariableProvider();
@@ -176,9 +146,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertNull($subject->get('variable'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sleepReturnsArrayWithVariableKey(): void
     {
         $subject = new StandardVariableProvider();
@@ -186,9 +154,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertContains('variables', $properties);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getScopeCopyReturnsCopyWithSettings(): void
     {
         $subject = new StandardVariableProvider(['foo' => 'bar', 'settings' => ['baz' => 'bam']]);
@@ -196,9 +162,7 @@ final class StandardVariableProviderTest extends UnitTestCase
         self::assertSame(['bar' => 'foo', 'settings' => ['baz' => 'bam']], $copy->getAll());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testSupportsDottedPath(): void
     {
         $provider = new StandardVariableProvider();
@@ -460,9 +424,9 @@ final class StandardVariableProviderTest extends UnitTestCase
 
     /**
      * @param mixed $expected
-     * @test
-     * @dataProvider getPathTestValues
      */
+    #[DataProvider('getPathTestValues')]
+    #[Test]
     public function getByPathReturnsExpectedValues(array $variables, string $path, $expected): void
     {
         $subject = new StandardVariableProvider();

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
@@ -43,9 +45,9 @@ final class VariableExtractorTest extends UnitTestCase
     /**
      * @param mixed $subject
      * @param mixed $expected
-     * @test
-     * @dataProvider getPathTestValues
      */
+    #[DataProvider('getPathTestValues')]
+    #[Test]
     public function testGetByPath($subject, string $path, $expected): void
     {
         $result = VariableExtractor::extract($subject, $path);
@@ -73,9 +75,9 @@ final class VariableExtractorTest extends UnitTestCase
 
     /**
      * @param mixed $subject
-     * @test
-     * @dataProvider getAccessorsForPathTestValues
      */
+    #[DataProvider('getAccessorsForPathTestValues')]
+    #[Test]
     public function testGetAccessorsForPath($subject, string $path, array $expected): void
     {
         $result = VariableExtractor::extractAccessors($subject, $path);
@@ -99,18 +101,16 @@ final class VariableExtractorTest extends UnitTestCase
     /**
      * @param mixed $subject
      * @param mixed $accessor
-     * @test
-     * @dataProvider getExtractRedectAccessorTestValues
      */
+    #[DataProvider('getExtractRedectAccessorTestValues')]
+    #[Test]
     public function testExtractRedetectsAccessorIfUnusableAccessorPassed($subject, string $path, $accessor, string $expected): void
     {
         $result = VariableExtractor::extract($subject, $path, [$accessor]);
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testExtractCallsMagicMethodGetters(): void
     {
         $subject = new ClassWithMagicGetter();

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -9,15 +9,14 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractTagBasedViewHelperTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderCallsRenderOnTagBuilder(): void
     {
         $tagBuilder = $this->createMock(TagBuilder::class);

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -41,10 +43,8 @@ class AbstractViewHelperTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @dataProvider getFirstElementOfNonEmptyTestValues
-     * @test
-     */
+    #[DataProvider('getFirstElementOfNonEmptyTestValues')]
+    #[Test]
     public function getFirstElementOfNonEmptyReturnsExpectedValue(mixed $input, string|null $expected): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
@@ -52,9 +52,7 @@ class AbstractViewHelperTest extends UnitTestCase
         self::assertEquals($expected, $method->invoke($subject, $input));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overrideArgumentOverwritesExistingArgumentDefinition(): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
@@ -68,9 +66,7 @@ class AbstractViewHelperTest extends UnitTestCase
         self::assertEquals($expected, $subject->prepareArguments());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function registeringTheSameArgumentNameAgainThrowsException(): void
     {
         $this->expectException(\Exception::class);
@@ -80,9 +76,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $method->invoke($subject, 'someName', 'integer', 'desc', true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument(): void
     {
         $this->expectException(\Exception::class);
@@ -91,9 +85,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $method->invoke($subject, 'argumentName', 'string', 'description', true);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validateArgumentsAcceptsAllObjectsImplementingArrayAccessAsAnArray(): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods(['prepareArguments'])->getMock();
@@ -102,9 +94,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $subject->validateArguments();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setRenderingContextShouldSetInnerVariables(): void
     {
         $templateVariableContainer = $this->createMock(VariableProviderInterface::class);
@@ -120,9 +110,7 @@ class AbstractViewHelperTest extends UnitTestCase
         self::assertSame($viewHelperVariableContainer, $property->getValue($subject));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderChildrenCallsRenderChildrenClosureIfSet(): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
@@ -146,10 +134,8 @@ class AbstractViewHelperTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider validateArgumentsErrorsDataProvider
-     */
+    #[DataProvider('validateArgumentsErrorsDataProvider')]
+    #[Test]
     public function validateArgumentsErrors(ArgumentDefinition $argument, array|string|object $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -160,9 +146,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $subject->validateArguments();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function validateAdditionalArgumentsThrowsExceptionIfNotEmpty(): void
     {
         $this->expectException(Exception::class);
@@ -171,9 +155,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $subject->validateAdditionalArguments(['foo' => 'bar']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCompileReturnsAndAssignsExpectedPhpCode(): void
     {
         $context = new RenderingContext();
@@ -185,9 +167,7 @@ class AbstractViewHelperTest extends UnitTestCase
         self::assertEquals(get_class($subject) . '::renderStatic(foobar, baz, $renderingContext)', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCallRenderMethodCanRenderViewHelperWithoutRenderMethodAndCallsRenderStatic(): void
     {
         $subject = new RenderMethodFreeViewHelper();
@@ -197,9 +177,7 @@ class AbstractViewHelperTest extends UnitTestCase
         self::assertSame('I was rendered', $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testCallRenderMethodOnViewHelperWithoutRenderMethodWithDefaultRenderStaticMethodThrowsException(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class ArgumentDefinitionTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function objectStoresDataCorrectly(): void
     {
         $name = 'This is a name';

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -9,32 +9,27 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 final class TagBuilderTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function constructorSetsTagName(): void
     {
         $tagBuilder = new TagBuilder('someTagName');
         self::assertEquals('someTagName', $tagBuilder->getTagName());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function constructorSetsTagContent(): void
     {
         $tagBuilder = new TagBuilder('', '<some text>');
         self::assertEquals('<some text>', $tagBuilder->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setContentDoesNotEscapeValue(): void
     {
         $tagBuilder = new TagBuilder();
@@ -42,18 +37,14 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<to be escaped>', $tagBuilder->getContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasContentReturnsTrueIfTagContainsText(): void
     {
         $tagBuilder = new TagBuilder('', 'foo');
         self::assertTrue($tagBuilder->hasContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasContentReturnsFalseIfContentIsNull(): void
     {
         $tagBuilder = new TagBuilder();
@@ -61,9 +52,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertFalse($tagBuilder->hasContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function hasContentReturnsFalseIfContentIsAnEmptyString(): void
     {
         $tagBuilder = new TagBuilder();
@@ -71,27 +60,21 @@ final class TagBuilderTest extends UnitTestCase
         self::assertFalse($tagBuilder->hasContent());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsEmptyStringByDefault(): void
     {
         $tagBuilder = new TagBuilder();
         self::assertEquals('', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsSelfClosingTagIfNoContentIsSpecified(): void
     {
         $tagBuilder = new TagBuilder('tag');
         self::assertEquals('<tag />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function contentCanBeRemoved(): void
     {
         $tagBuilder = new TagBuilder('tag', 'some content');
@@ -99,9 +82,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsOpeningAndClosingTagIfNoContentIsSpecifiedButForceClosingTagIsTrue(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -109,9 +90,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag></tag>', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesAreProperlyRendered(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -121,9 +100,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag attribute1="attribute1value" attribute2="attribute2value" attribute3="attribute3value" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayAttributesAreProperlyRendered(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -132,9 +109,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag data-attribute1="data1" data-attribute2="data2" aria-attribute1="aria1" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function customArrayAttributesThrowException(): void
     {
         self::expectException(\InvalidArgumentException::class);
@@ -144,9 +119,7 @@ final class TagBuilderTest extends UnitTestCase
         $tagBuilder->addAttribute('custom', ['attribute1' => 'data1', 'attribute2' => 'data2']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributeValuesAreEscapedByDefault(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -154,9 +127,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag foo="&lt;to be escaped&gt;" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributeValuesAreNotEscapedIfDisabled(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -164,9 +135,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag foo="<not to be escaped>" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesCanBeRemoved(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -177,9 +146,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag attribute1="attribute1value" attribute3="attribute3value" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyAttributesGetRemovedWhenCallingIgnoreEmptyAttributesWithTrue(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -190,9 +157,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag attribute3="attribute3value" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function emptyAttributesGetPreservedWhenCallingIgnoreEmptyAttributesWithFalse(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -203,9 +168,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag attribute1="" attribute2="" attribute3="attribute3value" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function ignoresNewEmptyAttributesIfEmptyAttributesIgnored(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -216,9 +179,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<tag attribute3="attribute3value" />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesCanBeAccessed(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -227,9 +188,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertSame('attribute1value', $attributeValue);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function attributesCanBeAccessedBulk(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -238,9 +197,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals(['attribute1' => 'attribute1value'], $attributeValues);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAttributeWithMissingAttributeReturnsNull(): void
     {
         $tagBuilder = new TagBuilder('tag');
@@ -248,9 +205,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertNull($attributeValue);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resetResetsTagBuilder(): void
     {
         $tagBuilder = new TagBuilder();
@@ -264,9 +219,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertSame([], $tagBuilder->getAttributes());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagNameCanBeOverridden(): void
     {
         $tagBuilder = new TagBuilder('foo');
@@ -274,9 +227,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<bar />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagContentCanBeOverridden(): void
     {
         $tagBuilder = new TagBuilder('foo', 'some content');
@@ -284,9 +235,7 @@ final class TagBuilderTest extends UnitTestCase
         self::assertEquals('<foo />', $tagBuilder->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function tagIsNotRenderedIfTagNameIsEmpty(): void
     {
         $tagBuilder = new TagBuilder('foo');

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures\ParserRuntimeOnlyFixture;
@@ -19,17 +20,13 @@ use TYPO3Fluid\Fluid\Tests\UnitTestCase;
  */
 final class ParserRuntimeOnlyTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsNull(): void
     {
         self::assertNull((new ParserRuntimeOnlyFixture())->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function compileReturnsEmptyString(): void
     {
         $initializationPhpCode = '';

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
@@ -24,10 +26,8 @@ final class ViewHelperInvokerTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider getInvocationTestValues
-     */
+    #[DataProvider('getInvocationTestValues')]
+    #[Test]
     public function testInvokeViewHelper(string $viewHelperClassName, array $arguments, string $expectedOutput): void
     {
         $invoker = new ViewHelperInvoker();

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
@@ -16,9 +18,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
 
 final class ViewHelperResolverTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceWithStringRecordsNamespace(): void
     {
         $subject = new ViewHelperResolver();
@@ -26,9 +26,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['test'], $subject->getNamespaces()['t']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceWithArrayRecordsNamespace(): void
     {
         $subject = new ViewHelperResolver();
@@ -36,9 +34,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['test'], $subject->getNamespaces()['t']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceWithNullDoesNotChoke(): void
     {
         $subject = new ViewHelperResolver();
@@ -46,9 +42,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'ignored' => null], $subject->getNamespaces());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceWithNullTwiceDoesNotChoke(): void
     {
         $subject = new ViewHelperResolver();
@@ -57,9 +51,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => null], $subject->getNamespaces());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceWithNullAndThenValidValueConvertsToNotIgnoredNamespace(): void
     {
         $subject = new ViewHelperResolver();
@@ -68,9 +60,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'], 'ignored' => ['Foo\\Bar']], $subject->getNamespaces());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addNamespaceDoesNotThrowAnExceptionIfTheAliasExistAlreadyAndPointsToTheSamePhpNamespace(): void
     {
         $subject = new ViewHelperResolver();
@@ -80,9 +70,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'foo' => ['Some\Namespace']], $subject->getNamespaces());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setNamespacesSetsNamespaces(): void
     {
         $subject = new ViewHelperResolver();
@@ -90,9 +78,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame(['t' => ['test']], $subject->getNamespaces());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function setNamespacesConvertsStringNamespaceToArray(): void
     {
         $subject = new ViewHelperResolver();
@@ -111,10 +97,8 @@ final class ViewHelperResolverTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider isNamespaceValidReturnsExpectedValueDataProvider
-     */
+    #[DataProvider('isNamespaceValidReturnsExpectedValueDataProvider')]
+    #[Test]
     public function isNamespaceValidReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
@@ -132,10 +116,8 @@ final class ViewHelperResolverTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider isNamespaceIgnoredReturnsExpectedValueDataProvider
-     */
+    #[DataProvider('isNamespaceIgnoredReturnsExpectedValueDataProvider')]
+    #[Test]
     public function isNamespaceIgnoredReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
@@ -153,10 +135,8 @@ final class ViewHelperResolverTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider isNamespaceValidOrIgnoredReturnsExpectedValueDataProvider
-     */
+    #[DataProvider('isNamespaceValidOrIgnoredReturnsExpectedValueDataProvider')]
+    #[Test]
     public function isNamespaceValidOrIgnoredReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
@@ -164,9 +144,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame($expected, $subject->isNamespaceValidOrIgnored($namespace));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveViewHelperClassNameThrowsExceptionIfClassNotResolved(): void
     {
         $this->expectException(Exception::class);
@@ -174,9 +152,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         $subject->resolveViewHelperClassName('f', 'invalid');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveViewHelperClassNameSupportsMultipleNamespaces(): void
     {
         $subject = new ViewHelperResolver();
@@ -186,9 +162,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $subject->resolveViewHelperClassName('f', 'render'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveViewHelperClassNameDoesNotChokeOnNullInMultipleNamespaces(): void
     {
         $subject = new ViewHelperResolver();
@@ -198,9 +172,7 @@ final class ViewHelperResolverTest extends UnitTestCase
         self::assertSame('TYPO3Fluid\\Fluid\\ViewHelpers\\RenderViewHelper', $subject->resolveViewHelperClassName('f', 'render'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function resolveViewHelperClassNameTrimsBackslashSuffixFromNamespace(): void
     {
         $subject = new ViewHelperResolver();
@@ -217,19 +189,15 @@ final class ViewHelperResolverTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider resolvePhpNamespaceFromFluidNamespaceDataProvider
-     */
+    #[DataProvider('resolvePhpNamespaceFromFluidNamespaceDataProvider')]
+    #[Test]
     public function resolvePhpNamespaceFromFluidNamespace(string $input, string $expected): void
     {
         $subject = new ViewHelperResolver();
         self::assertSame($expected, $subject->resolvePhpNamespaceFromFluidNamespace($input));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function createViewHelperInstanceCreatesInstance(): void
     {
         $subject = new ViewHelperResolver();

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
@@ -16,9 +17,7 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
 
 final class ViewHelperVariableContainerTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function storedDataCanBeReadOutAgain(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -29,9 +28,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertEquals($variable, $subject->get(TestViewHelper::class, 'test'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addOrUpdateSetsAKeyIfItDoesNotExistYet(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -39,9 +36,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertEquals($subject->get('Foo\Bar', 'nonExistentKey'), 'value1');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addOrUpdateOverridesAnExistingKey(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -50,9 +45,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertEquals($subject->get('Foo\Bar', 'someKey'), 'value2');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function aSetValueCanBeRemovedAgain(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -61,18 +54,14 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertFalse($subject->exists('Foo\Bar', 'nonExistentKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existsReturnsFalseIfTheSpecifiedKeyDoesNotExist(): void
     {
         $subject = new ViewHelperVariableContainer();
         self::assertFalse($subject->exists('Foo\Bar', 'nonExistentKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existsReturnsTrueIfTheSpecifiedKeyExists(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -80,9 +69,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertTrue($subject->exists('Foo\Bar', 'someKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function existsReturnsTrueIfTheSpecifiedKeyExistsAndIsNull(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -90,9 +77,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertTrue($subject->exists('Foo\Bar', 'someKey'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getViewReturnsPreviouslySetView(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -101,9 +86,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertSame($view, $subject->getView());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllGetsAllVariables(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -111,9 +94,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertSame(['foo' => 'foo', 'bar' => 'bar'], $subject->getAll('Foo\\Bar'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getAllReturnsDefaultIfNotFound(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -121,9 +102,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertSame(['foo' => 'bar'], $subject->getAll('Baz\\Baz', ['foo' => 'bar']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function addAllThrowsInvalidArgumentExceptionOnUnsupportedType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -131,9 +110,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         $subject->addAll('Foo\\Bar', new \DateTime('now'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function sleepReturnsExpectedPropertyNames(): void
     {
         $subject = new ViewHelperVariableContainer();
@@ -141,9 +118,7 @@ final class ViewHelperVariableContainerTest extends UnitTestCase
         self::assertContains('objects', $properties);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getReturnsDefaultIfRequestedVariableDoesNotExist(): void
     {
         $subject = new ViewHelperVariableContainer();

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 use TYPO3Fluid\Fluid\Core\ErrorHandler\StandardErrorHandler;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -23,9 +24,7 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 
 class AbstractTemplateViewTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function getRenderingContextReturnsPreviouslySetRenderingContext(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -35,9 +34,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         self::assertSame($renderingContext, $subject->getRenderingContext());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getViewHelperResolverReturnsViewHelperResolverFromRenderingContext(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -49,9 +46,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         self::assertSame($viewHelperResolver, $subject->getViewHelperResolver());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assignAddsValueToTemplateVariableContainer(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -72,9 +67,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->assign('foo', 'FooValue')->assign('bar', 'BarValue');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assignCanOverridePreviouslyAssignedValues(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -95,9 +88,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->assign('foo', 'FooValue')->assign('foo', 'FooValueOverridden');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assignMultipleAddsValuesToTemplateVariableContainer(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -119,9 +110,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->assignMultiple(['foo' => 'FooValue', 'bar' => 'BarValue'])->assignMultiple(['baz' => 'BazValue']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function assignMultipleCanOverridePreviouslyAssignedValues(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
@@ -143,9 +132,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->assign('foo', 'FooValue')->assignMultiple(['foo' => 'FooValueOverridden', 'bar' => 'BarValue']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSectionThrowsExceptionIfSectionMissingAndNotIgnoringUnknownWithNotCompiledTemplate(): void
     {
         $this->expectException(InvalidSectionException::class);
@@ -163,9 +150,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->renderSection('Missing');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSectionThrowsExceptionIfSectionMissingAndNotIgnoringUnknownWithCompiledTemplate(): void
     {
         $this->expectException(InvalidSectionException::class);
@@ -183,9 +168,7 @@ class AbstractTemplateViewTest extends UnitTestCase
         $subject->renderSection('Missing');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function renderSectionOnCompiledTemplateDoesNotThrowExceptionWhenIgnoreUnknownIsTrue(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);

--- a/tests/Unit/View/AbstractViewTest.php
+++ b/tests/Unit/View/AbstractViewTest.php
@@ -9,23 +9,20 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\AbstractViewTestFixture;
 use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 class AbstractViewTest extends UnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function renderReturnsEmptyString(): void
     {
         $subject = new AbstractViewTestFixture();
         self::assertSame('', $subject->render());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAssignsVariableAndReturnsSelf(): void
     {
         $subject = new AbstractViewTestFixture();
@@ -33,9 +30,7 @@ class AbstractViewTest extends UnitTestCase
         self::assertSame(['test' => 'foobar'], $subject->variables);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testAssignsMultipleVariablesAndReturnsSelf(): void
     {
         $subject = new AbstractViewTestFixture();

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
@@ -31,10 +33,8 @@ final class TemplatePathsTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider sanitizePathDataProvider
-     */
+    #[DataProvider('sanitizePathDataProvider')]
+    #[Test]
     public function sanitizePath(string|array $input, string|array $expected): void
     {
         $subject = new TemplatePaths();
@@ -52,10 +52,8 @@ final class TemplatePathsTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @test
-     * @dataProvider sanitizePathsDataProvider
-     */
+    #[DataProvider('sanitizePathsDataProvider')]
+    #[Test]
     public function sanitizePaths(array $input, array $expected): void
     {
         $subject = new TemplatePaths();
@@ -64,9 +62,7 @@ final class TemplatePathsTest extends BaseTestCase
         self::assertSame($expected, $output);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function getLayoutPathAndFilenameReturnsPreviouslySetLayoutPathAndFilename(): void
     {
         $subject = new TemplatePaths();
@@ -83,10 +79,8 @@ final class TemplatePathsTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getGetterAndSetterTestValues
-     * @test
-     */
+    #[DataProvider('getGetterAndSetterTestValues')]
+    #[Test]
     public function testGetterAndSetter(string $property, array $value): void
     {
         $getter = 'get' . ucfirst($property);
@@ -97,18 +91,14 @@ final class TemplatePathsTest extends BaseTestCase
         self::assertSame($value, $subject->$getter());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testFillByPackageName(): void
     {
         $instance = new TemplatePaths('TYPO3Fluid.Fluid');
         self::assertNotEmpty($instance->getTemplateRootPaths());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testFillByConfigurationArray(): void
     {
         $instance = new TemplatePaths([
@@ -129,10 +119,8 @@ final class TemplatePathsTest extends BaseTestCase
         ];
     }
 
-    /**
-     * @dataProvider getResolveFilesMethodTestValues
-     * @test
-     */
+    #[DataProvider('getResolveFilesMethodTestValues')]
+    #[Test]
     public function testResolveFilesMethodCallsResolveFilesInFolders(string $method, string $pathsMethod): void
     {
         $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['resolveFilesInFolders'])->getMock();
@@ -141,9 +129,7 @@ final class TemplatePathsTest extends BaseTestCase
         $subject->$method('format', 'format');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testToArray(): void
     {
         $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
@@ -160,9 +146,7 @@ final class TemplatePathsTest extends BaseTestCase
         self::assertEquals($expected, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testResolveFilesInFolders(): void
     {
         $subject = new TemplatePaths();
@@ -182,9 +166,7 @@ final class TemplatePathsTest extends BaseTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetTemplateSourceThrowsExceptionIfFileNotFound(): void
     {
         $this->expectException(InvalidTemplateResourceException::class);
@@ -192,9 +174,7 @@ final class TemplatePathsTest extends BaseTestCase
         $instance->getTemplateSource();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetTemplateSourceReadsStreamWrappers(): void
     {
         $fixture = __DIR__ . '/Fixtures/LayoutFixture.html';
@@ -205,9 +185,7 @@ final class TemplatePathsTest extends BaseTestCase
         fclose($stream);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testResolveFileInPathsThrowsExceptionIfFileNotFound(): void
     {
         $this->expectException(InvalidTemplateResourceException::class);
@@ -216,9 +194,7 @@ final class TemplatePathsTest extends BaseTestCase
         $method->invoke($instance, ['/not/', '/found/'], 'notfound.html');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testGetTemplateIdentifierReturnsSourceChecksumWithControllerAndActionAndFormat(): void
     {
         $instance = new TemplatePaths();
@@ -226,9 +202,7 @@ final class TemplatePathsTest extends BaseTestCase
         self::assertSame('source_d78fda63144c5c84_DummyController_dummyAction_html', $instance->getTemplateIdentifier('DummyController', 'dummyAction'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testActionTemplateWithControllerAndAction(): void
     {
         $subject = new TemplatePaths();
@@ -240,9 +214,7 @@ final class TemplatePathsTest extends BaseTestCase
         self::assertStringStartsWith('ARandomController_action_TestTemplate_', $identifier);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function testActionTemplateWithEmptyController(): void
     {
         $subject = new TemplatePaths();


### PR DESCRIPTION
phpunit 11 deprecates annotations like `@test` and `@dataProvider` in favor of their attribute counterparts.

Based on the migration in TYPO3 core, the following rector workflow has been used:

> composer req --dev rector/rector
> wget https://forge.typo3.org/attachments/download/38273/rector.php
> find tests/ -name \*Test.php | xargs vendor/bin/rector process
> rm rector.php
> composer rem --dev rector/rector

Associated TYPO3 patch: https://github.com/TYPO3/typo3/commit/5043d3cb4d6e3069dd1a5cd4c25c9802dad855fd