### PR TITLE
[TASK] Type hint arguments in ViewInterface (#933)

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -91,7 +91,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * @return $this
      * @api
      */
-    public function assign($key, $value)
+    public function assign(string $key, mixed $value)
     {
         $this->baseRenderingContext->getVariableProvider()->add($key, $value);
         return $this;

--- a/src/View/AbstractView.php
+++ b/src/View/AbstractView.php
@@ -41,7 +41,7 @@ abstract class AbstractView implements ViewInterface
      * @return $this
      * @api
      */
-    public function assign($key, $value)
+    public function assign(string $key, mixed $value)
     {
         $this->variables[$key] = $value;
         return $this;

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -23,7 +23,7 @@ interface ViewInterface
      * @return ViewInterface an instance of $this, to enable chaining
      * @api
      */
-    public function assign($key, $value);
+    public function assign(string $key, mixed $value);
 
     /**
      * Add multiple variables to the view data collection


### PR DESCRIPTION
Add proper type hints to the two arguments
in ViewInterface->assign(). This is not
breaking since existing implementations can
still accept "more" by not setting these
arguments - method arguments of subtypes
are contravariant. This will be backported
to 2.14.