### PR TITLE
[TASK] Trigger deprecation if true/false/null variable is used

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -12,6 +12,8 @@ namespace TYPO3Fluid\Fluid\Core\Variables;
  */
 class StandardVariableProvider implements VariableProviderInterface
 {
+    protected array $disallowedIdentifiers = ['null', 'true', 'false', '_all'];
+
     /**
      * @deprecated Unused. Will be removed in v4.
      */
@@ -101,6 +103,9 @@ class StandardVariableProvider implements VariableProviderInterface
      */
     public function add($identifier, $value)
     {
+        if (in_array(strtolower($identifier), $this->disallowedIdentifiers)) {
+            @trigger_error('The specified variable identifier "' . $identifier . '" will no longer be allowed in Fluid v4.', E_USER_DEPRECATED);
+        }
         $this->variables[$identifier] = $value;
     }
 


### PR DESCRIPTION
These variable names are no longer available in Fluid v4 because boolean literals will become part of the language.