### PR TITLE
[TASK] Add more type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/Core/Parser/ParsingState.php
 
 		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:setViewHelperNode\\(\\)\\.$#"
-			count: 1
-			path: src/Core/Parser/SyntaxTree/ViewHelperNode.php
-
-		-
 			message: "#^Binary operation \"\\+\" between non\\-empty\\-string and 0 results in an error\\.$#"
 			count: 1
 			path: src/Core/Parser/TemplateParser.php

--- a/src/Core/Parser/Interceptor/Escape.php
+++ b/src/Core/Parser/Interceptor/Escape.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -25,7 +27,7 @@ class Escape implements InterceptorInterface
      *
      * @var bool
      */
-    protected $childrenEscapingEnabled = true;
+    protected bool $childrenEscapingEnabled = true;
 
     /**
      * A stack of ViewHelperNodes which currently disable the interceptor.
@@ -33,18 +35,16 @@ class Escape implements InterceptorInterface
      *
      * @var NodeInterface[]
      */
-    protected $viewHelperNodesWhichDisableTheInterceptor = [];
+    protected array $viewHelperNodesWhichDisableTheInterceptor = [];
 
     /**
      * Adds a ViewHelper node using the Format\HtmlspecialcharsViewHelper to the given node.
      * If "escapingInterceptorEnabled" in the ViewHelper is false, will disable itself inside the ViewHelpers body.
      *
-     * @param NodeInterface $node
      * @param int $interceptorPosition One of the INTERCEPT_* constants for the current interception point
      * @param ParsingState $parsingState the current parsing state. Not needed in this interceptor.
-     * @return NodeInterface
      */
-    public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState)
+    public function process(NodeInterface $node, $interceptorPosition, ParsingState $parsingState): NodeInterface
     {
         if ($interceptorPosition === InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER) {
             /** @var ViewHelperNode $node */
@@ -74,7 +74,7 @@ class Escape implements InterceptorInterface
      *
      * @return array Array of INTERCEPT_* constants
      */
-    public function getInterceptionPoints()
+    public function getInterceptionPoints(): array
     {
         return [
             InterceptorInterface::INTERCEPT_OPENING_VIEWHELPER,

--- a/src/Core/Parser/InterceptorInterface.php
+++ b/src/Core/Parser/InterceptorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -12,6 +14,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 /**
  * An interceptor interface. Interceptors are used in the parsing stage to change
  * the syntax tree of a template, e.g. by adding viewhelper nodes.
+ *
+ * @todo add return types with Fluid v5
  */
 interface InterceptorInterface
 {

--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -21,16 +23,18 @@ abstract class AbstractNode implements NodeInterface
      *
      * @var NodeInterface[]
      */
-    protected $childNodes = [];
+    protected array $childNodes = [];
 
     /**
      * Evaluate all child nodes and return the evaluated results.
      *
-     * @param RenderingContextInterface $renderingContext
-     * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
+     * @return mixed If no child nodes exist, null is returned; If exactly one child node exists,
+     *               the evaluated value of that node is returned, which can be anything (because
+     *               ViewHelpers can return any type); If more than one child node exists, all nodes
+     *               will be converted to string and will be concatenated
      * @throws Parser\Exception
      */
-    public function evaluateChildNodes(RenderingContextInterface $renderingContext)
+    public function evaluateChildNodes(RenderingContextInterface $renderingContext): mixed
     {
         $evaluatedNodes = [];
         foreach ($this->getChildNodes() as $childNode) {
@@ -43,16 +47,14 @@ abstract class AbstractNode implements NodeInterface
         if (count($evaluatedNodes) === 1) {
             return $evaluatedNodes[0];
         }
-        return implode('', array_map([$this, 'castToString'], $evaluatedNodes));
+        return implode('', array_map($this->castToString(...), $evaluatedNodes));
     }
 
     /**
-     * @param NodeInterface $node
-     * @param RenderingContextInterface $renderingContext
-     * @param bool $cast
-     * @return mixed
+     * @return mixed Returns string if $cast is set to true, else it can return anything (because
+     *               ViewHelpers can return any type).
      */
-    protected function evaluateChildNode(NodeInterface $node, RenderingContextInterface $renderingContext, $cast)
+    protected function evaluateChildNode(NodeInterface $node, RenderingContextInterface $renderingContext, bool $cast): mixed
     {
         $output = $node->evaluate($renderingContext);
         if ($cast) {
@@ -61,11 +63,7 @@ abstract class AbstractNode implements NodeInterface
         return $output;
     }
 
-    /**
-     * @param mixed $value
-     * @return string
-     */
-    protected function castToString($value)
+    protected function castToString(mixed $value): string
     {
         if (is_object($value) && !method_exists($value, '__toString')) {
             throw new Parser\Exception('Cannot cast object of type "' . get_class($value) . '" to string.', 1273753083);
@@ -83,7 +81,7 @@ abstract class AbstractNode implements NodeInterface
      *
      * @return NodeInterface[] A list of nodes
      */
-    public function getChildNodes()
+    public function getChildNodes(): array
     {
         return $this->childNodes;
     }
@@ -93,7 +91,7 @@ abstract class AbstractNode implements NodeInterface
      *
      * @param NodeInterface $childNode The sub node to add
      */
-    public function addChildNode(NodeInterface $childNode)
+    public function addChildNode(NodeInterface $childNode): void
     {
         $this->childNodes[] = $childNode;
     }

--- a/src/Core/Parser/SyntaxTree/ArrayNode.php
+++ b/src/Core/Parser/SyntaxTree/ArrayNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -31,7 +33,7 @@ class ArrayNode extends AbstractNode
      * @param RenderingContextInterface $renderingContext
      * @return array An associative array with literal values
      */
-    public function evaluate(RenderingContextInterface $renderingContext)
+    public function evaluate(RenderingContextInterface $renderingContext): array
     {
         $arrayToBuild = [];
         foreach ($this->internalArray as $key => $value) {

--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -24,7 +26,7 @@ class BooleanNode extends AbstractNode
      *
      * @var NodeInterface[]
      */
-    protected $childNodes = [];
+    protected array $childNodes = [];
 
     /**
      * @var array
@@ -59,12 +61,7 @@ class BooleanNode extends AbstractNode
         return self::evaluateStack($renderingContext, $this->stack);
     }
 
-    /**
-     * @param NodeInterface $node
-     * @param RenderingContextInterface $renderingContext
-     * @return bool
-     */
-    public static function createFromNodeAndEvaluate(NodeInterface $node, RenderingContextInterface $renderingContext)
+    public static function createFromNodeAndEvaluate(NodeInterface $node, RenderingContextInterface $renderingContext): bool
     {
         $booleanNode = new BooleanNode($node);
         return $booleanNode->evaluate($renderingContext);
@@ -74,10 +71,6 @@ class BooleanNode extends AbstractNode
      * Takes a stack of nodes evaluates it with the end result
      * being a single boolean value. Creates new BooleanNodes
      * recursively to process braced expressions as single units.
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @param array $expressionParts
-     * @return bool the boolean value
      */
     public static function evaluateStack(RenderingContextInterface $renderingContext, array $expressionParts): bool
     {

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -8,7 +10,6 @@
 namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -24,11 +25,6 @@ class EscapingNode extends AbstractNode
      */
     protected NodeInterface $node;
 
-    /**
-     * Constructor.
-     *
-     * @param NodeInterface $node
-     */
     public function __construct(NodeInterface $node)
     {
         $this->node = $node;
@@ -37,10 +33,10 @@ class EscapingNode extends AbstractNode
     /**
      * Return the value associated to the syntax tree.
      *
-     * @param RenderingContextInterface $renderingContext
-     * @return mixed the value stored in this node/subtree.
+     * @return mixed escaped string if evaluated node is of type string or is stringable; otherwise
+     *               the evaluated value of the node will be returned as-is
      */
-    public function evaluate(RenderingContextInterface $renderingContext)
+    public function evaluate(RenderingContextInterface $renderingContext): mixed
     {
         $evaluated = $this->node->evaluate($renderingContext);
         if (is_string($evaluated) || (is_object($evaluated) && method_exists($evaluated, '__toString'))) {
@@ -58,9 +54,8 @@ class EscapingNode extends AbstractNode
      * NumericNode does not allow adding child nodes, so this will always throw an exception.
      *
      * @param NodeInterface $childNode The sub node to add
-     * @throws Parser\Exception
      */
-    public function addChildNode(NodeInterface $childNode)
+    public function addChildNode(NodeInterface $childNode): void
     {
         $this->node = $childNode;
     }

--- a/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/AbstractExpressionNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -15,6 +17,7 @@ use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 
 /**
  * Base class for nodes based on (shorthand) expressions.
+ * @todo add return types with Fluid v5
  */
 abstract class AbstractExpressionNode extends AbstractNode implements ExpressionNodeInterface
 {
@@ -23,12 +26,12 @@ abstract class AbstractExpressionNode extends AbstractNode implements Expression
      *
      * @var string
      */
-    protected $expression;
+    protected string $expression;
 
     /**
      * @var array
      */
-    protected $matches = [];
+    protected array $matches = [];
 
     /**
      * Constructor.
@@ -37,7 +40,7 @@ abstract class AbstractExpressionNode extends AbstractNode implements Expression
      * @param array $matches Matches extracted from expression
      * @throws Parser\Exception
      */
-    public function __construct($expression, array $matches)
+    public function __construct(string $expression, array $matches)
     {
         $this->expression = trim($expression, " \t\n\r\0\x0b");
         $this->matches = $matches;
@@ -68,9 +71,6 @@ abstract class AbstractExpressionNode extends AbstractNode implements Expression
      * The expression and matches can be read from the local
      * instance - and the RenderingContext and other APIs
      * can be accessed via the TemplateCompiler.
-     *
-     * @param TemplateCompiler $templateCompiler
-     * @return array
      */
     public function compile(TemplateCompiler $templateCompiler)
     {
@@ -93,37 +93,23 @@ abstract class AbstractExpressionNode extends AbstractNode implements Expression
 
     /**
      * Getter for returning the expression before parsing.
-     *
-     * @return string
      */
-    public function getExpression()
+    public function getExpression(): string
     {
         return $this->expression;
     }
 
-    /**
-     * @return array
-     */
-    public function getMatches()
+    public function getMatches(): array
     {
         return $this->matches;
     }
 
-    /**
-     * @param string $part
-     * @return string
-     */
-    protected static function trimPart($part)
+    protected static function trimPart(string $part): string
     {
         return trim($part, " \t\n\r\0\x0b{}");
     }
 
-    /**
-     * @param mixed $candidate
-     * @param RenderingContextInterface $renderingContext
-     * @return mixed
-     */
-    protected static function getTemplateVariableOrValueItself($candidate, RenderingContextInterface $renderingContext)
+    protected static function getTemplateVariableOrValueItself(mixed $candidate, RenderingContextInterface $renderingContext): mixed
     {
         $variables = $renderingContext->getVariableProvider()->getAll();
         $standardVariableProvider = new StandardVariableProvider();

--- a/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/CastingExpressionNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -18,10 +20,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class CastingExpressionNode extends AbstractExpressionNode
 {
-    /**
-     * @var array
-     */
-    protected static $validTypes = [
+    protected static array $validTypes = [
         'integer', 'boolean', 'string', 'float', 'array', 'DateTime',
     ];
 
@@ -31,7 +30,7 @@ class CastingExpressionNode extends AbstractExpressionNode
      * of the expression can also be a variable containing the type
      * of the variable.
      */
-    public static $detectionExpression = '/
+    public static string $detectionExpression = '/
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
@@ -42,13 +41,7 @@ class CastingExpressionNode extends AbstractExpressionNode
 			}                                # End of shorthand syntax
 		)/x';
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     * @param string $expression
-     * @param array $matches
-     * @return int|float
-     */
-    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches)
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, string $expression, array $matches): mixed
     {
         $expression = trim($expression, '{}');
         list($variable, $type) = explode(' as ', $expression);
@@ -68,12 +61,7 @@ class CastingExpressionNode extends AbstractExpressionNode
         return self::convertStatic($variable, $type);
     }
 
-    /**
-     * @param mixed $variable
-     * @param string $type
-     * @return mixed
-     */
-    protected static function convertStatic($variable, $type)
+    protected static function convertStatic(mixed $variable, string $type): mixed
     {
         $value = null;
         if ($type === 'integer') {
@@ -92,23 +80,15 @@ class CastingExpressionNode extends AbstractExpressionNode
         return $value;
     }
 
-    /**
-     * @param mixed $variable
-     * @return \DateTime|false
-     */
-    protected static function convertToDateTime($variable)
+    protected static function convertToDateTime(mixed $variable): \DateTime|false
     {
-        if (preg_match_all('/[a-z]+/i', $variable)) {
+        if (is_string($variable) || $variable instanceof \Stringable && preg_match_all('/[a-z]+/i', $variable)) {
             return new \DateTime($variable);
         }
-        return \DateTime::createFromFormat('U', (int)$variable);
+        return \DateTime::createFromFormat('U', (string)(int)$variable);
     }
 
-    /**
-     * @param mixed $variable
-     * @return array
-     */
-    protected static function convertToArray($variable)
+    protected static function convertToArray(mixed $variable): array
     {
         if (is_array($variable)) {
             return $variable;

--- a/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/Expression/ExpressionNodeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -13,6 +15,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * Interface for shorthand expression node types
+ * @todo add return types with Fluid v5
  */
 interface ExpressionNodeInterface extends NodeInterface
 {
@@ -35,7 +38,7 @@ interface ExpressionNodeInterface extends NodeInterface
      * @param array $matches
      * @return mixed
      */
-    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches);
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, string $expression, array $matches);
 
     /**
      * Compiles the ExpressionNode, returning an array with

--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -26,7 +26,7 @@ class MathExpressionNode extends AbstractExpressionNode
      *
      * {variable * 10}, {100 / variable}, {variable + variable2} etc.
      */
-    public static $detectionExpression = '/
+    public static string $detectionExpression = '/
 		(
 			{                                # Start of shorthand syntax
 				(?:                          # Math expression is composed of...
@@ -36,13 +36,7 @@ class MathExpressionNode extends AbstractExpressionNode
 			}                                # End of shorthand syntax
 		)/x';
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     * @param string $expression
-     * @param array $matches
-     * @return int|float
-     */
-    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches): int|float
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, string $expression, array $matches): int|float
     {
         // Split the expression on all recognized operators
         $matches = [];

--- a/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/TernaryExpressionNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -24,7 +26,7 @@ class TernaryExpressionNode extends AbstractExpressionNode
      * Pattern which detects ternary conditions written in shorthand
      * syntax, e.g. {checkvar ? thenvar : elsevar}.
      */
-    public static $detectionExpression = '/
+    public static string $detectionExpression = '/
 		(
 			{                                                               # Start of shorthand syntax
 				(?:                                                         # Math expression is composed of...
@@ -40,15 +42,9 @@ class TernaryExpressionNode extends AbstractExpressionNode
     /**
      * Filter out variable names form expression
      */
-    protected static $variableDetection = '/[^\'_a-zA-Z0-9\.\\\\]{0,1}([_a-zA-Z0-9\.\\\\]*)[^\']{0,1}/';
+    protected static string $variableDetection = '/[^\'_a-zA-Z0-9\.\\\\]{0,1}([_a-zA-Z0-9\.\\\\]*)[^\']{0,1}/';
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     * @param string $expression
-     * @param array $matches
-     * @return mixed
-     */
-    public static function evaluateExpression(RenderingContextInterface $renderingContext, $expression, array $matches)
+    public static function evaluateExpression(RenderingContextInterface $renderingContext, string $expression, array $matches): mixed
     {
         $parts = preg_split('/([\?:])/s', $expression);
         $parts = array_map([__CLASS__, 'trimPart'], $parts);
@@ -69,12 +65,7 @@ class TernaryExpressionNode extends AbstractExpressionNode
         return static::getTemplateVariableOrValueItself($renderingContext->getTemplateParser()->unquoteString($else), $renderingContext);
     }
 
-    /**
-     * @param mixed $candidate
-     * @param RenderingContextInterface $renderingContext
-     * @return mixed
-     */
-    public static function getTemplateVariableOrValueItself($candidate, RenderingContextInterface $renderingContext)
+    public static function getTemplateVariableOrValueItself(mixed $candidate, RenderingContextInterface $renderingContext): mixed
     {
         $suspect = parent::getTemplateVariableOrValueItself($candidate, $renderingContext);
         if ($suspect === $candidate) {
@@ -85,12 +76,8 @@ class TernaryExpressionNode extends AbstractExpressionNode
 
     /**
      * Gather all context variables used in the expression
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @param string $expression
-     * @return array
      */
-    public static function gatherContext($renderingContext, $expression)
+    public static function gatherContext(RenderingContextInterface $renderingContext, string $expression): array
     {
         $context = [];
         if (preg_match_all(static::$variableDetection, $expression, $matches) > 0) {
@@ -115,10 +102,9 @@ class TernaryExpressionNode extends AbstractExpressionNode
      * instance - and the RenderingContext and other APIs
      * can be accessed via the TemplateCompiler.
      *
-     * @param TemplateCompiler $templateCompiler
      * @return array<string, string>
      */
-    public function compile(TemplateCompiler $templateCompiler)
+    public function compile(TemplateCompiler $templateCompiler): array
     {
         $parts = preg_split('/([\?:])/s', $this->getExpression());
         $parts = array_map([__CLASS__, 'trimPart'], $parts);

--- a/src/Core/Parser/SyntaxTree/NodeInterface.php
+++ b/src/Core/Parser/SyntaxTree/NodeInterface.php
@@ -19,23 +19,23 @@ interface NodeInterface
      * Evaluate all child nodes and return the evaluated results.
      *
      * @param RenderingContextInterface $renderingContext
-     * @return mixed Normally, an object is returned - in case it is concatenated with a string, a string is returned.
+     * @return mixed Normally, any type can be returned - in case it is concatenated with a string, a string is returned.
      */
-    public function evaluateChildNodes(RenderingContextInterface $renderingContext);
+    public function evaluateChildNodes(RenderingContextInterface $renderingContext): mixed;
 
     /**
      * Returns all child nodes for a given node.
      *
-     * @return array<\TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface> A list of nodes
+     * @return \TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface[] A list of nodes
      */
-    public function getChildNodes();
+    public function getChildNodes(): array;
 
     /**
      * Appends a sub node to this node. Is used inside the parser to append children
      *
      * @param NodeInterface $childNode The sub node to add
      */
-    public function addChildNode(NodeInterface $childNode);
+    public function addChildNode(NodeInterface $childNode): void;
 
     /**
      * Evaluates the node - can return not only strings, but arbitary objects.

--- a/src/Core/Parser/SyntaxTree/NumericNode.php
+++ b/src/Core/Parser/SyntaxTree/NumericNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -23,15 +25,15 @@ class NumericNode extends AbstractNode
      * Contents of the numeric node
      * @var number
      */
-    protected $value;
+    protected float|int $value;
 
     /**
      * Constructor.
      *
-     * @param string|number $value value to store in this numericNode
+     * @param float|int|string $value value to store in this numericNode
      * @throws Parser\Exception
      */
-    public function __construct($value)
+    public function __construct(float|int|string $value)
     {
         if (!is_numeric($value)) {
             throw new Parser\Exception('Numeric node requires an argument of type number, "' . gettype($value) . '" given.');
@@ -42,20 +44,14 @@ class NumericNode extends AbstractNode
     /**
      * Return the value associated to the syntax tree.
      *
-     * @param RenderingContextInterface $renderingContext
-     * @return number the value stored in this node/subtree.
+     * @return float|int the value stored in this node/subtree.
      */
-    public function evaluate(RenderingContextInterface $renderingContext)
+    public function evaluate(RenderingContextInterface $renderingContext): float|int
     {
         return $this->value;
     }
 
-    /**
-     * Getter for value
-     *
-     * @return number The value of this node
-     */
-    public function getValue()
+    public function getValue(): float|int
     {
         return $this->value;
     }
@@ -66,7 +62,7 @@ class NumericNode extends AbstractNode
      * @param NodeInterface $childNode The sub node to add
      * @throws Parser\Exception
      */
-    public function addChildNode(NodeInterface $childNode)
+    public function addChildNode(NodeInterface $childNode): void
     {
         throw new Parser\Exception('Numeric nodes may not contain child nodes, tried to add "' . get_class($childNode) . '".');
     }

--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -20,10 +22,8 @@ class ObjectAccessorNode extends AbstractNode
 {
     /**
      * Object path which will be called. Is a list like "post.name.email"
-     *
-     * @var string
      */
-    protected $objectPath;
+    protected string $objectPath;
 
     /**
      * Constructor. Takes an object path as input.
@@ -33,7 +33,7 @@ class ObjectAccessorNode extends AbstractNode
      *
      * @param string $objectPath An Object Path, like object1.object2.object3
      */
-    public function __construct($objectPath)
+    public function __construct(string $objectPath)
     {
         $this->objectPath = $objectPath;
     }
@@ -58,10 +58,9 @@ class ObjectAccessorNode extends AbstractNode
      * The first part of the object path has to be a variable in the
      * VariableProvider.
      *
-     * @param RenderingContextInterface $renderingContext
      * @return mixed The evaluated object, can be any object type.
      */
-    public function evaluate(RenderingContextInterface $renderingContext)
+    public function evaluate(RenderingContextInterface $renderingContext): mixed
     {
         $objectPath = strtolower($this->objectPath);
         $variableProvider = $renderingContext->getVariableProvider();

--- a/src/Core/Parser/SyntaxTree/RootNode.php
+++ b/src/Core/Parser/SyntaxTree/RootNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -21,16 +23,15 @@ class RootNode extends AbstractNode
     /**
      * Evaluate the root node, by evaluating the subtree.
      *
-     * @param RenderingContextInterface $renderingContext
      * @return mixed Evaluated subtree
      */
-    public function evaluate(RenderingContextInterface $renderingContext)
+    public function evaluate(RenderingContextInterface $renderingContext): mixed
     {
         return $this->evaluateChildNodes($renderingContext);
     }
 
     /**
-     * @todo: Similar to TemplateCompiler->convertSubNodes(). See it's todo.
+     * @todo: Similar to TemplateCompiler->convertSubNodes(). See its todo.
      */
     public function convert(TemplateCompiler $templateCompiler): array
     {

--- a/src/Core/Parser/SyntaxTree/TextNode.php
+++ b/src/Core/Parser/SyntaxTree/TextNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.

--- a/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -16,17 +18,11 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  */
 class EscapingModifierTemplateProcessor implements TemplateProcessorInterface
 {
-    /**
-     * @var RenderingContextInterface
-     */
-    protected $renderingContext;
+    protected RenderingContextInterface $renderingContext;
 
     public const SCAN_PATTERN_ESCAPINGMODIFIER = '/{(escaping|escapingEnabled)\s*=*\s*(true|false|on|off)\s*}/i';
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     */
-    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    public function setRenderingContext(RenderingContextInterface $renderingContext): void
     {
         $this->renderingContext = $renderingContext;
     }
@@ -35,11 +31,8 @@ class EscapingModifierTemplateProcessor implements TemplateProcessorInterface
      * Pre-process the template source before it is
      * returned to the TemplateParser or passed to
      * the next TemplateProcessorInterface instance.
-     *
-     * @param string $templateSource
-     * @return string
      */
-    public function preProcessSource($templateSource)
+    public function preProcessSource(string $templateSource): string
     {
         if (strpos($templateSource, '{escaping') === false) {
             // No escaping modifier detected - early return to skip preg processing

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -23,15 +25,9 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
 {
     public const NAMESPACE_DECLARATION = '/(?<!\\\\){namespace\s*(?P<identifier>[a-zA-Z\*]+[a-zA-Z0-9\.\*]*)\s*(=\s*(?P<phpNamespace>(?:[A-Za-z0-9\.]+|Tx)(?:\\\\\w+)+)\s*)?}/m';
 
-    /**
-     * @var RenderingContextInterface
-     */
-    protected $renderingContext;
+    protected RenderingContextInterface $renderingContext;
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     */
-    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    public function setRenderingContext(RenderingContextInterface $renderingContext): void
     {
         $this->renderingContext = $renderingContext;
     }
@@ -40,11 +36,8 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      * Pre-process the template source before it is
      * returned to the TemplateParser or passed to
      * the next TemplateProcessorInterface instance.
-     *
-     * @param string $templateSource
-     * @return string
      */
-    public function preProcessSource($templateSource)
+    public function preProcessSource(string $templateSource): string
     {
         $templateSource = $this->replaceCdataSectionsByEmptyLines($templateSource);
         $templateSource = $this->registerNamespacesFromTemplateSource($templateSource);
@@ -55,11 +48,8 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      * Replaces all cdata sections with empty lines to exclude it from further
      * processing in the templateParser while maintaining the line-count
      * of the template string for the exception handler to reference to.
-     *
-     * @param string $templateSource
-     * @return string
      */
-    public function replaceCdataSectionsByEmptyLines($templateSource)
+    public function replaceCdataSectionsByEmptyLines(string $templateSource): string
     {
         $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -81,11 +71,8 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
 
     /**
      * Register all namespaces that are declared inside the template string
-     *
-     * @param string $templateSource
-     * @return string
      */
-    public function registerNamespacesFromTemplateSource($templateSource)
+    public function registerNamespacesFromTemplateSource(string $templateSource): string
     {
         $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
         $matches = [];

--- a/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/PassthroughSourceModifierTemplateProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -24,11 +26,9 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 class PassthroughSourceModifierTemplateProcessor implements TemplateProcessorInterface
 {
     /**
-     * @param string $templateSource
-     * @return string
      * @throws PassthroughSourceException
      */
-    public function preProcessSource($templateSource)
+    public function preProcessSource(string $templateSource): string
     {
         if (strpos($templateSource, '{parsing off}') !== false) {
             $templateSource = str_replace('{parsing off}', '', $templateSource);
@@ -39,10 +39,7 @@ class PassthroughSourceModifierTemplateProcessor implements TemplateProcessorInt
         return str_replace('{parsing on}', '', $templateSource);
     }
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     */
-    public function setRenderingContext(RenderingContextInterface $renderingContext)
+    public function setRenderingContext(RenderingContextInterface $renderingContext): void
     {
         // void
     }

--- a/src/Core/Parser/TemplateProcessorInterface.php
+++ b/src/Core/Parser/TemplateProcessorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -21,6 +23,8 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * For example, allowing an implementer to extract
  * custom instructions from the template which are
  * then used to manipulate how ViewHelpers resolve.
+ *
+ * @todo add return types with Fluid v5
  */
 interface TemplateProcessorInterface
 {
@@ -34,8 +38,7 @@ interface TemplateProcessorInterface
      * returned to the TemplateParser or passed to
      * the next TemplateProcessorInterface instance.
      *
-     * @param string $templateSource
      * @return string
      */
-    public function preProcessSource($templateSource);
+    public function preProcessSource(string $templateSource);
 }

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -30,6 +30,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * Make sure to NOT OVERRIDE the constructor.
  *
  * @api
+ * @todo add missing types with Fluid v5
  */
 abstract class AbstractConditionViewHelper extends AbstractViewHelper
 {

--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  * convenience methods to register default attributes, ...
  *
  * @api
+ * @todo add missing types with Fluid v5
  */
 abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
 {

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -18,6 +18,7 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  * The abstract base class for all view helpers.
  *
  * @api
+ * @todo add missing types with Fluid v5
  */
 abstract class AbstractViewHelper implements ViewHelperInterface
 {

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -20,6 +20,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
  * an argument value must be checked and used instead of
  * the normal render children closure, if that named
  * argument is specified and not empty.
+ *
+ * @todo add missing types with Fluid v5
  */
 trait CompileWithContentArgumentAndRenderStatic
 {

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -16,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
  * Provides default methods for rendering and compiling
  * any ViewHelper that conforms to the `renderStatic`
  * method pattern.
+ *
+ * @todo add missing types with Fluid v5
  */
 trait CompileWithRenderStatic
 {

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -24,6 +24,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *           in the AbstractViewHelper and maintained.
  *           We'll try to resolve this restriction midterm, but you should
  *           not fully implement ViewHelperInterface yourself for now.
+ * @todo add missing types with Fluid v5
  */
 interface ViewHelperInterface
 {

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -50,7 +50,7 @@ interface ViewHelperInterface
     /**
      * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
      *
-     * @return string the rendered ViewHelper.
+     * @return mixed the rendered ViewHelper.
      */
     public function initializeArgumentsAndRender();
 
@@ -117,7 +117,7 @@ interface ViewHelperInterface
      * @param array<string, mixed> $arguments
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
-     * @return string the resulting string which is directly shown
+     * @return mixed the resulting value from the ViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext);
 

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -36,7 +36,7 @@ class ViewHelperInvoker
      * Invoke the ViewHelper described by the ViewHelperNode, the properties
      * of which will already have been filled by the ViewHelperResolver.
      *
-     * @return string
+     * @return mixed
      */
     public function invoke(string|ViewHelperInterface $viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null)
     {

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -35,10 +35,8 @@ class ViewHelperInvoker
     /**
      * Invoke the ViewHelper described by the ViewHelperNode, the properties
      * of which will already have been filled by the ViewHelperResolver.
-     *
-     * @return mixed
      */
-    public function invoke(string|ViewHelperInterface $viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null)
+    public function invoke(string|ViewHelperInterface $viewHelperClassNameOrInstance, array $arguments, RenderingContextInterface $renderingContext, ?\Closure $renderChildrenClosure = null): mixed
     {
         $viewHelperResolver = $renderingContext->getViewHelperResolver();
         if ($viewHelperClassNameOrInstance instanceof ViewHelperInterface) {

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -20,6 +22,8 @@ use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
  * Abstract Fluid Template View.
  *
  * Contains the fundamental methods which any Fluid based template view needs.
+ *
+ * @todo add return types with Fluid v5
  */
 abstract class AbstractTemplateView extends AbstractView implements TemplateAwareViewInterface
 {

--- a/src/View/TemplateView.php
+++ b/src/View/TemplateView.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -11,6 +13,7 @@ namespace TYPO3Fluid\Fluid\View;
  * Interface of a view
  *
  * @api
+ * @todo add return types with Fluid v5
  */
 interface ViewInterface
 {


### PR DESCRIPTION
This patch adds more type hints to selected classes. For classes that are probably
extended by Fluid integrations, we don't implement all return type hints to prevent
hard-breaking existing functionality. In addition to careful consideration when
adding the types, this is verified by running the changes against TYPO3 Core CI
to catch any unwanted breaking changes. Some `@todo` lines have been added to
interfaces that are user-facing functionality and thus will get return types with
Fluid v5.

This patch also clarifies return types of ViewHelpers and functions that pass along
those values. In some areas, the existing PHPDOC annotations were incorrect here
because they didn't properly account for the fact that a ViewHelper can return
any type, not just a string, as long as its either stringable or will be directly
used by another ViewHelper that can take that type as an input value.