### PR TITLE
[TASK] Type hint arguments in ViewInterface

### DIFF
--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -23,7 +23,7 @@ interface ViewInterface
      * @return ViewInterface an instance of $this, to enable chaining
      * @api
      */
-    public function assign($key, $value);
+    public function assign(string $key, mixed $value);
 
     /**
      * Add multiple variables to the view data collection


### PR DESCRIPTION
Add proper type hints to the two arguments
in ViewInterface->assign(). This is not
breaking since existing implementations can
still accept "more" by not setting these
arguments - method arguments of subtypes
are contravariant. This will be backported
to 2.14.