### PR TITLE
[BUGFIX] Allow leading/trailing whitespace in math expression

### DIFF
--- a/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
+++ b/src/Core/Parser/SyntaxTree/Expression/MathExpressionNode.php
@@ -29,10 +29,12 @@ class MathExpressionNode extends AbstractExpressionNode
     public static string $detectionExpression = '/
 		(
 			{                                # Start of shorthand syntax
+                \s*                          # Allow whitespace before expression
 				(?:                          # Math expression is composed of...
 					[_a-zA-Z0-9\.]+(?:[\s]*[*+\^\/\%\-]{1}[\s]*[_a-zA-Z0-9\.]+)+   # Various math expressions left and right sides with any spaces
 					|(?R)                    # Other expressions inside
 				)+
+                \s*                          # Allow whitespace after expression
 			}                                # End of shorthand syntax
 		)/x';
 

--- a/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Expression/MathExpressionNodeTest.php
@@ -21,10 +21,11 @@ final class MathExpressionNodeTest extends TestCase
     public static function getEvaluateExpressionTestValues(): array
     {
         return [
-            ['1 gabbagabbahey 1', [], 0],
             ['1 + 1', [], 2],
             ['1 +
                    1', [], 2],
+            [' 1 + 2', [], 3],
+            ['1 + 2 ', [], 3],
             ['2 - 1', [], 1],
             ['2 % 4', [], 2],
             ['2 * 4', [], 8],
@@ -52,6 +53,12 @@ final class MathExpressionNodeTest extends TestCase
     #[Test]
     public function testEvaluateExpression(string $expression, array $variables, $expected): void
     {
+        // evaluateExpression() will really only be called if the regular expression pattern matches in the first
+        // place. So it doesn't make sense to test everything in isolation here. For now, we test the pattern manually
+        // to at least make sure that the test case will actually work in templates.
+        // @todo there should really be API for this, like canInterpret() or similar
+        self::assertEquals(1, preg_match(MathExpressionNode::$detectionExpression, '{' . $expression . '}'));
+
         $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider(new StandardVariableProvider($variables));
         $result = MathExpressionNode::evaluateExpression($renderingContext, $expression, []);


### PR DESCRIPTION
The parser of MathExpressionNode already allowed whitespace before
or after an expression. However, ExpressionNodes are only executed
if their `$detectionExpression` evaluates to true. This was not the case
for leading/trailing whitespace, which is why the regular expression is
extended to allow this.

Unfortunately, the test did only evaluate the parser but did not check
the regular expression beforehand. As there is no API for this (the
regular expression is the API and is executed directly in
`TemplateParser::textAndShorthandSyntaxHandler()`, we execute
the regex manually in the test as well. One existing test case is
removed because it never was actually supported.

In the future, we probably should implement a proper API for this.