### PR TITLE
[!!!][TASK] Throw exception for https namespaces

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -13,6 +13,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser;
 abstract class Patterns
 {
     public const NAMESPACEPREFIX = 'http://typo3.org/ns/';
+    public const NAMESPACEPREFIX_INVALID = 'https://typo3.org/ns/';
     public const NAMESPACESUFFIX = '/ViewHelpers';
 
     /**

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -7,6 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor;
 
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -96,9 +97,14 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
             preg_match_all('/' . $namespacePattern . '/', $matches[0], $namespaces, PREG_SET_ORDER);
             foreach ($namespaces as $set) {
                 $namespaceUrl = trim($set[2], '"\'');
-                if (strpos($namespaceUrl, Patterns::NAMESPACEPREFIX) === 0) {
+                if (str_starts_with($namespaceUrl, Patterns::NAMESPACEPREFIX)) {
                     $namespaceUri = substr($namespaceUrl, 20);
                     $namespacePhp = str_replace('/', '\\', $namespaceUri);
+                } elseif (str_starts_with($namespaceUrl, Patterns::NAMESPACEPREFIX_INVALID)) {
+                    throw new Exception(
+                        'Invalid Fluid namespace definition detected: ' . $namespaceUrl . '. Namespaces must always start with ' . Patterns::NAMESPACEPREFIX . '.',
+                        1721467847,
+                    );
                 } elseif (!preg_match('/([^a-z0-9_\\\\]+)/i', $namespaceUrl)) {
                     $namespacePhp = $namespaceUrl;
                     $namespacePhp = preg_replace('/\\\\{2,}/', '\\', $namespacePhp);

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\TemplateProcessor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
@@ -46,6 +47,14 @@ final class NamespaceDetectionTemplateProcessorTest extends AbstractFunctionalTe
             ],
             'ignores unknown namespaces' => [
                 '<html xmlns:unknown="http://not.from.here/ns/something" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
+                [
+                    'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
+                    'unknown' => null,
+                ],
+                PHP_EOL,
+            ],
+            'ignores unknown namespaces with https' => [
+                '<html xmlns:unknown="https://not.from.here/ns/something" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>',
                 [
                     'f' => ['TYPO3Fluid\Fluid\ViewHelpers'],
                     'unknown' => null,
@@ -108,5 +117,15 @@ final class NamespaceDetectionTemplateProcessorTest extends AbstractFunctionalTe
         $result = $subject->preProcessSource($templateSource);
         self::assertSame($expectedSource, $result);
         self::assertSame($expectedNamespaces, $viewHelperResolver->getNamespaces());
+    }
+
+    #[Test]
+    public function throwsErrorForInvalidFluidNamespace(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(1721467847);
+        $subject = new NamespaceDetectionTemplateProcessor();
+        $subject->setRenderingContext(new RenderingContext());
+        $subject->preProcessSource('<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers" xmlns:z="https://typo3.org/ns/X/Z/ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>');
     }
 }


### PR DESCRIPTION
One way to make custom ViewHelpers available in Fluid templates is to define them as xml namespaces. Fluid parses `<html>` tags in templates, extracts all XML namespaces relevant to Fluid and removes them from the resulting HTML output.

XML namespaces by convention are usually named as URIs. However, they are actually not "callable" URLs but rather unique identifiers. Thus, there is only one valid way to reference Fluid namespaces as xml namespaces: By using the following schema:

```
http://typo3.org/ns/$Vendor/$Package/ViewHelpers/
```

Using https instead of http is invalid. Previously, Fluid namespaces defined with https instead of http were ignored and kept in the resulting output. Now, we catch this bug in templates and throw an exception instead to make tempate authors aware that there is an issue in their template.

This change might break existing templates. However, this is easily avoidable by checking that no template in your project includes the following string:

``` 
https://typo3.org/ns/
```