### PR TITLE
[BUGFIX] Supply correct parameter to json_decode

### DIFF
--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -102,7 +102,7 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
             } else {
                 $source = $this->source;
             }
-            $this->variables = json_decode($source, defined('JSON_OBJECT_AS_ARRAY') ? JSON_OBJECT_AS_ARRAY : 1);
+            $this->variables = json_decode($source, true);
             $this->lastLoaded = time();
         }
     }


### PR DESCRIPTION
This line has been changed several times, but was probably never correct: Either set the second parameter of json_decode() to true to get an associative array or set the flag JSON_OBJECT_AS_ARRAY as fourth parameter.

We opt for the second parameter to keep things simple