### PR TITLE
[TASK] Avoid registerArgument() with required=false

### DIFF
--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -78,9 +78,9 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      */
     public function initializeArguments()
     {
-        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', false);
-        $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.', false);
-        $this->registerArgument('aria', 'array', 'Additional aria-* attributes. They will each be added with a "aria-" prefix.', false);
+        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.');
+        $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.');
+        $this->registerArgument('aria', 'array', 'Additional aria-* attributes. They will each be added with a "aria-" prefix.');
     }
 
     /**

--- a/src/ViewHelpers/FirstViewHelper.php
+++ b/src/ViewHelpers/FirstViewHelper.php
@@ -33,7 +33,7 @@ final class FirstViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'array', '', false);
+        $this->registerArgument('value', 'array', '');
     }
 
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -90,7 +90,7 @@ class ForViewHelper extends AbstractViewHelper
         parent::initializeArguments();
         $this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', true);
         $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
-        $this->registerArgument('key', 'string', 'Variable to assign array key to', false);
+        $this->registerArgument('key', 'string', 'Variable to assign array key to');
         $this->registerArgument('reverse', 'boolean', 'If true, iterates in reverse', false, false);
         $this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, total, isFirst, isLast, isEven, isOdd)');
     }

--- a/src/ViewHelpers/Format/CaseViewHelper.php
+++ b/src/ViewHelpers/Format/CaseViewHelper.php
@@ -103,7 +103,7 @@ final class CaseViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'string', 'The input value. If not given, the evaluated child nodes will be used.', false);
+        $this->registerArgument('value', 'string', 'The input value. If not given, the evaluated child nodes will be used.');
         $this->registerArgument('mode', 'string', 'The case to apply, must be one of this\' CASE_* constants. Defaults to uppercase application.', false, self::CASE_UPPER);
     }
 

--- a/src/ViewHelpers/Format/TrimViewHelper.php
+++ b/src/ViewHelpers/Format/TrimViewHelper.php
@@ -85,8 +85,8 @@ final class TrimViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'string', 'The string value to be trimmed. If not given, the evaluated child nodes will be used.', false);
-        $this->registerArgument('characters', 'string', 'Optionally, the stripped characters can also be specified using the characters parameter. Simply list all characters that you want to be stripped. With .. you can specify a range of characters.', false);
+        $this->registerArgument('value', 'string', 'The string value to be trimmed. If not given, the evaluated child nodes will be used.');
+        $this->registerArgument('characters', 'string', 'Optionally, the stripped characters can also be specified using the characters parameter. Simply list all characters that you want to be stripped. With .. you can specify a range of characters.');
         $this->registerArgument('side', 'string', 'The side to apply, must be one of this\' CASE_* constants. Defaults to both application.', false, self::SIDE_BOTH);
     }
 

--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -62,9 +62,9 @@ final class JoinViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'array', 'An array', false);
+        $this->registerArgument('value', 'array', 'An array');
         $this->registerArgument('separator', 'string', 'The separator', false, '');
-        $this->registerArgument('separatorLast', 'string', 'The separator for the last pair.', false, null);
+        $this->registerArgument('separatorLast', 'string', 'The separator for the last pair.');
     }
 
     /**

--- a/src/ViewHelpers/LastViewHelper.php
+++ b/src/ViewHelpers/LastViewHelper.php
@@ -33,7 +33,7 @@ final class LastViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'array', '', false);
+        $this->registerArgument('value', 'array', '');
     }
 
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed

--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -61,8 +61,8 @@ final class ReplaceViewHelper extends AbstractViewHelper
 
     public function initializeArguments(): void
     {
-        $this->registerArgument('value', 'string', '', false);
-        $this->registerArgument('search', 'mixed', '', false);
+        $this->registerArgument('value', 'string', '');
+        $this->registerArgument('search', 'mixed', '');
         $this->registerArgument('replace', 'mixed', '', true);
     }
 

--- a/tests/Functional/ViewHelpers/StaticCacheable/Fixtures/ViewHelpers/CompilableViewHelper.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/Fixtures/ViewHelpers/CompilableViewHelper.php
@@ -23,7 +23,7 @@ final class CompilableViewHelper extends AbstractViewHelper
     public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerArgument('page', 'int', 'The page', false);
+        $this->registerArgument('page', 'int', 'The page');
     }
 
     public static function renderStatic(


### PR DESCRIPTION
$required defaults to 'false' and does not need
to be set explicitly when there are no further
non-default arguments.