### PR TITLE
[!!!][FEATURE] Boolean and Null literals

### DIFF
--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -62,29 +62,42 @@ class ObjectAccessorNode extends AbstractNode
      */
     public function evaluate(RenderingContextInterface $renderingContext): mixed
     {
-        $objectPath = strtolower($this->objectPath);
         $variableProvider = $renderingContext->getVariableProvider();
-        if ($objectPath === '_all') {
-            return $variableProvider->getAll();
-        }
-        return $variableProvider->getByPath($this->objectPath);
+        return match (strtolower($this->objectPath)) {
+            '_all' => $variableProvider->getAll(),
+            'true' => true,
+            'false' => false,
+            'null' => null,
+            default => $variableProvider->getByPath($this->objectPath),
+        };
     }
 
     public function convert(TemplateCompiler $templateCompiler): array
     {
-        $path = $this->objectPath;
-        if ($path === '_all') {
-            return [
+        return match (strtolower($this->objectPath)) {
+            '_all' => [
                 'initialization' => '',
                 'execution' => '$renderingContext->getVariableProvider()->getAll()',
-            ];
-        }
-        return [
-            'initialization' => '',
-            'execution' => sprintf(
-                '$renderingContext->getVariableProvider()->getByPath(\'%s\')',
-                $path,
-            ),
-        ];
+            ],
+            'true' => [
+                'initialization' => '',
+                'execution' => 'true',
+            ],
+            'false' => [
+                'initialization' => '',
+                'execution' => 'false',
+            ],
+            'null' => [
+                'initialization' => '',
+                'execution' => 'null',
+            ],
+            default => [
+                'initialization' => '',
+                'execution' => sprintf(
+                    '$renderingContext->getVariableProvider()->getByPath(\'%s\')',
+                    $this->objectPath,
+                ),
+            ],
+        };
     }
 }

--- a/src/Core/Variables/InvalidVariableIdentifierException.php
+++ b/src/Core/Variables/InvalidVariableIdentifierException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Variables;
+
+class InvalidVariableIdentifierException extends \Exception {}

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -14,6 +14,8 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  */
 class StandardVariableProvider implements VariableProviderInterface
 {
+    protected array $disallowedIdentifiers = ['null', 'true', 'false', '_all'];
+
     /**
      * Variables stored in context
      *
@@ -75,6 +77,9 @@ class StandardVariableProvider implements VariableProviderInterface
      */
     public function add(string $identifier, mixed $value): void
     {
+        if (in_array(strtolower($identifier), $this->disallowedIdentifiers)) {
+            throw new InvalidVariableIdentifierException('Invalid variable identifier: ' . $identifier, 1723131119);
+        }
         $this->variables[$identifier] = $value;
     }
 

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -28,6 +28,9 @@ final class ObjectAccessorNodeTest extends TestCase
             [['foo' => ['bar' => 'test'], 'dynamic' => 'bar'], 'foo.{dynamic}', 'test'],
             [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar']], 'foo.{dynamic.sub}', 'test'],
             [['foo' => ['bar' => 'test'], 'dynamic' => ['sub' => 'bar'], 'baz' => 'sub'], 'foo.{dynamic.{baz}}', 'test'],
+            [[], 'true', true],
+            [[], 'false', false],
+            [[], 'null', null],
         ];
     }
 
@@ -43,7 +46,7 @@ final class ObjectAccessorNodeTest extends TestCase
         $variableContainer = new StandardVariableProvider($variables);
         $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);
-        self::assertEquals($expected, $value);
+        self::assertSame($expected, $value);
     }
 
     #[Test]

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Variables;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3Fluid\Fluid\Core\Variables\InvalidVariableIdentifierException;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\StandardVariableProviderModelFixture;
 
@@ -433,5 +434,14 @@ final class StandardVariableProviderTest extends TestCase
         $subject->setSource($variables);
         $result = $subject->getByPath($path);
         self::assertEquals($expected, $result);
+    }
+
+    #[Test]
+    public function exceptionIsThrownForInvalidVariableIdentifier(): void
+    {
+        self::expectException(InvalidVariableIdentifierException::class);
+        self::expectExceptionCode(1723131119);
+        $subject = new StandardVariableProvider();
+        $subject->add('TrUe', false);
     }
 }


### PR DESCRIPTION
This patch enhances Fluid's capabilities of dealing with booleans and null significantly. Previously, the actual booleans `false` and `true` could be only created from within inline syntax or if a ViewHelper argument was defined as boolean (in which case strings were parsed as boolean). `null` values couldn't really be created at all. Now, there exist standard variables for true, false, and null, which can be used in all contexts.

This patch is marked as breaking because it disallows the usage of the variable names `true`, `false` and `null` in variable providers.