### PR TITLE
[!!!][TASK] Apply more type hints

### DIFF
--- a/examples/src/CustomVariableProvider.php
+++ b/examples/src/CustomVariableProvider.php
@@ -19,10 +19,7 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  */
 class CustomVariableProvider extends StandardVariableProvider implements VariableProviderInterface
 {
-    /**
-     * @var int
-     */
-    protected $incrementer = 0;
+    protected int $incrementer = 0;
 
     /**
      * Get a variable by dotted path expression, retrieving the
@@ -30,11 +27,8 @@ class CustomVariableProvider extends StandardVariableProvider implements Variabl
      * If the second variable is passed, it is expected to contain
      * extraction method names (constants from StandardVariableProvider)
      * which indicate how each value is extracted.
-     *
-     * @param string $path
-     * @return mixed
      */
-    public function getByPath($path)
+    public function getByPath(string $path): mixed
     {
         if ($path === 'random') {
             return 'random' . hash('xxh3', (string)rand(0, 999999999));
@@ -45,11 +39,7 @@ class CustomVariableProvider extends StandardVariableProvider implements Variabl
         return parent::getByPath($path);
     }
 
-    /**
-     * @param string $identifier
-     * @return bool
-     */
-    public function exists($identifier)
+    public function exists(string $identifier): bool
     {
         return $identifier === 'incrementer' || $identifier === 'random' || parent::exists($identifier);
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Core/Compiler/TemplateCompiler.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\ErrorHandler\\\\StandardErrorHandler\\:\\:handleCompilerError\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: src/Core/ErrorHandler/StandardErrorHandler.php
-
-		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/Interceptor/Escape.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,11 +71,6 @@ parameters:
 			path: src/Core/ViewHelper/ViewHelperResolver.php
 
 		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\View\\\\ViewInterface\\:\\:getRenderingContext\\(\\)\\.$#"
-			count: 2
-			path: src/Tools/ConsoleRunner.php
-
-		-
 			message: "#^Variable \\$iterationData might not be defined\\.$#"
 			count: 1
 			path: src/ViewHelpers/ForViewHelper.php

--- a/src/Core/Cache/FluidCacheInterface.php
+++ b/src/Core/Cache/FluidCacheInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -18,31 +20,20 @@ interface FluidCacheInterface
     /**
      * Gets an entry from the cache or null if the
      * entry does not exist.
-     *
-     * @param string $name
-     * @return mixed
      */
-    public function get($name);
+    public function get(string $name): mixed;
 
     /**
      * Set or updates an entry identified by $name
      * into the cache.
-     *
-     * @param string $name
-     * @param mixed $value
      */
-    public function set($name, $value);
+    public function set(string $name, mixed $value): void;
 
     /**
      * Flushes the cache either by entry or flushes
      * the entire cache if no entry is provided.
-     *
-     * @param string|null $name
      */
-    public function flush($name = null);
+    public function flush(?string $name = null): void;
 
-    /**
-     * @return FluidCacheWarmerInterface
-     */
-    public function getCacheWarmer();
+    public function getCacheWarmer(): FluidCacheWarmerInterface;
 }

--- a/src/Core/Cache/FluidCacheWarmerInterface.php
+++ b/src/Core/Cache/FluidCacheWarmerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -28,9 +30,6 @@ interface FluidCacheWarmerInterface
      * completely up to the implementing class. Standard file based
      * template resolving and compiling can be inherited by subclassing
      * the provided StandardCacheWarmer and overriding methods.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return FluidCacheWarmupResult
      */
-    public function warm(RenderingContextInterface $renderingContext);
+    public function warm(RenderingContextInterface $renderingContext): FluidCacheWarmupResult;
 }

--- a/src/Core/Cache/FluidCacheWarmupResult.php
+++ b/src/Core/Cache/FluidCacheWarmupResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -22,15 +24,9 @@ class FluidCacheWarmupResult
     public const RESULT_FAILURE = 'failure';
     public const RESULT_MITIGATIONS = 'mitigations';
 
-    /**
-     * @var array
-     */
-    protected $results = [];
+    protected array $results = [];
 
-    /**
-     * @return self
-     */
-    public function merge()
+    public function merge(): static
     {
         /* @var FluidCacheWarmupResult[] $results */
         $results = func_get_args();
@@ -40,20 +36,12 @@ class FluidCacheWarmupResult
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getResults()
+    public function getResults(): array
     {
         return $this->results;
     }
 
-    /**
-     * @param ParsedTemplateInterface $state
-     * @param string $templatePathAndFilename
-     * @return self
-     */
-    public function add(ParsedTemplateInterface $state, $templatePathAndFilename)
+    public function add(ParsedTemplateInterface $state, string $templatePathAndFilename): static
     {
         $currentlyCompiled = $state->isCompiled();
         $this->results[$templatePathAndFilename] = [

--- a/src/Core/Cache/SimpleFileCache.php
+++ b/src/Core/Cache/SimpleFileCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -26,12 +28,9 @@ class SimpleFileCache implements FluidCacheInterface
     /**
      * @var string
      */
-    protected $directory = self::DIRECTORY_DEFAULT;
+    protected string $directory = self::DIRECTORY_DEFAULT;
 
-    /**
-     * @param string $directory
-     */
-    public function __construct($directory = self::DIRECTORY_DEFAULT)
+    public function __construct(string $directory = self::DIRECTORY_DEFAULT)
     {
         $this->directory = rtrim($directory, '/') . '/';
     }
@@ -41,10 +40,8 @@ class SimpleFileCache implements FluidCacheInterface
      * can warm up template files that would normally be
      * cached on-the-fly to this FluidCacheInterface
      * implementaion.
-     *
-     * @return FluidCacheWarmerInterface
      */
-    public function getCacheWarmer()
+    public function getCacheWarmer(): FluidCacheWarmerInterface
     {
         return new StandardCacheWarmer();
     }
@@ -54,11 +51,8 @@ class SimpleFileCache implements FluidCacheInterface
      * entry does not exist. Returns true if the cached
      * class file was included, false if it does not
      * exist in the cache directory.
-     *
-     * @param string $name
-     * @return bool
      */
-    public function get($name)
+    public function get(string $name): bool
     {
         if (class_exists($name)) {
             return true;
@@ -75,11 +69,9 @@ class SimpleFileCache implements FluidCacheInterface
      * Set or updates an entry identified by $name
      * into the cache.
      *
-     * @param string $name
-     * @param mixed $value
      * @throws \RuntimeException
      */
-    public function set($name, $value)
+    public function set(string $name, mixed $value): void
     {
         if (!file_exists(rtrim($this->directory, '/'))) {
             throw new \RuntimeException(sprintf('Invalid Fluid cache directory - %s does not exist!', $this->directory));
@@ -90,10 +82,8 @@ class SimpleFileCache implements FluidCacheInterface
     /**
      * Flushes the cache either by entry or flushes
      * the entire cache if no entry is provided.
-     *
-     * @param string|null $name
      */
-    public function flush($name = null)
+    public function flush(?string $name = null): void
     {
         if ($name !== null) {
             $this->flushByName($name);
@@ -105,35 +95,22 @@ class SimpleFileCache implements FluidCacheInterface
         }
     }
 
-    /**
-     * @return array
-     */
-    protected function getCachedFilenames()
+    protected function getCachedFilenames(): array
     {
         return glob($this->directory . '*.php');
     }
 
-    /**
-     * @param string $name
-     */
-    protected function flushByName($name)
+    protected function flushByName(string $name): void
     {
         $this->flushByFilename($this->getCachedFilePathAndFilename($name));
     }
 
-    /**
-     * @param string $filename
-     */
-    protected function flushByFilename($filename)
+    protected function flushByFilename(string $filename): void
     {
         unlink($filename);
     }
 
-    /**
-     * @param string $identifier
-     * @return string
-     */
-    protected function getCachedFilePathAndFilename($identifier)
+    protected function getCachedFilePathAndFilename(string $identifier): string
     {
         return $this->directory . $identifier . '.php';
     }

--- a/src/Core/Cache/StandardCacheWarmer.php
+++ b/src/Core/Cache/StandardCacheWarmer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -54,7 +56,7 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      *
      * @var array
      */
-    protected $formats = ['html', 'xml', 'txt', 'json', 'rtf', 'atom', 'rss'];
+    protected array $formats = ['html', 'xml', 'txt', 'json', 'rtf', 'atom', 'rss'];
 
     /**
      * Warm up an entire collection of templates based on the
@@ -65,11 +67,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      * about all detected template files and the compiling of
      * those files. If a template fails to compile or throws an
      * error, a mitigation suggestion is included for that file.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return FluidCacheWarmupResult
      */
-    public function warm(RenderingContextInterface $renderingContext)
+    public function warm(RenderingContextInterface $renderingContext): FluidCacheWarmupResult
     {
         $renderingContext->getTemplateCompiler()->enterWarmupMode();
         $result = new FluidCacheWarmupResult();
@@ -102,11 +101,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      *
      * Like other methods, returns a FluidCacheWarmupResult instance
      * which can be merged with other result instances.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return FluidCacheWarmupResult
      */
-    protected function warmupTemplateRootPaths(RenderingContextInterface $renderingContext)
+    protected function warmupTemplateRootPaths(RenderingContextInterface $renderingContext): FluidCacheWarmupResult
     {
         $result = new FluidCacheWarmupResult();
         $paths = $renderingContext->getTemplatePaths();
@@ -155,11 +151,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      *
      * Like other methods, returns a FluidCacheWarmupResult instance
      * which can be merged with other result instances.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return FluidCacheWarmupResult
      */
-    protected function warmupPartialRootPaths(RenderingContextInterface $renderingContext)
+    protected function warmupPartialRootPaths(RenderingContextInterface $renderingContext): FluidCacheWarmupResult
     {
         $result = new FluidCacheWarmupResult();
         $paths = $renderingContext->getTemplatePaths();
@@ -192,11 +185,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      *
      * Like other methods, returns a FluidCacheWarmupResult instance
      * which can be merged with other result instances.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return FluidCacheWarmupResult
      */
-    protected function warmupLayoutRootPaths(RenderingContextInterface $renderingContext)
+    protected function warmupLayoutRootPaths(RenderingContextInterface $renderingContext): FluidCacheWarmupResult
     {
         $result = new FluidCacheWarmupResult();
         $paths = $renderingContext->getTemplatePaths();
@@ -224,11 +214,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      * Detect all available controller names in provided TemplateRootPaths
      * array, returning the "basename" components of controller-template
      * directories encountered, as an array.
-     *
-     * @param array $templateRootPaths
-     * @return \Generator
      */
-    protected function detectControllerNamesInTemplateRootPaths(array $templateRootPaths)
+    protected function detectControllerNamesInTemplateRootPaths(array $templateRootPaths): \Generator
     {
         foreach ($templateRootPaths as $templateRootPath) {
             foreach ((array)glob(rtrim($templateRootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $pathName) {
@@ -249,13 +236,8 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
      *
      * Adds basic mitigation suggestions for each specific type of error,
      * giving hints to developers if a certain template fails to compile.
-     *
-     * @param string $templatePathAndFilename
-     * @param string $identifier
-     * @param RenderingContextInterface $renderingContext
-     * @return ParsedTemplateInterface
      */
-    protected function warmSingleFile($templatePathAndFilename, $identifier, RenderingContextInterface $renderingContext)
+    protected function warmSingleFile(string $templatePathAndFilename, string $identifier, RenderingContextInterface $renderingContext): ParsedTemplateInterface
     {
         $parsedTemplate = new FailedCompilingState();
         $parsedTemplate->setVariableProvider($renderingContext->getVariableProvider());
@@ -320,11 +302,7 @@ class StandardCacheWarmer implements FluidCacheWarmerInterface
         return $parsedTemplate;
     }
 
-    /**
-     * @param string $templatePathAndFilename
-     * @return \Closure
-     */
-    protected function createClosure($templatePathAndFilename)
+    protected function createClosure(string $templatePathAndFilename): \Closure
     {
         return function (TemplateParser $parser, TemplatePaths $templatePaths) use ($templatePathAndFilename) {
             return file_get_contents($templatePathAndFilename);

--- a/src/Core/ErrorHandler/ErrorHandlerInterface.php
+++ b/src/Core/ErrorHandler/ErrorHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -12,40 +14,29 @@ interface ErrorHandlerInterface
     /**
      * Handle errors caused by parsing templates, for example when
      * invalid arguments are used.
-     *
-     * @return string
      */
-    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error);
+    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error): string;
 
     /**
      * Handle errors caused by invalid expressions, e.g. errors
      * raised from misuse of `{variable xyz 123}` style expressions,
      * such as the casting expression `{variable as type}`.
-     *
-     * @return string
      */
-    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error);
+    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error): string;
 
     /**
      * Can be implemented to handle a ViewHelper errors which are
      * normally thrown from inside ViewHelpers during rendering.
-     *
-     * @return string
      */
-    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error);
+    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error): string;
 
     /**
      * Can be implemented to handle "cannot compile" errors in
      * desired ways (normally this simply disables the compiling,
      * but if your application deems compiler errors fatal then
      * you can throw a different exception type here).
-     *
-     * @return string
      */
-    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error);
+    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error): string;
 
-    /**
-     * @return string
-     */
-    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error);
+    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error): string;
 }

--- a/src/Core/ErrorHandler/StandardErrorHandler.php
+++ b/src/Core/ErrorHandler/StandardErrorHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -17,43 +19,27 @@ namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
  */
 class StandardErrorHandler implements ErrorHandlerInterface
 {
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Parser\Exception $error
-     * @throws \TYPO3Fluid\Fluid\Core\Parser\Exception
-     */
-    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error)
+    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error): string
     {
         throw $error;
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error
-     * @throws \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException
-     */
-    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error)
+    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error): string
     {
         throw $error;
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error
-     * @throws \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
-     */
-    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error)
+    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error): string
     {
         throw $error;
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error
-     */
-    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error) {}
+    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error): string
+    {
+        return '';
+    }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\View\Exception $error
-     * @throws \TYPO3Fluid\Fluid\View\Exception
-     */
-    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error)
+    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error): string
     {
         throw $error;
     }

--- a/src/Core/ErrorHandler/TolerantErrorHandler.php
+++ b/src/Core/ErrorHandler/TolerantErrorHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -19,47 +21,27 @@ namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
  */
 class TolerantErrorHandler implements ErrorHandlerInterface
 {
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Parser\Exception $error
-     * @return string
-     */
-    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error)
+    public function handleParserError(\TYPO3Fluid\Fluid\Core\Parser\Exception $error): string
     {
         return 'Parser error: ' . $error->getMessage() . ' Offending code: ';
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error
-     * @return string
-     */
-    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error)
+    public function handleExpressionError(\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\Expression\ExpressionException $error): string
     {
         return 'Invalid expression: ' . $error->getMessage();
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error
-     * @return string
-     */
-    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error)
+    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error): string
     {
         return 'ViewHelper error: ' . $error->getMessage() . ' - Offending code: ';
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error
-     * @return string
-     */
-    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error)
+    public function handleCompilerError(\TYPO3Fluid\Fluid\Core\Compiler\StopCompilingException $error): string
     {
         return '';
     }
 
-    /**
-     * @param \TYPO3Fluid\Fluid\View\Exception $error
-     * @return string
-     */
-    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error)
+    public function handleViewError(\TYPO3Fluid\Fluid\View\Exception $error): string
     {
         if ($error instanceof \TYPO3Fluid\Fluid\View\Exception\InvalidSectionException) {
             return 'Section rendering error: ' . $error->getMessage() . ' Section rendering is mandatory; "optional" is false.';

--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -17,10 +19,10 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
     /**
      * @var VariableProviderInterface[]
      */
-    protected $variableProviders = [];
+    protected array $variableProviders = [];
 
     /**
-     * @param array $variableProviders
+     * @param VariableProviderInterface[] $variableProviders
      */
     public function __construct(array $variableProviders = [])
     {
@@ -28,9 +30,9 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
     }
 
     /**
-     * @return array
+     * @return VariableProviderInterface[]
      */
-    public function getAll()
+    public function getAll(): array
     {
         $merged = [];
         foreach (array_reverse($this->variableProviders) as $provider) {
@@ -39,11 +41,7 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
         return array_merge($merged, $this->variables);
     }
 
-    /**
-     * @param string $identifier
-     * @return mixed
-     */
-    public function get($identifier)
+    public function get(string $identifier): mixed
     {
         if (array_key_exists($identifier, $this->variables)) {
             return $this->variables[$identifier];
@@ -57,11 +55,7 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
         return null;
     }
 
-    /**
-     * @param string $path
-     * @return mixed|null
-     */
-    public function getByPath($path)
+    public function getByPath(string $path): mixed
     {
         if (array_key_exists($path, $this->variables)) {
             return $this->variables[$path];
@@ -76,10 +70,7 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
         return null;
     }
 
-    /**
-     * @return array
-     */
-    public function getAllIdentifiers()
+    public function getAllIdentifiers(): array
     {
         $merged = parent::getAllIdentifiers();
         foreach ($this->variableProviders as $provider) {
@@ -88,11 +79,7 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
         return array_values(array_unique($merged));
     }
 
-    /**
-     * @param array|\ArrayAccess $variables
-     * @return ChainedVariableProvider
-     */
-    public function getScopeCopy($variables)
+    public function getScopeCopy(array|\ArrayAccess $variables): ChainedVariableProvider
     {
         $clone = clone $this;
         $clone->setSource($variables);

--- a/src/Core/Variables/JSONVariableProvider.php
+++ b/src/Core/Variables/JSONVariableProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -15,10 +17,7 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  */
 class JSONVariableProvider extends StandardVariableProvider implements VariableProviderInterface
 {
-    /**
-     * @var int
-     */
-    protected $lastLoaded = 0;
+    protected int $lastLoaded = 0;
 
     /**
      * Lifetime of fetched JSON sources before refetch. Using
@@ -26,75 +25,51 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
      * should allow any HTTPD process to finish in time but make
      * any CLI/infinite running scripts re-fetch JSON after this
      * time has passed.
-     *
-     * @var int
      */
-    protected $ttl = 15;
+    protected int $ttl = 15;
 
     /**
      * JSON source. Either a complete JSON string with an object
      * inside, or a reference to a JSON file either local or
      * remote (supporting any stream types PHP supports).
-     *
-     * @var string
      */
-    protected $source;
+    protected string $source;
 
-    /**
-     * @return mixed
-     */
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->source;
     }
 
-    /**
-     * @param mixed $source
-     */
-    public function setSource($source)
+    public function setSource(mixed $source): void
     {
         $this->source = $source;
     }
 
-    /**
-     * @return array
-     */
-    public function getAll()
+    public function getAll(): array
     {
         $this->load();
         return parent::getAll();
     }
 
-    /**
-     * @param string $identifier
-     * @return mixed
-     */
-    public function get($identifier)
+    public function get(string $identifier): mixed
     {
         $this->load();
         return parent::get($identifier);
     }
 
-    /**
-     * @param string $path
-     * @return mixed
-     */
-    public function getByPath($path)
+    public function getByPath(string $path): mixed
     {
         $this->load();
         return parent::getByPath($path);
     }
 
-    /**
-     * @return array
-     */
-    public function getAllIdentifiers()
+    public function getAllIdentifiers(): array
     {
         $this->load();
         return parent::getAllIdentifiers();
     }
 
-    protected function load()
+    protected function load(): void
     {
         if ($this->source !== null && time() > ($this->lastLoaded + $this->ttl)) {
             if (!$this->isJSON($this->source)) {
@@ -107,11 +82,7 @@ class JSONVariableProvider extends StandardVariableProvider implements VariableP
         }
     }
 
-    /**
-     * @param string $string
-     * @return bool
-     */
-    protected function isJSON($string)
+    protected function isJSON(string $string): bool
     {
         $string = trim($string);
         return $string[0] === '{' && substr($string, -1) === '}';

--- a/src/Core/Variables/ScopedVariableProvider.php
+++ b/src/Core/Variables/ScopedVariableProvider.php
@@ -39,7 +39,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
      * @param string $identifier Identifier of the variable to add
      * @param mixed $value The variable's value
      */
-    public function add($identifier, $value): void
+    public function add(string $identifier, mixed $value): void
     {
         $this->globalVariables->add($identifier, $value);
         $this->localVariables->add($identifier, $value);
@@ -48,7 +48,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param string $identifier The identifier to remove
      */
-    public function remove($identifier): void
+    public function remove(string $identifier): void
     {
         $this->globalVariables->remove($identifier);
         $this->localVariables->remove($identifier);
@@ -57,7 +57,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param mixed $source
      */
-    public function setSource($source): void
+    public function setSource(mixed $source): void
     {
         $this->globalVariables->setSource($source);
     }
@@ -78,7 +78,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param string $identifier
      */
-    public function exists($identifier): bool
+    public function exists(string $identifier): bool
     {
         return $this->localVariables->exists($identifier) || $this->globalVariables->exists($identifier);
     }
@@ -86,7 +86,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param string $identifier
      */
-    public function get($identifier): mixed
+    public function get(string $identifier): mixed
     {
         return $this->localVariables->get($identifier) ?? $this->globalVariables->get($identifier);
     }
@@ -94,7 +94,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
     /**
      * @param string $path
      */
-    public function getByPath($path): mixed
+    public function getByPath(string $path): mixed
     {
         $path = $this->resolveSubVariableReferences($path);
         $identifier = explode('.', $path, 2)[0];
@@ -111,10 +111,7 @@ final class ScopedVariableProvider extends StandardVariableProvider implements V
         ));
     }
 
-    /**
-     * @param array|\ArrayAccess $variables
-     */
-    public function getScopeCopy($variables): VariableProviderInterface
+    public function getScopeCopy(array|\ArrayAccess $variables): VariableProviderInterface
     {
         // Instead of cloning the instance of ScopedVariableProvider,
         // only the instance holding global variables can be used here.

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -30,11 +32,7 @@ class StandardVariableProvider implements VariableProviderInterface
         $this->variables = $variables;
     }
 
-    /**
-     * @param array|\ArrayAccess $variables
-     * @return VariableProviderInterface
-     */
-    public function getScopeCopy($variables)
+    public function getScopeCopy(array|\ArrayAccess $variables): VariableProviderInterface
     {
         if (!array_key_exists('settings', $variables) && array_key_exists('settings', $this->variables)) {
             $variables['settings'] = $this->variables['settings'];
@@ -47,18 +45,13 @@ class StandardVariableProvider implements VariableProviderInterface
      * Set the source data used by this VariableProvider. The
      * source can be any type, but the type must of course be
      * supported by the VariableProvider itself.
-     *
-     * @param mixed $source
      */
-    public function setSource($source)
+    public function setSource(mixed $source): void
     {
         $this->variables = $source;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSource()
+    public function getSource(): mixed
     {
         return $this->variables;
     }
@@ -67,10 +60,8 @@ class StandardVariableProvider implements VariableProviderInterface
      * Get every variable provisioned by the VariableProvider
      * implementing the interface. Must return an array or
      * ArrayAccess instance!
-     *
-     * @return array|\ArrayAccess
      */
-    public function getAll()
+    public function getAll(): array|\ArrayAccess
     {
         return $this->variables;
     }
@@ -82,7 +73,7 @@ class StandardVariableProvider implements VariableProviderInterface
      * @param mixed $value The variable's value
      * @api
      */
-    public function add($identifier, $value)
+    public function add(string $identifier, mixed $value): void
     {
         $this->variables[$identifier] = $value;
     }
@@ -94,11 +85,10 @@ class StandardVariableProvider implements VariableProviderInterface
      * if one of the other reserved variables are given, their appropriate value
      * they're representing is returned.
      *
-     * @param string $identifier
      * @return mixed The variable value identified by $identifier
      * @api
      */
-    public function get($identifier)
+    public function get(string $identifier): mixed
     {
         return $this->getByPath($identifier);
     }
@@ -110,7 +100,7 @@ class StandardVariableProvider implements VariableProviderInterface
      * @param string $path
      * @return mixed
      */
-    public function getByPath($path)
+    public function getByPath(string $path): mixed
     {
         $subject = $this->variables;
         $subVariableReferences = explode('.', $this->resolveSubVariableReferences($path));
@@ -154,7 +144,7 @@ class StandardVariableProvider implements VariableProviderInterface
      * @param string $identifier The identifier to remove
      * @api
      */
-    public function remove($identifier)
+    public function remove(string $identifier): void
     {
         if (array_key_exists($identifier, $this->variables)) {
             unset($this->variables[$identifier]);
@@ -164,9 +154,9 @@ class StandardVariableProvider implements VariableProviderInterface
     /**
      * Returns an array of all identifiers available in the context.
      *
-     * @return array Array of identifier strings
+     * @return string[] Array of identifier strings
      */
-    public function getAllIdentifiers()
+    public function getAllIdentifiers(): array
     {
         return array_keys($this->variables);
     }
@@ -174,11 +164,10 @@ class StandardVariableProvider implements VariableProviderInterface
     /**
      * Checks if this property exists in the VariableContainer.
      *
-     * @param string $identifier
      * @return bool true if $identifier exists
      * @api
      */
-    public function exists($identifier)
+    public function exists(string $identifier): bool
     {
         return array_key_exists($identifier, $this->variables);
     }
@@ -188,50 +177,39 @@ class StandardVariableProvider implements VariableProviderInterface
      *
      * @return string[]
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['variables'];
     }
 
     /**
      * Adds a variable to the context.
-     *
-     * @param string $identifier Identifier of the variable to add
-     * @param mixed $value The variable's value
      */
-    public function offsetSet($identifier, $value)
+    public function offsetSet(mixed $identifier, mixed $value): void
     {
         $this->add($identifier, $value);
     }
 
     /**
      * Remove a variable from context.
-     *
-     * @param string $identifier The identifier to remove
      */
-    public function offsetUnset($identifier)
+    public function offsetUnset(mixed $identifier): void
     {
         $this->remove($identifier);
     }
 
     /**
      * Checks if this property exists in the VariableContainer.
-     *
-     * @param string $identifier
-     * @return bool true if $identifier exists
      */
-    public function offsetExists($identifier)
+    public function offsetExists(mixed $identifier): bool
     {
         return $this->exists($identifier);
     }
 
     /**
      * Get a variable from the context.
-     *
-     * @param string $identifier
-     * @return mixed The variable identified by $identifier
      */
-    public function offsetGet($identifier)
+    public function offsetGet(mixed $identifier): mixed
     {
         return $this->get($identifier);
     }
@@ -250,7 +228,7 @@ class StandardVariableProvider implements VariableProviderInterface
                 $subPropertyPath = substr($match, 1, -1);
                 $subPropertyValue = $this->getByPath($subPropertyPath);
                 if ($subPropertyValue !== null) {
-                    $propertyPath = str_replace($match, $subPropertyValue, $propertyPath);
+                    $propertyPath = str_replace($match, (string) $subPropertyValue, $propertyPath);
                 }
             }
         }

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -228,7 +228,7 @@ class StandardVariableProvider implements VariableProviderInterface
                 $subPropertyPath = substr($match, 1, -1);
                 $subPropertyValue = $this->getByPath($subPropertyPath);
                 if ($subPropertyValue !== null) {
-                    $propertyPath = str_replace($match, (string) $subPropertyValue, $propertyPath);
+                    $propertyPath = str_replace($match, (string)$subPropertyValue, $propertyPath);
                 }
             }
         }

--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -28,34 +30,24 @@ interface VariableProviderInterface extends \ArrayAccess
      * of the new VariableProvider as well as take care of any
      * automatically transferred variables (in the default
      * implementation the $settings variable is transferred).
-     *
-     * @param array|\ArrayAccess $variables
-     * @return VariableProviderInterface
      */
-    public function getScopeCopy($variables);
+    public function getScopeCopy(array|\ArrayAccess $variables): VariableProviderInterface;
 
     /**
      * Set the source data used by this VariableProvider. The
      * source can be any type, but the type must of course be
      * supported by the VariableProvider itself.
-     *
-     * @param mixed $source
      */
-    public function setSource($source);
+    public function setSource(mixed $source): void;
 
-    /**
-     * @return mixed
-     */
-    public function getSource();
+    public function getSource(): mixed;
 
     /**
      * Get every variable provisioned by the VariableProvider
      * implementing the interface. Must return an array or
      * ArrayAccess instance!
-     *
-     * @return array|\ArrayAccess
      */
-    public function getAll();
+    public function getAll(): array|\ArrayAccess;
 
     /**
      * Add a variable to the context
@@ -64,25 +56,21 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param mixed $value The variable's value
      * @api
      */
-    public function add($identifier, $value);
+    public function add(string $identifier, mixed $value): void;
 
     /**
      * Get a variable from the context.
      *
-     * @param string $identifier
      * @return mixed The variable value identified by $identifier
      * @api
      */
-    public function get($identifier);
+    public function get(string $identifier): mixed;
 
     /**
      * Get a variable by dotted path expression, retrieving the
      * variable from nested arrays/objects one segment at a time.
-     *
-     * @param string $path
-     * @return mixed
      */
-    public function getByPath($path);
+    public function getByPath(string $path): mixed;
 
     /**
      * Remove a variable from context.
@@ -90,56 +78,40 @@ interface VariableProviderInterface extends \ArrayAccess
      * @param string $identifier The identifier to remove
      * @api
      */
-    public function remove($identifier);
+    public function remove(string $identifier): void;
 
     /**
      * Returns an array of all identifiers available in the context.
      *
-     * @return array Array of identifier strings
+     * @return string[] Array of identifier strings
      */
-    public function getAllIdentifiers();
+    public function getAllIdentifiers(): array;
 
     /**
      * Checks if this property exists in the VariableContainer.
      *
-     * @param string $identifier
      * @return bool true if $identifier exists
      * @api
      */
-    public function exists($identifier);
+    public function exists(string $identifier): bool;
 
     /**
      * Adds a variable to the context.
-     *
-     * @param string $identifier Identifier of the variable to add
-     * @param mixed $value The variable's value
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($identifier, $value);
+    public function offsetSet(mixed $identifier, mixed $value): void;
 
     /**
      * Remove a variable from context.
-     *
-     * @param string $identifier The identifier to remove
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($identifier);
+    public function offsetUnset(mixed $identifier): void;
 
     /**
      * Checks if this property exists in the VariableContainer.
-     *
-     * @param string $identifier
-     * @return bool true if $identifier exists
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($identifier);
+    public function offsetExists(mixed $identifier): bool;
 
     /**
      * Get a variable from the context.
-     *
-     * @param string $identifier
-     * @return mixed The variable identified by $identifier
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($identifier);
+    public function offsetGet(mixed $identifier): mixed;
 }

--- a/src/Tools/ConsoleRunner.php
+++ b/src/Tools/ConsoleRunner.php
@@ -19,9 +19,9 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Exception;
 use TYPO3Fluid\Fluid\Schema\SchemaGenerator;
 use TYPO3Fluid\Fluid\Schema\ViewHelperFinder;
+use TYPO3Fluid\Fluid\View\AbstractTemplateView;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 use TYPO3Fluid\Fluid\View\TemplateView;
-use TYPO3Fluid\Fluid\View\ViewInterface;
 
 /**
  * @internal
@@ -233,11 +233,7 @@ final class ConsoleRunner
         return $view->render($action);
     }
 
-    /**
-     * @param FluidCacheWarmupResult $result
-     * @return string
-     */
-    private function renderWarmupResult(FluidCacheWarmupResult $result)
+    private function renderWarmupResult(FluidCacheWarmupResult $result): string
     {
         $string = PHP_EOL . 'Template cache warmup results' . PHP_EOL . PHP_EOL;
         foreach ($result->getResults() as $templatePathAndFilename => $aspects) {
@@ -270,11 +266,7 @@ final class ConsoleRunner
         return $string;
     }
 
-    /**
-     * @param string $socketIdentifier
-     * @param ViewInterface $view
-     */
-    private function listenIndefinitelyOnSocket($socketIdentifier, ViewInterface $view)
+    private function listenIndefinitelyOnSocket(string $socketIdentifier, AbstractTemplateView $view): void
     {
         if (file_exists($socketIdentifier)) {
             unlink($socketIdentifier);
@@ -304,12 +296,7 @@ final class ConsoleRunner
         }
     }
 
-    /**
-     * @param string $input
-     * @param TemplatePaths $paths
-     * @return string
-     */
-    private function parseTemplatePathAndFilenameFromHeaders($input, TemplatePaths $paths)
+    private function parseTemplatePathAndFilenameFromHeaders(string $input, TemplatePaths $paths): string
     {
         if (strpos($input, "\000") !== false) {
             return $this->parseTemplatePathAndFilenameFromScgiHeaders($input);
@@ -317,12 +304,7 @@ final class ConsoleRunner
         return $this->parseTemplatePathAndFilenameFromProcessedHeaders($input, $paths);
     }
 
-    /**
-     * @param string $input
-     * @param TemplatePaths $paths
-     * @return string
-     */
-    private function parseTemplatePathAndFilenameFromProcessedHeaders($input, TemplatePaths $paths)
+    private function parseTemplatePathAndFilenameFromProcessedHeaders(string $input, TemplatePaths $paths): string
     {
         $matches = [];
         preg_match('/^GET ([^\s]+)/', $input, $matches);
@@ -336,11 +318,7 @@ final class ConsoleRunner
         return $templateRootPath . $uri;
     }
 
-    /**
-     * @param string $input
-     * @return string
-     */
-    private function parseTemplatePathAndFilenameFromScgiHeaders($input)
+    private function parseTemplatePathAndFilenameFromScgiHeaders(string $input): string
     {
         $lines = explode("\000", $input);
         $parameters = [];
@@ -350,11 +328,7 @@ final class ConsoleRunner
         return $parameters['DOCUMENT_ROOT'] . $parameters['REQUEST_URI'];
     }
 
-    /**
-     * @param string $response
-     * @param int $code
-     */
-    private function createErrorResponse($response, $code)
+    private function createErrorResponse(string $response, int $code): string
     {
         $headers = [
             'HTTP/1.1 ' . $code . ' ' . $response,
@@ -362,11 +336,7 @@ final class ConsoleRunner
         return implode("\n", $headers) . "\n\n" . $response;
     }
 
-    /**
-     * @param string $response
-     * @return string
-     */
-    private function createResponse($response)
+    private function createResponse(string $response): string
     {
         $headers = [
             'HTTP/1.1 200 OK',
@@ -380,11 +350,9 @@ final class ConsoleRunner
     }
 
     /**
-     * @param $templatePathAndFilename
-     * @param ViewInterface $view
      * @return string
      */
-    private function renderSocketRequest($templatePathAndFilename, ViewInterface $view)
+    private function renderSocketRequest(string $templatePathAndFilename, AbstractTemplateView $view)
     {
         $view->getRenderingContext()->getTemplatePaths()->setTemplatePathAndFilename($templatePathAndFilename);
         return $view->render();
@@ -395,7 +363,7 @@ final class ConsoleRunner
      * @param string[] $allowed
      * @return array<string, mixed>
      */
-    private function parseAndValidateInputArguments(array $arguments, array $allowed)
+    private function parseAndValidateInputArguments(array $arguments, array $allowed): array
     {
         $argumentPointer = false;
         $parsed = [];
@@ -430,10 +398,7 @@ final class ConsoleRunner
         return $parsed;
     }
 
-    /**
-     * @return string
-     */
-    private function dumpHelpHeader()
+    private function dumpHelpHeader(): string
     {
         return PHP_EOL .
             '----------------------------------------------------------------------------------------------' . PHP_EOL .
@@ -466,10 +431,7 @@ final class ConsoleRunner
         return $parameterString . PHP_EOL;
     }
 
-    /**
-     * @return string
-     */
-    private function dumpRunExamples()
+    private function dumpRunExamples(): string
     {
         return <<< HELP
 Use the CLI utility in the following modes:


### PR DESCRIPTION
More type hints are applied in the following areas:

* ConsoleRunner
* Cache interface and implementations
* Cache warmup interface and implementations
* Variable providers
* Error handlers

While these changes are breaking, they shouldn't affect the vast majority of users,
since in most cases the Fluid implementations of the affected interfaces are used.