### PR TITLE
[BUGFIX] Correct attribute name in ConstantViewHelper example

### DIFF
--- a/src/ViewHelpers/ConstantViewHelper.php
+++ b/src/ViewHelpers/ConstantViewHelper.php
@@ -23,7 +23,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * ::
  *
- *    {f:constant(value: 'PHP_INT_MAX')}
+ *    {f:constant(name: 'PHP_INT_MAX')}
  *
  * Output::
  *
@@ -35,14 +35,14 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  *
  * ::
  *
- *    {f:constant(value: '\Vendor\Package\Class::CONSTANT')}
+ *    {f:constant(name: '\Vendor\Package\Class::CONSTANT')}
  *
  * Get enum value
  * --------------
  *
  * ::
  *
- *    {f:constant(value: '\Vendor\Package\Enum::CASE')}
+ *    {f:constant(name: '\Vendor\Package\Enum::CASE')}
  */
 class ConstantViewHelper extends AbstractViewHelper
 {


### PR DESCRIPTION
The attribute in `ConstantViewHelper` is called `name`, but the documentation references it as `value`. This PR fixes the examples in the documentation.