### PR TITLE
[TASK] Set content argument name explicitly in ViewHelpers

### DIFF
--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -84,4 +84,12 @@ class CountViewHelper extends AbstractViewHelper
         }
         return count($countable);
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'subject';
+    }
 }

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -84,4 +84,12 @@ class CdataViewHelper extends AbstractViewHelper
     ) {
         return sprintf('<![CDATA[%s]]>', $renderChildrenClosure());
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
 }

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -91,4 +91,12 @@ class PrintfViewHelper extends AbstractViewHelper
     {
         return vsprintf($renderChildrenClosure(), $arguments['arguments']);
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
 }

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -108,4 +108,12 @@ class RawViewHelper extends AbstractViewHelper
             $closureName,
         );
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
 }

--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -62,4 +62,12 @@ class InlineViewHelper extends AbstractViewHelper
     ) {
         return $renderingContext->getTemplateParser()->parse((string)$renderChildrenClosure())->render($renderingContext);
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'code';
+    }
 }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -75,4 +75,12 @@ class OrViewHelper extends AbstractViewHelper
 
         return $content;
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'content';
+    }
 }

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -57,4 +57,12 @@ class VariableViewHelper extends AbstractViewHelper
         $value = $renderChildrenClosure();
         $renderingContext->getVariableProvider()->add($arguments['name'], $value);
     }
+
+    /**
+     * Explicitly set argument name to be used as content.
+     */
+    public function resolveContentArgumentName(): string
+    {
+        return 'value';
+    }
 }


### PR DESCRIPTION
`CompileWithContentArgumentAndRenderStatic` exists to simplify
a common use case of ViewHelpers: A ViewHelper should be
callable both with an argument and with its child content.

Example:

```
<f:variable name="myVar" value="my value" />
<f:variable name="myVar">my value</f:variable>
```

This can also be helpful with Fluid's inline syntax:

```
{f:format.json(value: myObject)}
{myObject -> f:format.json()}
```

While this feature is very useful, the trait also offers a more
confusing feature: If the "content argument name" isn't defined
explicitly, it will try to guess that name by going through all
defined ViewHelper arguments and pick the first optional
argument.

This is unnecessary magic behavior, which will be removed in
the future. As preparation for that, we define the content argument
name explicitly in all existing ViewHelpers that still use the
automagic behavior.