### PR TITLE
[TASK] Simplify calls to iterator_to_array()

### DIFF
--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -55,7 +55,7 @@ class ViewHelperVariableContainer
     {
         $this->objects[$viewHelperName] = array_replace_recursive(
             isset($this->objects[$viewHelperName]) ? $this->objects[$viewHelperName] : [],
-            $variables instanceof Traversable ? iterator_to_array($variables) : $variables,
+            iterator_to_array($variables),
         );
     }
 

--- a/src/ViewHelpers/FirstViewHelper.php
+++ b/src/ViewHelpers/FirstViewHelper.php
@@ -49,16 +49,8 @@ final class FirstViewHelper extends AbstractViewHelper
             );
         }
 
-        $value = self::iteratorToArray($value);
+        $value = iterator_to_array($value);
 
         return array_shift($value);
-    }
-
-    /**
-     * This ensures compatibility with PHP 8.1
-     */
-    private static function iteratorToArray(\Traversable|array $iterator): array
-    {
-        return is_array($iterator) ? $iterator : iterator_to_array($iterator);
     }
 }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -112,12 +112,7 @@ class ForViewHelper extends AbstractViewHelper
         }
 
         if ($arguments['reverse'] === true) {
-            // array_reverse only supports arrays
-            if (is_object($arguments['each'])) {
-                $each = $arguments['each'];
-                $arguments['each'] = iterator_to_array($each);
-            }
-            $arguments['each'] = array_reverse($arguments['each'], true);
+            $arguments['each'] = array_reverse(iterator_to_array($arguments['each']), true);
         }
         if (isset($arguments['iteration'])) {
             $iterationData = [

--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -89,7 +89,7 @@ final class JoinViewHelper extends AbstractViewHelper
             );
         }
 
-        $value = self::iteratorToArray($value);
+        $value = iterator_to_array($value);
 
         if (\count($value) < 2) {
             return (string)array_pop($value);
@@ -100,13 +100,5 @@ final class JoinViewHelper extends AbstractViewHelper
         }
 
         return implode($separator, \array_slice($value, 0, -1)) . $separatorLast . $value[\count($value) - 1];
-    }
-
-    /**
-     * This ensures compatibility with PHP 8.1
-     */
-    private static function iteratorToArray(\Traversable|array $iterator): array
-    {
-        return is_array($iterator) ? $iterator : iterator_to_array($iterator);
     }
 }

--- a/src/ViewHelpers/LastViewHelper.php
+++ b/src/ViewHelpers/LastViewHelper.php
@@ -49,16 +49,8 @@ final class LastViewHelper extends AbstractViewHelper
             );
         }
 
-        $value = self::iteratorToArray($value);
+        $value = iterator_to_array($value);
 
         return array_pop($value);
-    }
-
-    /**
-     * This ensures compatibility with PHP 8.1
-     */
-    private static function iteratorToArray(\Traversable|array $iterator): array
-    {
-        return is_array($iterator) ? $iterator : iterator_to_array($iterator);
     }
 }

--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -84,7 +84,7 @@ final class ReplaceViewHelper extends AbstractViewHelper
                 ), 1710441988);
             }
 
-            $replace = self::iteratorToArray($replace);
+            $replace = iterator_to_array($replace);
 
             $search = array_keys($replace);
             $replace = array_values($replace);
@@ -102,8 +102,8 @@ final class ReplaceViewHelper extends AbstractViewHelper
                 ), 1710441990);
             }
 
-            $search = is_iterable($search) ? self::iteratorToArray($search) : [$search];
-            $replace = is_iterable($replace) ? self::iteratorToArray($replace) : [$replace];
+            $search = is_iterable($search) ? iterator_to_array($search) : [$search];
+            $replace = is_iterable($replace) ? iterator_to_array($replace) : [$replace];
 
             if (\count($search) !== \count($replace)) {
                 throw new \InvalidArgumentException('Count of "search" and "replace" arguments must be the same.', 1710441991);
@@ -111,13 +111,5 @@ final class ReplaceViewHelper extends AbstractViewHelper
         }
 
         return str_replace($search, $replace, (string)$value);
-    }
-
-    /**
-     * This ensures compatibility with PHP 8.1
-     */
-    private static function iteratorToArray(\Traversable|array $iterator): array
-    {
-        return is_array($iterator) ? $iterator : iterator_to_array($iterator);
     }
 }


### PR DESCRIPTION
Since Fluid now requires at least PHP 8.2, we can simplify some calls to iterator_to_array(). Before PHP 8.2, the function could only handle iterator objects as argument, now also arrays are supported. We can remove some compatibility code which made sure that no arrays were passed to the function.