### PR TITLE
[BUGFIX] Use correct return type for TemplateCompiler::get()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method TYPO3Fluid\\\\Fluid\\\\Core\\\\Compiler\\\\TemplateCompiler\\:\\:get\\(\\) should return TYPO3Fluid\\\\Fluid\\\\Core\\\\Parser\\\\ParsedTemplateInterface but returns TYPO3Fluid\\\\Fluid\\\\Core\\\\Compiler\\\\UncompilableTemplateInterface\\.$#"
-			count: 1
-			path: src/Core/Compiler/TemplateCompiler.php
-
-		-
 			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/Interceptor/Escape.php

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -98,7 +98,7 @@ class TemplateCompiler
         return false;
     }
 
-    public function get(string $identifier): ParsedTemplateInterface
+    public function get(string $identifier): ParsedTemplateInterface|UncompilableTemplateInterface
     {
         $identifier = $this->sanitizeIdentifier($identifier);
 


### PR DESCRIPTION
TemplateCompiler::get() might also return an
UncompilableTemplateInterface.