### PR TITLE
[TASK] Use RenderingContext->setAttribute() (#922)

### DIFF
--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -365,14 +365,12 @@ class RenderingContext implements RenderingContextInterface
         return $parserConfiguration;
     }
 
-    public function withAttribute(string $className, object $value): static
+    public function setAttribute(string $className, object $value): void
     {
         if (!$value instanceof $className) {
             throw new \RuntimeException('$value is not an instance of ' . $className, 1719410580);
         }
-        $clonedObject = clone $this;
-        $clonedObject->attributes[$className] = $value;
-        return $clonedObject;
+        $this->attributes[$className] = $value;
     }
 
     public function hasAttribute(string $className): bool

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -181,16 +181,18 @@ interface RenderingContextInterface
     public function setControllerAction($action);
 
     /**
-     * Return an instance with the specified attribute being attached.
+     * Add an object to this instance.
      *
      * This method allows you to attach arbitrary objects to the
-     * rendering context to be used later e. g. in ViewHelpers.
+     * rendering context to be used later e.g. in ViewHelpers.
+     *
+     * A typical use case is to attach a ServerRequestInterface here.
      *
      * @template T of object
      * @param class-string<T> $className
      * @param T $value
      */
-    public function withAttribute(string $className, object $value): RenderingContextInterface;
+    public function setAttribute(string $className, object $value): void;
 
     /**
      * Return true if an attribute object of that type exists.

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -98,11 +98,11 @@ final class RenderingContextTest extends TestCase
     }
 
     #[Test]
-    public function withAttributeThrowsIfValueIsNotInstanceofClassName(): void
+    public function setAttributeThrowsIfValueIsNotInstanceofClassName(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionCode(1719410580);
-        (new RenderingContext())->withAttribute(RenderingContext::class, new stdClass());
+        (new RenderingContext())->setAttribute(RenderingContext::class, new stdClass());
     }
 
     #[Test]
@@ -114,7 +114,8 @@ final class RenderingContextTest extends TestCase
     #[Test]
     public function hasAttributeReturnsTrueIfSet(): void
     {
-        $subject = (new RenderingContext())->withAttribute(stdClass::class, new stdClass());
+        $subject = new RenderingContext();
+        $subject->setAttribute(stdClass::class, new stdClass());
         self::assertTrue($subject->hasAttribute(stdClass::class));
     }
 
@@ -127,11 +128,11 @@ final class RenderingContextTest extends TestCase
     }
 
     #[Test]
-    public function getAttributeReturnsInstanceSetUsingWithAttribute(): void
+    public function getAttributeReturnsInstanceSetUsingSetAttribute(): void
     {
         $object = new stdClass();
         $subject = new RenderingContext();
-        $clonedSubject = $subject->withAttribute(stdClass::class, $object);
-        self::assertEquals($object, $clonedSubject->getAttribute(stdClass::class));
+        $subject->setAttribute(stdClass::class, $object);
+        self::assertEquals($object, $subject->getAttribute(stdClass::class));
     }
 }


### PR DESCRIPTION
When we designed the RenderingContext functionality to add "arbitrary" objects to RenderingContext
(like a Request) in a recent minor release, we tried start making RenderingContext immutable and added
the implementation using a "with'er".

This is in general a good idea: RenderinContext
*should* be immutable.

It is however problematic to do this with this
single property: It leads to too many and
partially breaking changes when consumers try
to use this.

As such, the patch rolls back to a setAttribute()
approach. With the default implementation being
done in the Fluid delivered RenderingContext,
this change is currently not considered breaking
since no (known) consumer actually uses it.

To make RenderingContext immutable, we need a new
approach, maybe re-starting with a new class that
does it. This is a topic for a different major
version, though.