### PR TITLE
[TASK] Improve test case inheritance chain

### DIFF
--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\TestCase;
  *
  * Don't subclass this test case but rather choose a more specialized base test case,
  * such as UnitTestCase or FunctionalTestCase
+ *
+ * @deprecated Will be removed in v4. Update .gitattributes to fully exclude tests/
  */
 abstract class BaseTestCase extends TestCase
 {

--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
-use TYPO3Fluid\Fluid\Tests\BaseTestCase;
 
 /**
  * Base test case for functional tests.
@@ -27,17 +27,14 @@ use TYPO3Fluid\Fluid\Tests\BaseTestCase;
  *           exported as package file. Extensions with own view helpers can not rely on it as test base.
  *           This may change in case this abstract stabilizes, later.
  */
-abstract class AbstractFunctionalTestCase extends BaseTestCase
+abstract class AbstractFunctionalTestCase extends TestCase
 {
-    /**
-     * @var FluidCacheInterface
-     */
-    protected static $cache;
+    protected static FluidCacheInterface $cache;
 
     /**
      * @var string Absolute path to cache directory
      */
-    protected static $cachePath;
+    protected static string $cachePath;
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -14,13 +14,13 @@ use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
-use TYPO3Fluid\Fluid\Tests\BaseTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\TestViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\MutableTestViewHelper;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TagBasedTestViewHelper;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
-final class ViewHelperEscapingTest extends BaseTestCase
+final class ViewHelperEscapingTest extends AbstractFunctionalTestCase
 {
     private const UNESCAPED = '<script>alert(1)</script>';
     private const ESCAPED = '&lt;script&gt;alert(1)&lt;/script&gt;';

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -14,9 +14,9 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
-final class NamespaceDetectionTemplateProcessorTest extends UnitTestCase
+final class NamespaceDetectionTemplateProcessorTest extends AbstractFunctionalTestCase
 {
     public static function preProcessSourceExtractsNamespacesDataProvider(): array
     {

--- a/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
@@ -11,10 +11,10 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits;
 
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Exception;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits\Fixtures\CompileWithContentArgumentAndRenderStaticTestTraitViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class CompileWithContentArgumentAndRenderStaticTest extends UnitTestCase
+final class CompileWithContentArgumentAndRenderStaticTest extends AbstractFunctionalTestCase
 {
     #[Test]
     public function resolveContentArgumentNameThrowsExceptionIfNoArgumentsAvailable(): void

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheWarmupResult;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class FluidCacheWarmupResultTest extends UnitTestCase
+final class FluidCacheWarmupResultTest extends TestCase
 {
     #[Test]
     public function mergeCombinesTwoResults(): void

--- a/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
+++ b/tests/Unit/Core/Cache/StandardCacheWarmerTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Cache;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Cache\StandardCacheWarmer;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
@@ -18,10 +19,9 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-final class StandardCacheWarmerTest extends UnitTestCase
+final class StandardCacheWarmerTest extends TestCase
 {
     #[Test]
     public function testDetectControllerNamesInTemplateRootPaths(): void

--- a/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
+++ b/tests/Unit/Core/Compiler/AbstractCompiledTemplateTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler\Fixtures\AbstractCompiledTemplateTestFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class AbstractCompiledTemplateTest extends UnitTestCase
+class AbstractCompiledTemplateTest extends TestCase
 {
     #[Test]
     public function setIdentifierDoesNotChangeObject(): void

--- a/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
+++ b/tests/Unit/Core/Compiler/FailedCompilingStateTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\FailedCompilingState;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class FailedCompilingStateTest extends UnitTestCase
+final class FailedCompilingStateTest extends TestCase
 {
     #[Test]
     public function getFailureReasonReturnsPreviouslySetFailureReason(): void

--- a/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
+++ b/tests/Unit/Core/Compiler/StopCompilingChildrenExceptionTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingChildrenException;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 /**
  * @deprecated Remove together with StopCompilingChildrenException
  */
-final class StopCompilingChildrenExceptionTest extends UnitTestCase
+final class StopCompilingChildrenExceptionTest extends TestCase
 {
     #[Test]
     public function setAndGetReplacementString(): void

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Compiler;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
@@ -17,9 +18,8 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class TemplateCompilerTest extends UnitTestCase
+final class TemplateCompilerTest extends TestCase
 {
     #[Test]
     public function isWarmupModeReturnsTrueAfterEnterWarmupModeHasBeenCalled(): void

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -11,13 +11,13 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class BooleanParserTest extends UnitTestCase
+final class BooleanParserTest extends TestCase
 {
     public static function getSomeEvaluationTestValues(): array
     {

--- a/tests/Unit/Core/Parser/ConfigurationTest.php
+++ b/tests/Unit/Core/Parser/ConfigurationTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ConfigurationTest extends UnitTestCase
+final class ConfigurationTest extends TestCase
 {
     #[Test]
     public function testAddInterceptor(): void

--- a/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
+++ b/tests/Unit/Core/Parser/Interceptor/EscapeTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\Interceptor;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
@@ -17,9 +18,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class EscapeTest extends UnitTestCase
+final class EscapeTest extends TestCase
 {
     #[Test]
     public function processDoesNotDisableEscapingInterceptorByDefault(): void

--- a/tests/Unit/Core/Parser/ParsingStateTest.php
+++ b/tests/Unit/Core/Parser/ParsingStateTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ParsingStateTest extends UnitTestCase
+final class ParsingStateTest extends TestCase
 {
     #[Test]
     public function getIdentifierReturnsPreviouslySetIdentifier(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -11,14 +11,14 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class AbstractNodeTest extends UnitTestCase
+class AbstractNodeTest extends TestCase
 {
     #[Test]
     public function evaluateChildNodesPassesRenderingContextToChildNodes(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ArrayNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
@@ -21,9 +22,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class BooleanNodeTest extends UnitTestCase
+final class BooleanNodeTest extends TestCase
 {
     #[Test]
     public function convertToBooleanProperlyConvertsValuesOfTypeBoolean(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/EscapingNodeTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\EscapingNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class EscapingNodeTest extends UnitTestCase
+final class EscapingNodeTest extends TestCase
 {
     #[Test]
     public function testEscapesNodeInConstructor(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/CastingExpressionNodeTest.php
@@ -11,14 +11,14 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Expression;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\CastingExpressionNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToArray;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class CastingExpressionNodeTest extends UnitTestCase
+final class CastingExpressionNodeTest extends TestCase
 {
     #[Test]
     public function testEvaluateDelegatesToEvaluteExpression(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -11,12 +11,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Expression;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\MathExpressionNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class MathExpressionNodeTest extends UnitTestCase
+final class MathExpressionNodeTest extends TestCase
 {
     public static function getEvaluateExpressionTestValues(): array
     {

--- a/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/NumericNodeTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NumericNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class NumericNodeTest extends UnitTestCase
+final class NumericNodeTest extends TestCase
 {
     #[Test]
     public function renderReturnsProperIntegerGivenInConstructor(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -11,12 +11,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ObjectAccessorNodeTest extends UnitTestCase
+final class ObjectAccessorNodeTest extends TestCase
 {
     public static function getEvaluateTestValues(): array
     {

--- a/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/RootNodeTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class RootNodeTest extends UnitTestCase
+final class RootNodeTest extends TestCase
 {
     #[Test]
     public function testEvaluateCallsEvaluateChildNodes(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/TextNodeTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class TextNodeTest extends UnitTestCase
+final class TextNodeTest extends TestCase
 {
     #[Test]
     public function renderReturnsSameStringAsGivenInConstructor(): void

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ViewHelperNodeTest extends UnitTestCase
+final class ViewHelperNodeTest extends TestCase
 {
     #[Test]
     public function getArgumentsReturnsArgumentsSetByConstructor(): void

--- a/tests/Unit/Core/Parser/TemplateParserPatternTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserPatternTest.php
@@ -11,11 +11,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class TemplateParserPatternTest extends UnitTestCase
+final class TemplateParserPatternTest extends TestCase
 {
     #[Test]
     public function testSCAN_PATTERN_NAMESPACEDECLARATION(): void

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
@@ -31,7 +32,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
 
 /**
@@ -40,7 +40,7 @@ use TYPO3Fluid\Fluid\ViewHelpers\CommentViewHelper;
  * This is to at least half a system test, as it compares rendered results to
  * expectations, and does not strictly check the parsing...
  */
-final class TemplateParserTest extends UnitTestCase
+final class TemplateParserTest extends TestCase
 {
     #[Test]
     public function testInitializeViewHelperAndAddItToStackReturnsFalseIfNamespaceIgnored(): void

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -11,13 +11,13 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\TemplateProcessor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\EscapingModifierTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class EscapingModifierTemplateProcessorTest extends UnitTestCase
+final class EscapingModifierTemplateProcessorTest extends TestCase
 {
     public static function getEscapingTestValues(): array
     {

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache;
@@ -22,10 +23,9 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-final class RenderingContextTest extends UnitTestCase
+final class RenderingContextTest extends TestCase
 {
     public static function gettersReturnPreviouslySetValuesDataProvider(): array
     {

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -11,11 +11,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Variables\ChainedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ChainedVariableProviderTest extends UnitTestCase
+final class ChainedVariableProviderTest extends TestCase
 {
     public static function getGetTestValues(): array
     {

--- a/tests/Unit/Core/Variables/JSONVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/JSONVariableProviderTest.php
@@ -11,13 +11,10 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Variables\JSONVariableProvider;
-use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 
-/**
- * @todo Validate if extending AbstractFunctionalTestCase is needed. If so, move to `Tests/Functional/*`
- */
-final class JSONVariableProviderTest extends AbstractFunctionalTestCase
+final class JSONVariableProviderTest extends TestCase
 {
     public static function provideVariablesDataProvider(): array
     {

--- a/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ScopedVariableProviderTest.php
@@ -11,11 +11,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ScopedVariableProviderTest extends UnitTestCase
+final class ScopedVariableProviderTest extends TestCase
 {
     public static function getAllDataProvider(): \Generator
     {

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -11,11 +11,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\StandardVariableProviderModelFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class StandardVariableProviderTest extends UnitTestCase
+final class StandardVariableProviderTest extends TestCase
 {
     #[Test]
     public function getSourceReturnsEmptyArray(): void

--- a/tests/Unit/Core/Variables/VariableExtractorTest.php
+++ b/tests/Unit/Core/Variables/VariableExtractorTest.php
@@ -11,13 +11,13 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableExtractor;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithoutToString;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\ClassWithMagicGetter;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class VariableExtractorTest extends UnitTestCase
+final class VariableExtractorTest extends TestCase
 {
     public static function getPathTestValues(): array
     {

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -10,11 +10,11 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class AbstractTagBasedViewHelperTest extends UnitTestCase
+class AbstractTagBasedViewHelperTest extends TestCase
 {
     #[Test]
     public function renderCallsRenderOnTagBuilder(): void

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -21,9 +22,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeDefaultRenderStaticViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\RenderMethodFreeViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class AbstractViewHelperTest extends UnitTestCase
+class AbstractViewHelperTest extends TestCase
 {
     public static function getFirstElementOfNonEmptyTestValues(): array
     {

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ArgumentDefinitionTest extends UnitTestCase
+final class ArgumentDefinitionTest extends TestCase
 {
     #[Test]
     public function objectStoresDataCorrectly(): void

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class TagBuilderTest extends UnitTestCase
+final class TagBuilderTest extends TestCase
 {
     #[Test]
     public function constructorSetsTagName(): void

--- a/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
+++ b/tests/Unit/Core/ViewHelper/Traits/ParserRuntimeOnlyTest.php
@@ -10,15 +10,15 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Traits\Fixtures\ParserRuntimeOnlyFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
 /**
  * @deprecated remove together with ParserRuntimeOnly.
  */
-final class ParserRuntimeOnlyTest extends UnitTestCase
+final class ParserRuntimeOnlyTest extends TestCase
 {
     #[Test]
     public function renderReturnsNull(): void

--- a/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperInvokerTest.php
@@ -11,12 +11,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-final class ViewHelperInvokerTest extends UnitTestCase
+final class ViewHelperInvokerTest extends TestCase
 {
     public static function getInvocationTestValues(): array
     {

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -11,12 +11,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\ViewHelpers\RenderViewHelper;
 
-final class ViewHelperResolverTest extends UnitTestCase
+final class ViewHelperResolverTest extends TestCase
 {
     #[Test]
     public function addNamespaceWithStringRecordsNamespace(): void

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
-final class ViewHelperVariableContainerTest extends UnitTestCase
+final class ViewHelperVariableContainerTest extends TestCase
 {
     #[Test]
     public function storedDataCanBeReadOutAgain(): void

--- a/tests/Unit/Schema/SchemaGeneratorTest.php
+++ b/tests/Unit/Schema/SchemaGeneratorTest.php
@@ -11,12 +11,12 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Schema;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Schema\SchemaGenerator;
 use TYPO3Fluid\Fluid\Schema\ViewHelperMetadata;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class SchemaGeneratorTest extends UnitTestCase
+class SchemaGeneratorTest extends TestCase
 {
     public static function generateSchemaDataProvider(): iterable
     {

--- a/tests/Unit/Schema/ViewHelperMetadataFactoryTest.php
+++ b/tests/Unit/Schema/ViewHelperMetadataFactoryTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Schema;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Schema\ViewHelperMetadataFactory;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\AbstractViewHelper;
@@ -21,9 +22,8 @@ use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\WithoutClassSuffix;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\WithoutDocumentationViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\WithoutInterfaceViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\WrongDirectoryViewHelper;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class ViewHelperMetadataFactoryTest extends UnitTestCase
+class ViewHelperMetadataFactoryTest extends TestCase
 {
     public static function createObjectDataProvider(): iterable
     {

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate;
 use TYPO3Fluid\Fluid\Core\ErrorHandler\StandardErrorHandler;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -18,11 +19,10 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\AbstractTemplateViewTestFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 
-class AbstractTemplateViewTest extends UnitTestCase
+class AbstractTemplateViewTest extends TestCase
 {
     #[Test]
     public function getRenderingContextReturnsPreviouslySetRenderingContext(): void

--- a/tests/Unit/View/AbstractViewTest.php
+++ b/tests/Unit/View/AbstractViewTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Tests\Unit\View\Fixtures\AbstractViewTestFixture;
-use TYPO3Fluid\Fluid\Tests\UnitTestCase;
 
-class AbstractViewTest extends UnitTestCase
+class AbstractViewTest extends TestCase
 {
     #[Test]
     public function renderReturnsEmptyString(): void

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -11,11 +11,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Tests\BaseTestCase;
+use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
-final class TemplatePathsTest extends BaseTestCase
+final class TemplatePathsTest extends TestCase
 {
     public static function sanitizePathDataProvider(): array
     {

--- a/tests/UnitTestCase.php
+++ b/tests/UnitTestCase.php
@@ -16,5 +16,7 @@ namespace TYPO3Fluid\Fluid\Tests;
  * to extend this class for unit test cases instead of the base test case because if,
  * at some point, specific behavior needs to be implemented for unit tests, your test cases
  * will profit from it automatically.
+ *
+ * @deprecated Will be removed in v4. Update .gitattributes to fully exclude tests/
  */
 abstract class UnitTestCase extends BaseTestCase {}


### PR DESCRIPTION
BaseTestCase and UnitTestCase contain only deprecated methods. Change unit tests to extend from phpunit
TestCase directly and mark the two classes deprecated.