### PR TITLE
[TASK] Introduce type hints to ViewHelper-related API

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -9,6 +9,8 @@ Changelog 4.x
 4.0
 ---
 
+* Breaking: Careful addition of method and property type hints throughout the system.
+  This should be only mildly breaking and projects should be able to adapt easily.
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`
   now emits a E_USER_DEPRECATED level error.
 * Deprecation: Calling method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper->registerUniversalTagAttributes()`

--- a/examples/src/CustomViewHelperResolver.php
+++ b/examples/src/CustomViewHelperResolver.php
@@ -25,12 +25,8 @@ class CustomViewHelperResolver extends ViewHelperResolver
      * Returns the built-in set of ViewHelper classes with
      * one addition, `f:myLink` which is redirected to anoter
      * class.
-     *
-     * @param string $namespaceIdentifier
-     * @param string $methodIdentifier
-     * @return string
      */
-    public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier)
+    public function resolveViewHelperClassName(string $namespaceIdentifier, string $methodIdentifier): string
     {
         if ($namespaceIdentifier === 'f' && $methodIdentifier === 'myLink') {
             return CustomViewHelper::class;
@@ -43,10 +39,9 @@ class CustomViewHelperResolver extends ViewHelperResolver
      * a case which matches our custom ViewHelper in order to
      * manipulate its argument definitions.
      *
-     * @param ViewHelperInterface $viewHelper
      * @return ArgumentDefinition[]
      */
-    public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper)
+    public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper): array
     {
         $arguments = parent::getArgumentDefinitionsForViewHelper($viewHelper);
         if ($viewHelper instanceof CustomViewHelper) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,24 +66,9 @@ parameters:
 			path: src/Core/ViewHelper/AbstractViewHelper.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\|string and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Core/ViewHelper/ViewHelperResolver.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between class\\-string and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/Core/ViewHelper/ViewHelperResolver.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/Core/ViewHelper/ViewHelperVariableContainer.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Core/ViewHelper/ViewHelperVariableContainer.php
 
 		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface\\:\\:getTemplatePaths\\(\\)\\.$#"

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -35,7 +35,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * ViewHelper class many times throughout the rendering process.
      * @var array
      */
-    private static $argumentDefinitionCache = [];
+    private static array $argumentDefinitionCache = [];
 
     /**
      * Current view helper node

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -14,38 +16,28 @@ class ArgumentDefinition
 {
     /**
      * Name of argument
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Type of argument
-     *
-     * @var string
      */
-    protected $type;
+    protected string $type;
 
     /**
      * Description of argument
-     *
-     * @var string
      */
-    protected $description;
+    protected string $description;
 
     /**
      * Is argument required?
-     *
-     * @var bool
      */
-    protected $required = false;
+    protected bool $required = false;
 
     /**
      * Default value for argument
-     *
-     * @var mixed
      */
-    protected $defaultValue;
+    protected mixed $defaultValue;
 
     /**
      * Escaping instruction, in line with $this->escapeOutput / $this->escapeChildren on ViewHelpers.
@@ -57,10 +49,8 @@ class ArgumentDefinition
      *
      * "false" means "never escape argument" (as in behavior of f:format.raw, which supports both passing
      * argument as actual argument or as tag content, but wants neither to be escaped).
-     *
-     * @var bool|null
      */
-    protected $escape;
+    protected ?bool $escape;
 
     /**
      * Constructor for this argument definition.
@@ -72,7 +62,7 @@ class ArgumentDefinition
      * @param mixed $defaultValue Default value
      * @param bool|null $escape Whether argument is escaped, or uses default escaping behavior (see class var comment)
      */
-    public function __construct($name, $type, $description, $required, $defaultValue = null, $escape = null)
+    public function __construct(string $name, string $type, string $description, bool $required, mixed $defaultValue = null, ?bool $escape = null)
     {
         $this->name = $name;
         $this->type = $type;
@@ -87,7 +77,7 @@ class ArgumentDefinition
      *
      * @return string Name of argument
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -97,7 +87,7 @@ class ArgumentDefinition
      *
      * @return string Type of argument
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -107,7 +97,7 @@ class ArgumentDefinition
      *
      * @return string Description of argument
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -117,7 +107,7 @@ class ArgumentDefinition
      *
      * @return bool true if argument is optional
      */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->required;
     }
@@ -127,7 +117,7 @@ class ArgumentDefinition
      *
      * @return mixed Default value
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): mixed
     {
         return $this->defaultValue;
     }
@@ -135,7 +125,7 @@ class ArgumentDefinition
     /**
      * @return bool|null
      */
-    public function getEscape()
+    public function getEscape(): ?bool
     {
         return $this->escape;
     }

--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -16,46 +18,37 @@ class TagBuilder
 {
     /**
      * Name of the Tag to be rendered
-     *
-     * @var string
      */
-    protected $tagName = '';
+    protected string $tagName = '';
 
     /**
      * Content of the tag to be rendered
-     *
-     * @var string
      */
-    protected $content = '';
+    protected ?string $content = '';
 
     /**
      * Attributes of the tag to be rendered
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    protected $attributes = [];
+    protected array $attributes = [];
 
     /**
      * Specifies whether this tag needs a closing tag.
      * E.g. <textarea> cant be self-closing even if its empty
-     *
-     * @var bool
      */
-    protected $forceClosingTag = false;
+    protected bool $forceClosingTag = false;
 
-    /**
-     * @var bool
-     */
-    protected $ignoreEmptyAttributes = false;
+    protected bool $ignoreEmptyAttributes = false;
 
     /**
      * Constructor
      *
      * @param string $tagName name of the tag to be rendered
-     * @param string $tagContent content of the tag to be rendered
+     * @param string|null $tagContent content of the tag to be rendered
      * @api
      */
-    public function __construct($tagName = '', $tagContent = '')
+    public function __construct(string $tagName = '', ?string $tagContent = '')
     {
         $this->setTagName($tagName);
         $this->setContent($tagContent);
@@ -67,7 +60,7 @@ class TagBuilder
      * @param string $tagName name of the tag to be rendered
      * @api
      */
-    public function setTagName($tagName)
+    public function setTagName(string $tagName): void
     {
         $this->tagName = $tagName;
     }
@@ -78,7 +71,7 @@ class TagBuilder
      * @return string tag name of the tag to be rendered
      * @api
      */
-    public function getTagName()
+    public function getTagName(): string
     {
         return $this->tagName;
     }
@@ -86,10 +79,10 @@ class TagBuilder
     /**
      * Sets the content of the tag
      *
-     * @param string $tagContent content of the tag to be rendered
+     * @param string|null $tagContent content of the tag to be rendered
      * @api
      */
-    public function setContent($tagContent)
+    public function setContent(?string $tagContent): void
     {
         $this->content = $tagContent;
     }
@@ -97,10 +90,10 @@ class TagBuilder
     /**
      * Gets the content of the tag
      *
-     * @return string content of the tag to be rendered
+     * @return string|null content of the tag to be rendered
      * @api
      */
-    public function getContent()
+    public function getContent(): ?string
     {
         return $this->content;
     }
@@ -111,7 +104,7 @@ class TagBuilder
      * @return bool true if tag contains text
      * @api
      */
-    public function hasContent()
+    public function hasContent(): bool
     {
         return $this->content !== '' && $this->content !== null;
     }
@@ -120,10 +113,9 @@ class TagBuilder
      * Set this to true to force a closing tag
      * E.g. <textarea> cant be self-closing even if its empty
      *
-     * @param bool $forceClosingTag
      * @api
      */
-    public function forceClosingTag($forceClosingTag)
+    public function forceClosingTag(bool $forceClosingTag): void
     {
         $this->forceClosingTag = $forceClosingTag;
     }
@@ -135,7 +127,7 @@ class TagBuilder
      * @return bool true if the tag has an attribute with the given name
      * @api
      */
-    public function hasAttribute($attributeName)
+    public function hasAttribute(string $attributeName): bool
     {
         return array_key_exists($attributeName, $this->attributes);
     }
@@ -147,7 +139,7 @@ class TagBuilder
      * @return string|null The attribute value or null if the attribute is not registered
      * @api
      */
-    public function getAttribute($attributeName)
+    public function getAttribute(string $attributeName): ?string
     {
         if (!$this->hasAttribute($attributeName)) {
             return null;
@@ -161,15 +153,12 @@ class TagBuilder
      * @return array Attributes indexed by attribute name
      * @api
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
 
-    /**
-     * @param bool $ignoreEmptyAttributes
-     */
-    public function ignoreEmptyAttributes($ignoreEmptyAttributes)
+    public function ignoreEmptyAttributes(bool $ignoreEmptyAttributes): void
     {
         $this->ignoreEmptyAttributes = $ignoreEmptyAttributes;
         if ($ignoreEmptyAttributes) {
@@ -188,12 +177,12 @@ class TagBuilder
      * @param bool $escapeSpecialCharacters apply htmlspecialchars to attribute value
      * @api
      */
-    public function addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters = true)
+    public function addAttribute(string $attributeName, $attributeValue, bool $escapeSpecialCharacters = true): void
     {
         if ($escapeSpecialCharacters) {
             $attributeName = htmlspecialchars($attributeName);
         }
-        if (is_array($attributeValue) || $attributeValue instanceof \Traversable) {
+        if (is_iterable($attributeValue)) {
             if (!in_array($attributeName, ['data', 'aria'], true)) {
                 throw new \InvalidArgumentException(
                     sprintf('Value of tag attribute "%s" cannot be of type array.', $attributeName),
@@ -219,10 +208,10 @@ class TagBuilder
      * Adds attributes to the $attributes-collection
      *
      * @param array $attributes collection of attributes to add. key = attribute name, value = attribute value
-     * @param bool $escapeSpecialCharacters apply htmlspecialchars to attribute values#
+     * @param bool $escapeSpecialCharacters apply htmlspecialchars to attribute values
      * @api
      */
-    public function addAttributes(array $attributes, $escapeSpecialCharacters = true)
+    public function addAttributes(array $attributes, bool $escapeSpecialCharacters = true): void
     {
         foreach ($attributes as $attributeName => $attributeValue) {
             $this->addAttribute($attributeName, $attributeValue, $escapeSpecialCharacters);
@@ -235,7 +224,7 @@ class TagBuilder
      * @param string $attributeName name of the attribute to be removed from the tag
      * @api
      */
-    public function removeAttribute($attributeName)
+    public function removeAttribute(string $attributeName): void
     {
         unset($this->attributes[$attributeName]);
     }
@@ -245,7 +234,7 @@ class TagBuilder
      *
      * @api
      */
-    public function reset()
+    public function reset(): void
     {
         $this->tagName = '';
         $this->content = '';
@@ -256,10 +245,9 @@ class TagBuilder
     /**
      * Renders and returns the tag
      *
-     * @return string
      * @api
      */
-    public function render()
+    public function render(): string
     {
         if (empty($this->tagName)) {
             return '';

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -34,13 +36,9 @@ class ViewHelperInvoker
      * Invoke the ViewHelper described by the ViewHelperNode, the properties
      * of which will already have been filled by the ViewHelperResolver.
      *
-     * @param string|ViewHelperInterface $viewHelperClassNameOrInstance
-     * @param array<string, mixed> $arguments
-     * @param RenderingContextInterface $renderingContext
-     * @param \Closure|null $renderChildrenClosure
      * @return string
      */
-    public function invoke($viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null)
+    public function invoke(string|ViewHelperInterface $viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null)
     {
         $viewHelperResolver = $renderingContext->getViewHelperResolver();
         if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -23,25 +25,19 @@ use TYPO3Fluid\Fluid\Core\Parser\Patterns;
  */
 class ViewHelperResolver
 {
-    /**
-     * @var array
-     */
-    protected $resolvedViewHelperClassNames = [];
+    protected array $resolvedViewHelperClassNames = [];
 
     /**
      * Namespaces requested by the template being rendered,
      * in [shortname => phpnamespace] format.
      *
-     * @var array
+     * @var array<string, string[]|null>
      */
-    protected $namespaces = [
+    protected array $namespaces = [
         'f' => ['TYPO3Fluid\\Fluid\\ViewHelpers'],
     ];
 
-    /**
-     * @return array
-     */
-    public function getNamespaces()
+    public function getNamespaces(): array
     {
         return $this->namespaces;
     }
@@ -78,11 +74,8 @@ class ViewHelperResolver
      * you need to remove or replace previously added namespaces. Be aware
      * that setNamespaces() also removes the default "f" namespace, so
      * when you use this method you should always include the "f" namespace.
-     *
-     * @param string $identifier
-     * @param string|array $phpNamespace
      */
-    public function addNamespace($identifier, $phpNamespace)
+    public function addNamespace(string $identifier, string|array|null $phpNamespace): void
     {
         if (!array_key_exists($identifier, $this->namespaces) || $this->namespaces[$identifier] === null) {
             $this->namespaces[$identifier] = $phpNamespace === null ? null : (array)$phpNamespace;
@@ -98,10 +91,8 @@ class ViewHelperResolver
      * clearing the already added namespaces. Utility method mainly
      * used in compiled templates, where some namespaces can be added
      * from outside and some can be added from compiled values.
-     *
-     * @param array $namespaces
      */
-    public function addNamespaces(array $namespaces)
+    public function addNamespaces(array $namespaces): void
     {
         foreach ($namespaces as $identifier => $namespace) {
             $this->addNamespace($identifier, $namespace);
@@ -119,7 +110,7 @@ class ViewHelperResolver
      * @param string $fluidNamespace
      * @return string
      */
-    public function resolvePhpNamespaceFromFluidNamespace($fluidNamespace)
+    public function resolvePhpNamespaceFromFluidNamespace(string $fluidNamespace): string
     {
         $namespace = $fluidNamespace;
         $suffixLength = strlen(Patterns::NAMESPACESUFFIX);
@@ -149,10 +140,8 @@ class ViewHelperResolver
      * belonged to "f" as a new alias and use that in your templates.
      *
      * Use getNamespaces() to get an array of currently added namespaces.
-     *
-     * @param array $namespaces
      */
-    public function setNamespaces(array $namespaces)
+    public function setNamespaces(array $namespaces): void
     {
         $this->namespaces = [];
         foreach ($namespaces as $identifier => $phpNamespace) {
@@ -165,10 +154,9 @@ class ViewHelperResolver
      * if the namespace is unknown, causing the tag to be rendered
      * without processing.
      *
-     * @param string $namespaceIdentifier
      * @return bool true if the given namespace is valid
      */
-    public function isNamespaceValid($namespaceIdentifier)
+    public function isNamespaceValid(string $namespaceIdentifier): bool
     {
         if (!array_key_exists($namespaceIdentifier, $this->namespaces)) {
             return false;
@@ -184,7 +172,7 @@ class ViewHelperResolver
      * @param string $namespaceIdentifier
      * @return bool true if the given namespace is valid
      */
-    public function isNamespaceValidOrIgnored($namespaceIdentifier)
+    public function isNamespaceValidOrIgnored(string $namespaceIdentifier): bool
     {
         if ($this->isNamespaceValid($namespaceIdentifier) === true) {
             return true;
@@ -205,7 +193,7 @@ class ViewHelperResolver
      * @param string $namespaceIdentifier
      * @return bool
      */
-    public function isNamespaceIgnored($namespaceIdentifier)
+    public function isNamespaceIgnored(string $namespaceIdentifier): bool
     {
         if (array_key_exists($namespaceIdentifier, $this->namespaces)) {
             return $this->namespaces[$namespaceIdentifier] === null;
@@ -234,12 +222,9 @@ class ViewHelperResolver
      * If no ViewHelper class can be detected in any of the added
      * PHP namespaces a Fluid Parser Exception is thrown.
      *
-     * @param string $namespaceIdentifier
-     * @param string $methodIdentifier
-     * @return string|null
      * @throws ParserException
      */
-    public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier)
+    public function resolveViewHelperClassName(string $namespaceIdentifier, string $methodIdentifier): string
     {
         if (!isset($this->resolvedViewHelperClassNames[$namespaceIdentifier][$methodIdentifier])) {
             $resolvedViewHelperClassName = $this->resolveViewHelperName($namespaceIdentifier, $methodIdentifier);
@@ -262,12 +247,8 @@ class ViewHelperResolver
      * Can be overridden by custom implementations to change the way
      * classes are loaded when the class is a ViewHelper - for
      * example making it possible to use a DI-aware class loader.
-     *
-     * @param string $namespace
-     * @param string $viewHelperShortName
-     * @return ViewHelperInterface
      */
-    public function createViewHelperInstance($namespace, $viewHelperShortName)
+    public function createViewHelperInstance(string $namespace, string $viewHelperShortName): ViewHelperInterface
     {
         $className = $this->resolveViewHelperClassName($namespace, $viewHelperShortName);
         return $this->createViewHelperInstanceFromClassName($className);
@@ -278,11 +259,8 @@ class ViewHelperResolver
      * the final method called when creating ViewHelper classes -
      * overriding this method allows custom constructors, dependency
      * injections etc. to be performed on the ViewHelper instance.
-     *
-     * @param string $viewHelperClassName
-     * @return ViewHelperInterface
      */
-    public function createViewHelperInstanceFromClassName($viewHelperClassName)
+    public function createViewHelperInstanceFromClassName(string $viewHelperClassName): ViewHelperInterface
     {
         return new $viewHelperClassName();
     }
@@ -294,10 +272,9 @@ class ViewHelperResolver
      * implementations can if necessary add/remove/replace arguments
      * which will be passed to the ViewHelper.
      *
-     * @param ViewHelperInterface $viewHelper
      * @return ArgumentDefinition[]
      */
-    public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper)
+    public function getArgumentDefinitionsForViewHelper(ViewHelperInterface $viewHelper): array
     {
         return $viewHelper->prepareArguments();
     }
@@ -309,7 +286,7 @@ class ViewHelperResolver
      * @param string $methodIdentifier Method identifier, might be hierarchical like "link.url"
      * @return string The fully qualified class name of the viewhelper
      */
-    protected function resolveViewHelperName($namespaceIdentifier, $methodIdentifier)
+    protected function resolveViewHelperName(string $namespaceIdentifier, string $methodIdentifier): string
     {
         $explodedViewHelperName = explode('.', $methodIdentifier);
         if (count($explodedViewHelperName) > 1) {

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -7,6 +9,7 @@
 
 namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
+use Traversable;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
@@ -20,14 +23,11 @@ class ViewHelperVariableContainer
      * Two-dimensional object array storing the values. The first dimension is the fully qualified ViewHelper name,
      * and the second dimension is the identifier for the data the ViewHelper wants to store.
      *
-     * @var array
+     * @var array<string, array<string, mixed>>
      */
-    protected $objects = [];
+    protected array $objects = [];
 
-    /**
-     * @var ViewInterface
-     */
-    protected $view;
+    protected ?ViewInterface $view = null;
 
     /**
      * Add a variable to the Variable Container. Make sure that $viewHelperName is ALWAYS set
@@ -38,7 +38,7 @@ class ViewHelperVariableContainer
      * @param mixed $value The value to store
      * @api
      */
-    public function add($viewHelperName, $key, $value)
+    public function add(string $viewHelperName, string $key, mixed $value): void
     {
         $this->addOrUpdate($viewHelperName, $key, $value);
     }
@@ -48,21 +48,14 @@ class ViewHelperVariableContainer
      * array or Traversable (with string keys!).
      *
      * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-     * @param array|\Traversable $variables An associative array of all variables to add
+     * @param iterable $variables An associative array of all variables to add
      * @api
      */
-    public function addAll($viewHelperName, $variables)
+    public function addAll(string $viewHelperName, iterable $variables): void
     {
-        if (!is_array($variables) && !$variables instanceof \Traversable) {
-            throw new \InvalidArgumentException(
-                'Invalid argument type for $variables in ViewHelperVariableContainer->addAll(). Expects array/Traversable ' .
-                'but received ' . (is_object($variables) ? get_class($variables) : gettype($variables)),
-                1501425195,
-            );
-        }
         $this->objects[$viewHelperName] = array_replace_recursive(
             isset($this->objects[$viewHelperName]) ? $this->objects[$viewHelperName] : [],
-            $variables instanceof \Traversable ? iterator_to_array($variables) : $variables,
+            $variables instanceof Traversable ? iterator_to_array($variables) : $variables,
         );
     }
 
@@ -75,7 +68,7 @@ class ViewHelperVariableContainer
      * @param string $key Key of the data
      * @param mixed $value The value to store
      */
-    public function addOrUpdate($viewHelperName, $key, $value)
+    public function addOrUpdate(string $viewHelperName, string $key, mixed $value): void
     {
         if (!isset($this->objects[$viewHelperName])) {
             $this->objects[$viewHelperName] = [];
@@ -92,7 +85,7 @@ class ViewHelperVariableContainer
      * @return mixed The object stored
      * @api
      */
-    public function get($viewHelperName, $key, $default = null)
+    public function get(string $viewHelperName, string $key, mixed $default = null): mixed
     {
         return $this->exists($viewHelperName, $key) ? $this->objects[$viewHelperName][$key] : $default;
     }
@@ -101,10 +94,10 @@ class ViewHelperVariableContainer
      * Gets all variables stored for a particular ViewHelper
      *
      * @param string $viewHelperName The ViewHelper Class name (Fully qualified, like "TYPO3Fluid\Fluid\ViewHelpers\ForViewHelper")
-     * @param mixed $default
+     * @param array $default
      * @return array
      */
-    public function getAll($viewHelperName, $default = null)
+    public function getAll(string $viewHelperName, array $default = []): array
     {
         return array_key_exists($viewHelperName, $this->objects) ? $this->objects[$viewHelperName] : $default;
     }
@@ -117,7 +110,7 @@ class ViewHelperVariableContainer
      * @return bool true if a value for the given ViewHelperName / Key is stored
      * @api
      */
-    public function exists($viewHelperName, $key)
+    public function exists(string $viewHelperName, string $key): bool
     {
         return isset($this->objects[$viewHelperName]) && array_key_exists($key, $this->objects[$viewHelperName]);
     }
@@ -129,7 +122,7 @@ class ViewHelperVariableContainer
      * @param string $key Key of the data to remove
      * @api
      */
-    public function remove($viewHelperName, $key)
+    public function remove(string $viewHelperName, string $key): void
     {
         unset($this->objects[$viewHelperName][$key]);
     }
@@ -139,7 +132,7 @@ class ViewHelperVariableContainer
      *
      * @param ViewInterface $view View to set
      */
-    public function setView(ViewInterface $view)
+    public function setView(ViewInterface $view): void
     {
         $this->view = $view;
     }
@@ -151,7 +144,7 @@ class ViewHelperVariableContainer
      *
      * @return ViewInterface|null The View, or null if view was not set
      */
-    public function getView()
+    public function getView(): ?ViewInterface
     {
         return $this->view;
     }
@@ -161,7 +154,7 @@ class ViewHelperVariableContainer
      *
      * @return array
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['objects'];
     }

--- a/tests/Functional/Fixtures/Various/TestViewHelperResolver.php
+++ b/tests/Functional/Fixtures/Various/TestViewHelperResolver.php
@@ -39,12 +39,12 @@ class TestViewHelperResolver extends ViewHelperResolver
         $this->override = $instance;
     }
 
-    public function isNamespaceValid($namespaceIdentifier)
+    public function isNamespaceValid(string $namespaceIdentifier): bool
     {
         return $namespaceIdentifier === 'test' || parent::isNamespaceValid($namespaceIdentifier);
     }
 
-    public function isNamespaceIgnored($namespaceIdentifier)
+    public function isNamespaceIgnored(string $namespaceIdentifier): bool
     {
         if ($namespaceIdentifier === 'test') {
             return false;
@@ -52,12 +52,12 @@ class TestViewHelperResolver extends ViewHelperResolver
         return parent::isNamespaceIgnored($namespaceIdentifier);
     }
 
-    public function resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier)
+    public function resolveViewHelperClassName(string $namespaceIdentifier, string $methodIdentifier): string
     {
         return $namespaceIdentifier === 'test' && $methodIdentifier === 'test' && $this->override !== null ? get_class($this->override) : parent::resolveViewHelperClassName($namespaceIdentifier, $methodIdentifier);
     }
 
-    public function createViewHelperInstanceFromClassName($viewHelperClassName)
+    public function createViewHelperInstanceFromClassName(string $viewHelperClassName): ViewHelperInterface
     {
         if ($viewHelperClassName === MutableTestViewHelper::class) {
             return $this->override;
@@ -65,7 +65,7 @@ class TestViewHelperResolver extends ViewHelperResolver
         return parent::createViewHelperInstanceFromClassName($viewHelperClassName);
     }
 
-    public function createViewHelperInstance($namespace, $viewHelperShortName)
+    public function createViewHelperInstance(string $namespace, string $viewHelperShortName): ViewHelperInterface
     {
         return $namespace === 'test' && $viewHelperShortName === 'test' && $this->override !== null ? clone $this->override : parent::createViewHelperInstance($namespace, $viewHelperShortName);
     }

--- a/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable;
 
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable\Fixtures\ViewHelpers\CompilableViewHelper;
@@ -35,7 +36,7 @@ final class SharedStaticCompilableViewHelperTest extends AbstractFunctionalTestC
             ];
             public array $called = [];
 
-            public function createViewHelperInstanceFromClassName($viewHelperClassName)
+            public function createViewHelperInstanceFromClassName(string $viewHelperClassName): ViewHelperInterface
             {
                 $this->called[$viewHelperClassName] ??= 0;
                 $this->called[$viewHelperClassName]++;

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -70,7 +70,7 @@ class AbstractViewHelperTest extends TestCase
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods(['prepareArguments'])->getMock();
         $subject->setArguments(['test' => new \ArrayObject()]);
-        $subject->expects(self::once())->method('prepareArguments')->willReturn(['test' => new ArgumentDefinition('test', 'array', false, 'documentation')]);
+        $subject->expects(self::once())->method('prepareArguments')->willReturn(['test' => new ArgumentDefinition('test', 'array', 'documentation', false)]);
         $subject->validateArguments();
     }
 

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -103,14 +103,6 @@ final class ViewHelperVariableContainerTest extends TestCase
     }
 
     #[Test]
-    public function addAllThrowsInvalidArgumentExceptionOnUnsupportedType(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $subject = new ViewHelperVariableContainer();
-        $subject->addAll('Foo\\Bar', new \DateTime('now'));
-    }
-
-    #[Test]
     public function sleepReturnsExpectedPropertyNames(): void
     {
         $subject = new ViewHelperVariableContainer();


### PR DESCRIPTION
With v4 of Fluid, the goal is to not break any custom ViewHelpers out there. Thus, we only apply type hints to ViewHelper-related API for cases where we can be reasonably sure that it won't break ViewHelpers.

AbstractViewHelper is extended directly by custom ViewHelpers, so we can only type hint private properties.

ViewHelperInvoker and ViewHelperResolver are APIs that are implemented by frameworks that use Fluid for templating, so stricter types don't affect ViewHelper implementations. Still, there are some cases in which we won't enforce types because it is unclear if there are edge cases out there where the supplied types actually match existing PHPDOC annotations. For example, we can't really be sure if templates or ViewHelpers always return strings, so we stay away from those type hints for now.

TagBuilder, ArgumentDefinition and ViewHelperVariableContainer are often utilized from within ViewHelpers. However, because of their respected isolated functionality, we can be pretty sure about the types and thus apply them for most methods and properties.