### PR TITLE
[!!!][TASK] Add type hints to template compiler

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Core/Compiler/TemplateCompiler.php
 
 		-
-			message: "#^Property TYPO3Fluid\\\\Fluid\\\\Core\\\\Compiler\\\\TemplateCompiler\\:\\:\\$currentlyProcessingState \\(TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\ParsedTemplateInterface\\) does not accept null\\.$#"
-			count: 1
-			path: src/Core/Compiler/TemplateCompiler.php
-
-		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/Interceptor/Escape.php
@@ -19,11 +14,6 @@ parameters:
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isOutputEscapingEnabled\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/Interceptor/Escape.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$rootNode with type TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\SyntaxTree\\\\NodeInterface is not subtype of native type TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\SyntaxTree\\\\RootNode\\.$#"
-			count: 1
-			path: src/Core/Parser/ParsingState.php
 
 		-
 			message: "#^Binary operation \"\\+\" between non\\-empty\\-string and 0 results in an error\\.$#"

--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -19,28 +19,17 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  */
 abstract class AbstractCompiledTemplate implements ParsedTemplateInterface
 {
-    /**
-     * @param string $identifier
-     */
-    public function setIdentifier($identifier)
+    public function setIdentifier(string $identifier): void
     {
         // void, ignored.
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return static::class;
     }
 
-    /**
-     * Returns a variable container used in the PostParse Facet.
-     *
-     * @return VariableProviderInterface
-     */
-    public function getVariableContainer()
+    public function getVariableContainer(): VariableProviderInterface
     {
         return new StandardVariableProvider();
     }
@@ -51,46 +40,30 @@ abstract class AbstractCompiledTemplate implements ParsedTemplateInterface
      * @param RenderingContextInterface $renderingContext The rendering context to use
      * @return string Rendered string
      */
-    public function render(RenderingContextInterface $renderingContext)
+    public function render(RenderingContextInterface $renderingContext): mixed
     {
         return '';
     }
 
-    /**
-     * @return bool
-     */
-    public function isCompilable()
+    public function isCompilable(): bool
     {
         return false;
     }
 
-    /**
-     * @return bool
-     */
-    public function isCompiled()
+    public function isCompiled(): bool
     {
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasLayout()
+    public function hasLayout(): bool
     {
         return false;
     }
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
-    public function getLayoutName(RenderingContextInterface $renderingContext)
+    public function getLayoutName(RenderingContextInterface $renderingContext): ?string
     {
         return '';
     }
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     */
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {}
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext): void {}
 }

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -7,6 +9,7 @@
 
 namespace TYPO3Fluid\Fluid\Core\Parser;
 
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
@@ -16,55 +19,39 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  */
 interface ParsedTemplateInterface
 {
-    /**
-     * @param string $identifier
-     */
-    public function setIdentifier($identifier);
+    public function setIdentifier(string $identifier);
 
-    /**
-     * @return string
-     */
-    public function getIdentifier();
+    public function getIdentifier(): string;
 
     /**
      * Render the parsed template with rendering context
      *
      * @param RenderingContextInterface $renderingContext The rendering context to use
-     * @return string Rendered string
      */
-    public function render(RenderingContextInterface $renderingContext);
+    public function render(RenderingContextInterface $renderingContext): mixed;
 
     /**
      * Returns a variable container used in the PostParse Facet.
-     *
-     * @return VariableProviderInterface
      */
-    public function getVariableContainer();
+    public function getVariableContainer(): VariableProviderInterface;
 
     /**
      * Returns the name of the layout that is defined within the current template via <f:layout name="..." />
      * If no layout is defined, this returns null.
      * This requires the current rendering context in order to be able to evaluate the layout name
-     *
-     * @param RenderingContextInterface $renderingContext
-     * @return string|null
      */
-    public function getLayoutName(RenderingContextInterface $renderingContext);
+    public function getLayoutName(RenderingContextInterface $renderingContext): string|null|NodeInterface;
 
     /**
      * Method generated on compiled templates to add ViewHelper namespaces which were defined in-template
      * and add those to the ones already defined in the ViewHelperResolver.
-     *
-     * @param RenderingContextInterface $renderingContext
      */
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext);
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext): void;
 
     /**
      * Returns true if the current template has a template defined via <f:layout name="..." />
-     *
-     * @return bool
      */
-    public function hasLayout();
+    public function hasLayout(): bool;
 
     /**
      * If the template contains constructs which prevent the compiler from compiling the template
@@ -72,10 +59,10 @@ interface ParsedTemplateInterface
      *
      * @return bool true if the template can be compiled
      */
-    public function isCompilable();
+    public function isCompilable(): bool;
 
     /**
      * @return bool true if the template is already compiled
      */
-    public function isCompiled();
+    public function isCompiled(): bool;
 }

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file belongs to the package "TYPO3 Fluid".
  * See LICENSE.txt that was shipped with this package.
@@ -20,79 +22,58 @@ use TYPO3Fluid\Fluid\View;
  */
 class ParsingState implements ParsedTemplateInterface
 {
-    /**
-     * @var string
-     */
-    protected $identifier;
+    protected string $identifier;
 
     /**
      * Root node reference
-     *
-     * @var RootNode
      */
-    protected $rootNode;
+    protected RootNode $rootNode;
 
     /**
      * Array of node references currently open.
      *
-     * @var array
+     * @var NodeInterface[]
      */
-    protected $nodeStack = [];
+    protected array $nodeStack = [];
 
     /**
      * Variable container where ViewHelpers implementing the PostParseFacet can
      * store things in.
-     *
-     * @var VariableProviderInterface
      */
-    protected $variableContainer;
+    protected VariableProviderInterface $variableContainer;
 
-    /**
-     * @var bool
-     */
-    protected $compilable = true;
-    /**
-     * @param string $identifier
-     */
-    public function setIdentifier($identifier)
+    protected bool $compilable = true;
+
+    public function setIdentifier(string $identifier): void
     {
         $this->identifier = $identifier;
     }
 
-    /**
-     * @return string
-     */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
 
     /**
      * Injects a variable container to be used during parsing.
-     *
-     * @param VariableProviderInterface $variableContainer
      */
-    public function setVariableProvider(VariableProviderInterface $variableContainer)
+    public function setVariableProvider(VariableProviderInterface $variableContainer): void
     {
         $this->variableContainer = $variableContainer;
     }
 
     /**
      * Set root node of this parsing state.
-     *
-     * @param NodeInterface $rootNode
      */
-    public function setRootNode(RootNode $rootNode)
+    public function setRootNode(RootNode $rootNode): void
     {
         $this->rootNode = $rootNode;
     }
 
     /**
      * Get root node of this parsing state.
-     *
-     * @return NodeInterface The root node
      */
-    public function getRootNode()
+    public function getRootNode(): RootNode
     {
         return $this->rootNode;
     }
@@ -101,9 +82,8 @@ class ParsingState implements ParsedTemplateInterface
      * Render the parsed template with rendering context
      *
      * @param RenderingContextInterface $renderingContext The rendering context to use
-     * @return string Rendered string
      */
-    public function render(RenderingContextInterface $renderingContext)
+    public function render(RenderingContextInterface $renderingContext): mixed
     {
         return $this->getRootNode()->evaluate($renderingContext);
     }
@@ -114,7 +94,7 @@ class ParsingState implements ParsedTemplateInterface
      *
      * @param NodeInterface $node Node to push to node stack
      */
-    public function pushNodeToStack(NodeInterface $node)
+    public function pushNodeToStack(NodeInterface $node): void
     {
         $this->nodeStack[] = $node;
     }
@@ -124,7 +104,7 @@ class ParsingState implements ParsedTemplateInterface
      *
      * @return NodeInterface the top stack element.
      */
-    public function getNodeFromStack()
+    public function getNodeFromStack(): NodeInterface
     {
         return $this->nodeStack[count($this->nodeStack) - 1];
     }
@@ -134,7 +114,7 @@ class ParsingState implements ParsedTemplateInterface
      *
      * @return NodeInterface the top stack element, which was removed.
      */
-    public function popNodeFromStack()
+    public function popNodeFromStack(): NodeInterface
     {
         return array_pop($this->nodeStack);
     }
@@ -144,7 +124,7 @@ class ParsingState implements ParsedTemplateInterface
      *
      * @return int Number of elements on the node stack (i.e. number of currently open Fluid tags)
      */
-    public function countNodeStack()
+    public function countNodeStack(): int
     {
         return count($this->nodeStack);
     }
@@ -154,17 +134,15 @@ class ParsingState implements ParsedTemplateInterface
      *
      * @return VariableProviderInterface The variable container or null if none has been set yet
      */
-    public function getVariableContainer()
+    public function getVariableContainer(): VariableProviderInterface
     {
         return $this->variableContainer;
     }
 
     /**
      * Returns true if the current template has a template defined via <f:layout name="..." />
-     *
-     * @return bool
      */
-    public function hasLayout()
+    public function hasLayout(): bool
     {
         return $this->variableContainer->exists('layoutName');
     }
@@ -174,41 +152,27 @@ class ParsingState implements ParsedTemplateInterface
      * If no layout is defined, this returns null.
      * This requires the current rendering context in order to be able to evaluate the layout name
      *
-     * @param RenderingContextInterface $renderingContext
-     * @return string|null
      * @throws View\Exception
      */
-    public function getLayoutName(RenderingContextInterface $renderingContext)
+    public function getLayoutName(RenderingContextInterface $renderingContext): string|null|NodeInterface
     {
         $layoutName = $this->variableContainer->get('layoutName');
         return $layoutName instanceof RootNode ? $layoutName->evaluate($renderingContext) : $layoutName;
     }
 
-    /**
-     * @param RenderingContextInterface $renderingContext
-     */
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext) {}
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext): void {}
 
-    /**
-     * @return bool
-     */
-    public function isCompilable()
+    public function isCompilable(): bool
     {
         return $this->compilable;
     }
 
-    /**
-     * @param bool $compilable
-     */
-    public function setCompilable($compilable)
+    public function setCompilable(bool $compilable): void
     {
         $this->compilable = $compilable;
     }
 
-    /**
-     * @return bool
-     */
-    public function isCompiled()
+    public function isCompiled(): bool
     {
         return false;
     }

--- a/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
+++ b/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
@@ -12,50 +12,51 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 
 class ParsedTemplateImplementationFixture implements ParsedTemplateInterface
 {
-    public function setIdentifier($identifier)
+    public function setIdentifier(string $identifier): void
     {
         // stub
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return 'myIdentifier';
     }
 
-    public function render(RenderingContextInterface $renderingContext)
+    public function render(RenderingContextInterface $renderingContext): mixed
     {
         return 'rendered by fixture';
     }
 
-    public function getVariableContainer()
+    public function getVariableContainer(): VariableProviderInterface
     {
         return new StandardVariableProvider();
     }
 
-    public function getLayoutName(RenderingContextInterface $renderingContext)
+    public function getLayoutName(RenderingContextInterface $renderingContext): ?string
     {
         return null;
     }
 
-    public function addCompiledNamespaces(RenderingContextInterface $renderingContext)
+    public function addCompiledNamespaces(RenderingContextInterface $renderingContext): void
     {
         // stub
     }
 
-    public function hasLayout()
+    public function hasLayout(): bool
     {
         return false;
     }
 
-    public function isCompilable()
+    public function isCompilable(): bool
     {
         return false;
     }
 
-    public function isCompiled()
+    public function isCompiled(): bool
     {
         return false;
     }

--- a/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
+++ b/tests/Unit/Core/Cache/FluidCacheWarmupResultTest.php
@@ -30,15 +30,15 @@ final class FluidCacheWarmupResultTest extends TestCase
         $expected = [
             'baz' => [
                 'compilable' => false,
-                'compiled' => null,
-                'hasLayout' => null,
-                'compiledClassName' => null,
+                'compiled' => false,
+                'hasLayout' => false,
+                'compiledClassName' => '',
             ],
             'foo' => [
                 'compilable' => false,
-                'compiled' => null,
-                'hasLayout' => null,
-                'compiledClassName' => null,
+                'compiled' => false,
+                'hasLayout' => false,
+                'compiledClassName' => '',
             ],
         ];
         self::assertSame($expected, $subject->getResults());
@@ -57,9 +57,9 @@ final class FluidCacheWarmupResultTest extends TestCase
         $expected = [
             'baz' => [
                 'compilable' => false,
-                'compiled' => null,
-                'hasLayout' => null,
-                'compiledClassName' => null,
+                'compiled' => false,
+                'hasLayout' => false,
+                'compiledClassName' => '',
             ],
         ];
         self::assertSame($expected, $subject->getResults());

--- a/tests/Unit/Core/Parser/TemplateParserTest.php
+++ b/tests/Unit/Core/Parser/TemplateParserTest.php
@@ -154,7 +154,7 @@ final class TemplateParserTest extends TestCase
         $compiler->expects(self::atLeastOnce())->method('has')->willReturn(false);
         $compiler->expects(self::atLeastOnce())->method('store')->willReturnOnConsecutiveCalls(
             self::throwException(new StopCompilingException()),
-            true,
+            '',
         );
         $context->setTemplateCompiler($compiler);
         $context->setVariableProvider(new StandardVariableProvider());
@@ -352,15 +352,16 @@ final class TemplateParserTest extends TestCase
     #[Test]
     public function buildArgumentObjectTreeBuildsObjectTreeForComplexString(): void
     {
+        $rootNode = new RootNode();
         $objectTree = $this->createMock(ParsingState::class);
-        $objectTree->expects(self::once())->method('getRootNode')->willReturn('theRootNode');
+        $objectTree->expects(self::once())->method('getRootNode')->willReturn($rootNode);
         $subject = $this->getMockBuilder(TemplateParser::class)
             ->onlyMethods(['splitTemplateAtDynamicTags', 'buildObjectTree'])
             ->getMock();
         $subject->expects(self::atLeastOnce())->method('splitTemplateAtDynamicTags')->with('a <very> {complex} string')->willReturn(['split string']);
         $subject->expects(self::atLeastOnce())->method('buildObjectTree')->with(['split string'])->willReturn($objectTree);
         $method = new \ReflectionMethod($subject, 'buildArgumentObjectTree');
-        self::assertEquals('theRootNode', $method->invoke($subject, 'a <very> {complex} string'));
+        self::assertSame($rootNode, $method->invoke($subject, 'a <very> {complex} string'));
     }
 
     #[Test]


### PR DESCRIPTION
This patch adds type hints to the template compiler and associated classes, such as parsed/compiled templates and the parsing state. A few adjustments in test cases are necessary because of excessive mocking of internal functionality. In some cases, types were used in mock implementations that don't actually exist in real world use, these are now adjusted when necessary.

Note that these changes require all cached templates to be regenerated because type hints need to be added to the generated classes as well. Because of this, the patch has been marked as breaking.