### PR TITLE
[TASK] Clarify return type of HtmlspecialcharsViewHelper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: src/ViewHelpers/ForViewHelper.php
 
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\ViewHelpers\\\\Format\\\\HtmlspecialcharsViewHelper\\:\\:render\\(\\) should return string but returns mixed\\.$#"
-			count: 1
-			path: src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -69,9 +69,10 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
     /**
      * Escapes special characters with their escaped counterparts as needed using PHPs htmlspecialchars() function.
      *
-     * @return string the altered string
+     * @return mixed the altered string. If a non-string is provided, the value is returned unchanged
      * @see http://www.php.net/manual/function.htmlspecialchars.php
      * @api
+     * @todo change return type to string. This needs further investigation because the ViewHelper is used internally by Fluid
      */
     public function render()
     {


### PR DESCRIPTION
For now, we only correct the invalid type hint here because the class is also used internally by Fluid.