### PR TITLE
[TASK] Views return arbitrary types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,11 +56,6 @@ parameters:
 			path: src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with TYPO3Fluid\\\\Fluid\\\\Tests\\\\Functional\\\\Fixtures\\\\Various\\\\UserWithoutToString and string will always evaluate to false\\.$#"
-			count: 1
-			path: tests/Functional/ViewHelpers/Format/HtmlspecialcharsViewHelperTest.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -123,7 +123,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      * If "layoutName" is set in a PostParseFacet callback, it will render the file with the given layout.
      *
      * @param string|null $actionName If set, this action's template will be rendered instead of the one defined in the context.
-     * @return string Rendered Template
+     * @return mixed Rendered Template
      * @api
      */
     public function render($actionName = null)

--- a/src/View/AbstractView.php
+++ b/src/View/AbstractView.php
@@ -24,7 +24,7 @@ abstract class AbstractView implements ViewInterface
     /**
      * Renders the view
      *
-     * @return string The rendered view
+     * @return mixed The rendered view
      * @api
      */
     public function render()

--- a/src/View/ViewInterface.php
+++ b/src/View/ViewInterface.php
@@ -40,7 +40,7 @@ interface ViewInterface
     /**
      * Renders the view
      *
-     * @return string The rendered view
+     * @return mixed The rendered view
      * @api
      */
     public function render();


### PR DESCRIPTION
The previous type hint suggested that View objects only return strings. However, this is not the case. For example, if a View only contains a ViewHelper call without any other strings (like whitespace), the view might return any type the ViewHelper returns, such as an object or an array.