### PR TITLE
[TASK] Avoid implicitly nullable method parameter

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,10 @@ return (new PhpCsFixer\Config())
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_whitespace_in_blank_line' => true,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
+        'nullable_type_declaration_for_default_null_value' => true,
         'ordered_imports' => true,
         'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
         'php_unit_mock_short_will_return' => true,

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -583,7 +583,7 @@ class TemplateParser
         return $argumentsObjectTree + $undeclaredArguments;
     }
 
-    protected function isArgumentEscaped(ViewHelperInterface $viewHelper, ArgumentDefinition $argumentDefinition = null)
+    protected function isArgumentEscaped(ViewHelperInterface $viewHelper, ?ArgumentDefinition $argumentDefinition = null)
     {
         $hasDefinition = $argumentDefinition instanceof ArgumentDefinition;
         $isBoolean = $hasDefinition && ($argumentDefinition->getType() === 'boolean' || $argumentDefinition->getType() === 'bool');
@@ -752,7 +752,7 @@ class TemplateParser
      * @return NodeInterface[] the array node built up
      * @throws Exception
      */
-    protected function recursiveArrayHandler(ParsingState $state, $arrayText, ViewHelperInterface $viewHelper = null)
+    protected function recursiveArrayHandler(ParsingState $state, $arrayText, ?ViewHelperInterface $viewHelper = null)
     {
         $undeclaredArguments = [];
         $argumentDefinitions = [];

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -40,7 +40,7 @@ class ViewHelperInvoker
      * @param \Closure|null $renderChildrenClosure
      * @return string
      */
-    public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, \Closure $renderChildrenClosure = null)
+    public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null)
     {
         $viewHelperResolver = $renderingContext->getViewHelperResolver();
         if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -54,7 +54,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      *
      * @param RenderingContextInterface|null $context
      */
-    public function __construct(RenderingContextInterface $context = null)
+    public function __construct(?RenderingContextInterface $context = null)
     {
         if (!$context) {
             $context = new RenderingContext();

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -33,7 +33,7 @@ final class ChainedVariableProviderTest extends TestCase
 
     #[DataProvider('getGetTestValues')]
     #[Test]
-    public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
+    public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, ?string $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
         $subject->setSource($local);
@@ -42,7 +42,7 @@ final class ChainedVariableProviderTest extends TestCase
 
     #[DataProvider('getGetTestValues')]
     #[Test]
-    public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, string|null $expected): void
+    public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, ?string $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
         $subject->setSource($local);

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -45,7 +45,7 @@ class AbstractViewHelperTest extends TestCase
 
     #[DataProvider('getFirstElementOfNonEmptyTestValues')]
     #[Test]
-    public function getFirstElementOfNonEmptyReturnsExpectedValue(mixed $input, string|null $expected): void
+    public function getFirstElementOfNonEmptyReturnsExpectedValue(mixed $input, ?string $expected): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
         $method = new \ReflectionMethod($subject, 'getFirstElementOfNonEmpty');


### PR DESCRIPTION
Implicit nullable method parameters are deprecated with PHP 8.4. The patch prepares affected method
signatures and activates an according php-cs-fixer rule.