### PR TITLE
[TASK] Deprecate shortcut methods in AbstractTemplateView

### DIFF
--- a/Documentation/Changelog/2.x.rst
+++ b/Documentation/Changelog/2.x.rst
@@ -9,6 +9,22 @@ Changelog 2.x
 2.14
 ----
 
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::initializeRenderingContext()`
+  has been marked as deprecated. It will be removed in Fluid v4.
+  Migration path is to call the rendering context directly via
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getRenderingContext()->getViewHelperVariableContainer()->setView()`
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::setCache()`
+  has been marked as deprecated. It will be removed in Fluid v4.
+  Migration path is to call the rendering context directly via
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getRenderingContext()->setCache()`
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getTemplatePaths()`
+  has been marked as deprecated. It will be removed in Fluid v4.
+  Migration path is to call the rendering context directly via
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getRenderingContext()->getTemplatePaths()`
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getViewHelperResolver()`
+  has been marked as deprecated. It will be removed in Fluid v4.
+  Migration path is to call the rendering context directly via
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getRenderingContext()->getViewHelperResolver()`
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`
   has been marked as deprecated. It will log a deprecation level error message when called in
   Fluid v4. It will be removed in Fluid v5.

--- a/Documentation/Development/Implementation.rst
+++ b/Documentation/Development/Implementation.rst
@@ -120,7 +120,8 @@ Should you need to store the compiled templates in other ways you can implement
 
 Whether you use your own cache class or the default, the `FluidCache`
 *must be passed as third parameter for the View* or it
-*must be assigned using `$view->setCache($cacheInstance)` before calling `$view->render()`*.
+*must be assigned using `$view->getRenderingContext()->setCache($cacheInstance)`
+before calling `$view->render()`*.
 
 TemplateProcessor
 =================

--- a/examples/example_cachestatic.php
+++ b/examples/example_cachestatic.php
@@ -33,7 +33,7 @@ $view->assign('foobar', 'Cached as static text');
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CacheStatic.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CacheStatic.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_cachewarmup.php
+++ b/examples/example_cachewarmup.php
@@ -37,7 +37,7 @@ $view->assign('dynamicName', 'Works');
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CacheWarmup.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CacheWarmup.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_conditions.php
+++ b/examples/example_conditions.php
@@ -40,7 +40,7 @@ $view->assign('asArray', [
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Conditions.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.

--- a/examples/example_customresolving.php
+++ b/examples/example_customresolving.php
@@ -37,7 +37,7 @@ $view->getRenderingContext()->setViewHelperResolver(new CustomViewHelperResolver
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/CustomResolving.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.

--- a/examples/example_dynamiclayout.php
+++ b/examples/example_dynamiclayout.php
@@ -28,7 +28,7 @@ $view = $exampleHelper->init();
 $view->assign('layout', 'Dynamic');
 
 // Set the template path and filename we will render
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/DynamicLayout.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/DynamicLayout.html');
 
 $output = $view->render();
 

--- a/examples/example_errorhandling.php
+++ b/examples/example_errorhandling.php
@@ -28,7 +28,7 @@ $view->getRenderingContext()->setErrorHandler(new TolerantErrorHandler());
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/ErrorHandling.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/ErrorHandling.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_escapingmodifier.php
+++ b/examples/example_escapingmodifier.php
@@ -25,7 +25,7 @@ $view->assign('html', '<strong>This is not escaped</strong>');
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/EscapingModifier.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/EscapingModifier.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_format.php
+++ b/examples/example_format.php
@@ -21,7 +21,7 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setFormat('json');
 
 // Rendering the View: we use the $action argument for the render() method in

--- a/examples/example_layoutless.php
+++ b/examples/example_layoutless.php
@@ -21,7 +21,7 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/LayoutLess.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the

--- a/examples/example_math.php
+++ b/examples/example_math.php
@@ -30,7 +30,7 @@ $view->assign('half', 0.5);
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Math.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Math.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/example_multiplepaths.php
+++ b/examples/example_multiplepaths.php
@@ -37,7 +37,7 @@ $view = $exampleHelper->init();
 // the overrides to a path in, for example, another package's Resources folder.
 // Specifying this array can also be done as constructor argument for the
 // TemplatePaths class which can be passed to the View; see view_init.php.
-$view->getTemplatePaths()->fillFromConfigurationArray([
+$view->getRenderingContext()->getTemplatePaths()->fillFromConfigurationArray([
     TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [
         __DIR__ . '/Resources/Private/Templates/',
         __DIR__ . '/ResourceOverrides/Private/Templates/',

--- a/examples/example_namespaceresolving.php
+++ b/examples/example_namespaceresolving.php
@@ -23,7 +23,7 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/NamespaceResolving.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/NamespaceResolving.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.
 $output = $view->render();

--- a/examples/example_namespaces.php
+++ b/examples/example_namespaces.php
@@ -24,7 +24,7 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Namespaces.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Namespaces.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_passthrough.php
+++ b/examples/example_passthrough.php
@@ -25,7 +25,7 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Passthrough.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.

--- a/examples/example_single.php
+++ b/examples/example_single.php
@@ -32,7 +32,7 @@ $view->assign('foobar', 'Single template');
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Single.html');
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Single.html');
 
 // Rendering the View: we don't specify the optional `$action` parameter for the
 // `render()` method - and internally, the View doesn't try to resolve an action

--- a/examples/example_structures.php
+++ b/examples/example_structures.php
@@ -22,8 +22,8 @@ $view = $exampleHelper->init();
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
-$view->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Structures.html');
+$paths = $view->getRenderingContext()->getTemplatePaths();
+$view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Structures.html');
 
 $view->assign('dynamicSection', 'Dynamic');
 $view->assign('notTrue', false);

--- a/examples/example_variableprovider.php
+++ b/examples/example_variableprovider.php
@@ -29,7 +29,7 @@ $dynamic2 = 'DYN2'; // used as dynamic part when accessing other variables
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/VariableProvider.html');
 
 // Assigning a custom VariableProvider which will return two variables:

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -60,7 +60,7 @@ $view->assignMultiple([
 
 // Assigning the template path and filename to be rendered. Doing this overrides
 // resolving normally done by the TemplatePaths and directly renders this file.
-$paths = $view->getTemplatePaths();
+$paths = $view->getRenderingContext()->getTemplatePaths();
 $paths->setTemplatePathAndFilename(__DIR__ . '/Resources/Private/Singles/Variables.html');
 
 // Rendering the View: plain old rendering of single file, no bells and whistles.

--- a/examples/src/Helper/ExampleHelper.php
+++ b/examples/src/Helper/ExampleHelper.php
@@ -20,7 +20,7 @@ class ExampleHelper
         $view = new TemplateView();
 
         // TemplatePaths object: a subclass can be used if custom resolving is wanted.
-        $paths = $view->getTemplatePaths();
+        $paths = $view->getRenderingContext()->getTemplatePaths();
 
         // Configuring paths: explicit setters used in this example. Paths can also
         // be passed as a ["templateRootPaths" => ["path1/", "path2/"]] constructor
@@ -45,7 +45,7 @@ class ExampleHelper
         if (!is_dir($cachePath)) {
             mkdir($cachePath);
         }
-        $view->setCache(new SimpleFileCache($cachePath));
+        $view->getRenderingContext()->setCache(new SimpleFileCache($cachePath));
 
         return $view;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,8 +91,13 @@ parameters:
 			path: src/Core/ViewHelper/ViewHelperVariableContainer.php
 
 		-
+			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface\\:\\:getRenderingContext\\(\\)\\.$#"
+			count: 1
+			path: src/Tools/ConsoleRunner.php
+
+		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface\\:\\:getTemplatePaths\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: src/Tools/ConsoleRunner.php
 
 		-

--- a/src/Tools/ConsoleRunner.php
+++ b/src/Tools/ConsoleRunner.php
@@ -287,7 +287,7 @@ final class ConsoleRunner
         }
         while ($socket = stream_socket_accept($socketServer, -1)) {
             $input = stream_socket_recvfrom($socket, 1024);
-            $templatePathAndFilename = $this->parseTemplatePathAndFilenameFromHeaders($input, $view->getTemplatePaths());
+            $templatePathAndFilename = $this->parseTemplatePathAndFilenameFromHeaders($input, $view->getRenderingContext()->getTemplatePaths());
             if (!file_exists($templatePathAndFilename)) {
                 $response = $this->createErrorResponse('Not Found', 404);
             } else {

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -68,6 +68,8 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * Initialize the RenderingContext. This method can be overridden in your
      * View implementation to manipulate the rendering context *before* it is
      * passed during rendering.
+     *
+     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getViewHelperVariableContainer()->setView()
      */
     public function initializeRenderingContext()
     {
@@ -78,6 +80,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * Sets the cache to use in RenderingContext.
      *
      * @param FluidCacheInterface $cache
+     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->setCache()
      */
     public function setCache(FluidCacheInterface $cache)
     {
@@ -88,6 +91,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * Gets the TemplatePaths instance from RenderingContext
      *
      * @return TemplatePaths
+     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getTemplatePaths()
      */
     public function getTemplatePaths()
     {
@@ -98,6 +102,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * Gets the ViewHelperResolver instance from RenderingContext
      *
      * @return ViewHelperResolver
+     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getViewHelperResolver()
      */
     public function getViewHelperResolver()
     {
@@ -122,7 +127,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
     public function setRenderingContext(RenderingContextInterface $renderingContext)
     {
         $this->baseRenderingContext = $renderingContext;
-        $this->initializeRenderingContext();
+        $this->baseRenderingContext->getViewHelperVariableContainer()->setView($this);
     }
 
     /**

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -147,8 +147,8 @@ class RenderViewHelper extends AbstractViewHelper
             throw new Exception(
                 'The f:render ViewHelper was used in a context where the ViewHelperVariableContainer does not contain ' .
                 'a reference to the View. Normally this is taken care of by the TemplateView, so most likely this ' .
-                'error is because you overrode AbstractTemplateView->initializeRenderingContext() and did not call ' .
-                '$renderingContext->getViewHelperVariableContainer()->setView($this) or parent::initializeRenderingContext. ' .
+                'error is because you overrode AbstractTemplateView->setRenderingContext() and did not call ' .
+                '$renderingContext->getViewHelperVariableContainer()->setView($this). ' .
                 'This is an issue you must fix in your code as f:render is fully unable to render anything without a View.',
             );
         }

--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -45,7 +45,7 @@ final class ViewHelperEscapingTest extends AbstractFunctionalTestCase
         $context->getVariableProvider()->add('value', '<script>alert(1)</script>');
 
         $view = new TemplateView($context);
-        $view->getTemplatePaths()->setTemplateSource($fluidCode);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($fluidCode);
 
         return $view->render();
     }

--- a/tests/Functional/Cases/Rendering/DataAccessorTest.php
+++ b/tests/Functional/Cases/Rendering/DataAccessorTest.php
@@ -95,13 +95,13 @@ final class DataAccessorTest extends AbstractFunctionalTestCase
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->assignMultiple($variables);
-        $view->getTemplatePaths()->setTemplateSource($template);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
         self::assertSame($expected, json_decode($view->render(), true));
 
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->assignMultiple($variables);
-        $view->getTemplatePaths()->setTemplateSource($template);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
         self::assertSame($expected, json_decode($view->render(), true));
     }
 
@@ -111,7 +111,7 @@ final class DataAccessorTest extends AbstractFunctionalTestCase
         $this->expectException(\Throwable::class);
         $this->expectExceptionCode(0);
         $view = new TemplateView();
-        $view->getTemplatePaths()->setTemplateSource('["{data.privateValue}"]');
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('["{data.privateValue}"]');
         $view->assignMultiple(['data' => new WithProperties()]);
         $view->render();
     }

--- a/tests/Functional/Cases/TagBasedTest.php
+++ b/tests/Functional/Cases/TagBasedTest.php
@@ -89,7 +89,7 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-        $view->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
         $output = $view->render();
         self::assertEquals($expected, $output);
 
@@ -97,7 +97,7 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-        $view->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
         $output = $view->render();
         self::assertEquals($expected, $output);
     }
@@ -123,7 +123,7 @@ final class TagBasedTest extends AbstractFunctionalTestCase
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-        $view->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
         $view->render();
     }
 }

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -43,7 +43,7 @@ class AbstractTemplateViewTest extends TestCase
         $renderingContext->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolver);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
-        self::assertSame($viewHelperResolver, $subject->getViewHelperResolver());
+        self::assertSame($viewHelperResolver, $subject->getRenderingContext()->getViewHelperResolver());
     }
 
     #[Test]


### PR DESCRIPTION
In order to simplify integrations of the Fluid template engine into frameworks (such as TYPO3), we deprecate four methods of AbstractTemplateView that are only shortcuts to the rendering context object.

These methods will be removed in Fluid v4 because the migration path is easy and it simplifies further work on TYPO3's Fluid integration.