### PR TITLE
[TASK] Avoid pre PHP 8.0 code switches

### DIFF
--- a/tests/Functional/Cases/Conditions/BasicConditionsTest.php
+++ b/tests/Functional/Cases/Conditions/BasicConditionsTest.php
@@ -23,14 +23,11 @@ final class BasicConditionsTest extends AbstractFunctionalTestCase
             ['1 != 2', true],
             ['1 == 2', false],
             ['1 === 1', true],
-            // expected value based on php versions behaviour
-            ['\'foo\' == 0', PHP_VERSION_ID < 80000],
-            // expected value based on php versions behaviour
-            ['1.1 >= \'foo\'', PHP_VERSION_ID < 80000],
+            ['\'foo\' == 0', false],
+            ['1.1 >= \'foo\'', false],
             ['\'String containing word \"false\" in text\'', true],
             ['\'  FALSE  \'', true],
-            // expected value based on php versions behaviour
-            ['\'foo\' > 0', !(PHP_VERSION_ID < 80000)],
+            ['\'foo\' > 0', true],
             ['FALSE', false],
             ['(FALSE || (FALSE || 1)', true],
             ['(FALSE or (FALSE or 1)', true],

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -97,11 +97,9 @@ final class BooleanParserTest extends TestCase
             ['0 OR 0', false],
             ['0 OR 1', true],
 
-            // edge cases as per https://github.com/TYPO3Fluid/Fluid/issues/7
-            // expected value based on php versions behaviour
-            ['\'foo\' == 0', (PHP_VERSION_ID < 80000 ? true : false)],
-            ['1.1 >= foo', (PHP_VERSION_ID < 80000 ? true : false)],
-            ['\'foo\' > 0', (PHP_VERSION_ID < 80000 ? false : true)],
+            ['\'foo\' == 0', false],
+            ['1.1 >= foo', false],
+            ['\'foo\' > 0', true],
 
             ['{foo}', true, ['foo' => true]],
             ['{foo} == FALSE', true, ['foo' => false]],

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -466,11 +466,9 @@ final class BooleanNodeTest extends TestCase
     public function equalsReturnsTrueIfComparingStringWithZero(): void
     {
         $renderingContext = new RenderingContext();
-        // expected value based on php versions behaviour
-        $expected = (PHP_VERSION_ID < 80000 ? true : false);
         $rootNode = new RootNode();
         $rootNode->addChildNode(new TextNode('\'stringA\' == 0'));
-        self::assertSame($expected, BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
+        self::assertFalse(BooleanNode::createFromNodeAndEvaluate($rootNode, $renderingContext));
     }
 
     #[Test]


### PR DESCRIPTION
Releases: main, 2.13, 2.12