### PR TITLE
[!!!][TASK] Mark internal constants as protected

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -9,6 +9,12 @@ Changelog 4.x
 4.0
 ---
 
+* Breaking: Change visibility of class constants that represent internal Fluid state. The
+  following constants have been set to `protected` and can only be accessed by
+  `AbstractTemplateView` and its child implementations:
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_TEMPLATE`,
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_PARTIAL`,
+  :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_LAYOUT`
 * Breaking: Careful addition of method and property type hints throughout the system.
   This should be only mildly breaking and projects should be able to adapt easily.
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -28,9 +28,9 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
     /**
      * Constants defining possible rendering types
      */
-    public const RENDERING_TEMPLATE = 1;
-    public const RENDERING_PARTIAL = 2;
-    public const RENDERING_LAYOUT = 3;
+    protected const RENDERING_TEMPLATE = 1;
+    protected const RENDERING_PARTIAL = 2;
+    protected const RENDERING_LAYOUT = 3;
 
     /**
      * The initial rendering context for this template view.

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -145,7 +145,7 @@ class AbstractTemplateViewTest extends TestCase
         $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();
         $subject->setRenderingContext($renderingContext);
-        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
+        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(3);
         $subject->expects(self::once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
         $subject->renderSection('Missing');
     }
@@ -163,7 +163,7 @@ class AbstractTemplateViewTest extends TestCase
         $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();
         $subject->setRenderingContext($renderingContext);
-        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
+        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(3);
         $subject->expects(self::once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
         $subject->renderSection('Missing');
     }
@@ -178,7 +178,7 @@ class AbstractTemplateViewTest extends TestCase
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(true);
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();
         $subject->setRenderingContext($renderingContext);
-        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(AbstractTemplateView::RENDERING_LAYOUT);
+        $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(3);
         $subject->expects(self::once())->method('getCurrentParsedTemplate')->willReturn($parsedTemplate);
         $subject->renderSection('Section', [], true);
     }


### PR DESCRIPTION
The following constants represent internal Fluid state and have been
set to `protected`. Thus, they can only be accessed by `AbstractTemplateView` and its child implementations:

:php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_TEMPLATE`
:php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_PARTIAL`
:php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_LAYOUT`