### PR TITLE
[!!!][TASK] Remove deprecated methods in AbstractTemplateView

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -9,6 +9,14 @@ Changelog 4.x
 4.0
 ---
 
+* Breaking: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::initializeRenderingContext()`
+  has been removed.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::setCache()`
+  has been removed.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getTemplatePaths()`
+  has been removed.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::getViewHelperResolver()`
+  has been removed.
 * Breaking: Change visibility of class constants that represent internal Fluid state. The
   following constants have been set to `protected` and can only be accessed by
   `AbstractTemplateView` and its child implementations:

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -7,13 +7,11 @@
 
 namespace TYPO3Fluid\Fluid\View;
 
-use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Parser\PassthroughSourceException;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
@@ -62,51 +60,6 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
             $context->setControllerAction('Default');
         }
         $this->setRenderingContext($context);
-    }
-
-    /**
-     * Initialize the RenderingContext. This method can be overridden in your
-     * View implementation to manipulate the rendering context *before* it is
-     * passed during rendering.
-     *
-     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getViewHelperVariableContainer()->setView()
-     */
-    public function initializeRenderingContext()
-    {
-        $this->baseRenderingContext->getViewHelperVariableContainer()->setView($this);
-    }
-
-    /**
-     * Sets the cache to use in RenderingContext.
-     *
-     * @param FluidCacheInterface $cache
-     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->setCache()
-     */
-    public function setCache(FluidCacheInterface $cache)
-    {
-        $this->baseRenderingContext->setCache($cache);
-    }
-
-    /**
-     * Gets the TemplatePaths instance from RenderingContext
-     *
-     * @return TemplatePaths
-     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getTemplatePaths()
-     */
-    public function getTemplatePaths()
-    {
-        return $this->baseRenderingContext->getTemplatePaths();
-    }
-
-    /**
-     * Gets the ViewHelperResolver instance from RenderingContext
-     *
-     * @return ViewHelperResolver
-     * @deprecated Will be removed in v4. Migration path is to call the rendering context directly via self::getRenderingContext()->getViewHelperResolver()
-     */
-    public function getViewHelperResolver()
-    {
-        return $this->baseRenderingContext->getViewHelperResolver();
     }
 
     /**


### PR DESCRIPTION
These methods have been marked as deprecated in Fluid 2.14 and are now removed.