### PR TITLE
[TASK] Allow registerArgument() to override arguments

### DIFF
--- a/Documentation/Changelog/2.x.rst
+++ b/Documentation/Changelog/2.x.rst
@@ -6,6 +6,18 @@
 Changelog 2.x
 =============
 
+2.14
+----
+
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`
+  has been marked as deprecated. It will log a deprecation level error message when called in
+  Fluid v4. It will be removed in Fluid v5.
+  :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->registerArgument()` now no longer throws
+  an exception if an argument is already defined, so calls to
+  :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`
+  can be replaced with :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->registerArgument()`.
+
+
 2.12
 ----
 

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -148,7 +148,8 @@ abstract class AbstractViewHelper implements ViewHelperInterface
 
     /**
      * Register a new argument. Call this method from your ViewHelper subclass
-     * inside the initializeArguments() method.
+     * inside the initializeArguments() method. If an argument with the same name
+     * is already defined, it will be overridden.
      *
      * @param string $name Name of the argument
      * @param string $type Type of the argument
@@ -157,17 +158,10 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * @param mixed $defaultValue Default value of argument. Will be used if the argument is not set.
      * @param bool|null $escape Can be toggled to true to force escaping of variables and inline syntax passed as argument value.
      * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
-     * @throws Exception
      * @api
      */
     protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
     {
-        if (array_key_exists($name, $this->argumentDefinitions)) {
-            throw new Exception(
-                'Argument "' . $name . '" has already been defined, thus it should not be defined again.',
-                1253036401,
-            );
-        }
         $this->argumentDefinitions[$name] = new ArgumentDefinition($name, $type, $description, $required, $defaultValue, $escape);
         return $this;
     }
@@ -186,6 +180,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * @return \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper $this, to allow chaining.
      * @throws Exception
      * @api
+     * @deprecated Will log deprecation in v4, will be removed in v5. No longer necessary since self::registerArgument() now allows overriding
      */
     protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
     {

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -67,13 +67,16 @@ class AbstractViewHelperTest extends TestCase
     }
 
     #[Test]
-    public function registeringTheSameArgumentNameAgainThrowsException(): void
+    public function registeringTheSameArgumentNameAgainOverridesArgument(): void
     {
-        $this->expectException(\Exception::class);
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
         $method = new \ReflectionMethod($subject, 'registerArgument');
         $method->invoke($subject, 'someName', 'string', 'desc', true);
-        $method->invoke($subject, 'someName', 'integer', 'desc', true);
+        $method->invoke($subject, 'someName', 'integer', 'changed desc', true);
+        $expected = [
+            'someName' => new ArgumentDefinition('someName', 'integer', 'changed desc', true),
+        ];
+        self::assertEquals($expected, $subject->prepareArguments());
     }
 
     #[Test]


### PR DESCRIPTION
Previously, `overrideArgument()` needed to be used to override an existing ViewHelper argument. With this change, `registerArgument()` no longer throws an exception if an argument with the same name already exists. This simplifies the ViewHelper API.

Since it is no longer necessary with this change, `overrideArgument()` is now deprecated.