### PR TITLE
[FEATURE] Provide contentArgument API to all ViewHelpers

### DIFF
--- a/Documentation/Changelog/2.x.rst
+++ b/Documentation/Changelog/2.x.rst
@@ -9,6 +9,9 @@ Changelog 2.x
 2.15
 ----
 
+* Deprecation: Trait :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic`
+  has been marked as deprecated. It will log a deprecation level error message when called in
+  Fluid v4. It will be removed in Fluid v5.
 * Deprecation: Variable names `true`, `false` and `null` will log a deprecation level error message because these
   identifiers will become a Fluid language feature with v4.
 

--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -25,6 +25,8 @@ Changelog 4.x
   :php:`TYPO3Fluid\Fluid\View\AbstractTemplateView::RENDERING_LAYOUT`
 * Breaking: Careful addition of method and property type hints throughout the system.
   This should be only mildly breaking and projects should be able to adapt easily.
+* Deprecation: Trait :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic`
+  now emits a E_USER_DEPRECATED level error.
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper->overrideArgument()`
   now emits a E_USER_DEPRECATED level error.
 * Deprecation: Calling method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper->registerUniversalTagAttributes()`

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
-use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Exception;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
  * Class CompilableWithContentArgumentAndRenderStatic
@@ -21,7 +19,9 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
  * the normal render children closure, if that named
  * argument is specified and not empty.
  *
- * @todo add missing types with Fluid v5
+ * @deprecated Will be removed in v5. No longer necessary since resolveContentArgumentName() has been
+ * integrated into AbstractViewHelper with v4. Name has to be specified explicitly by overriding the
+ * method, implicit definition (= first optional argument) is no longer supported.
  */
 trait CompileWithContentArgumentAndRenderStatic
 {
@@ -71,6 +71,7 @@ trait CompileWithContentArgumentAndRenderStatic
      */
     public function render()
     {
+        trigger_error('CompileWithContentArgumentAndRenderStatic has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         return static::renderStatic(
             $this->arguments,
             $this->buildRenderChildrenClosure(),
@@ -79,73 +80,13 @@ trait CompileWithContentArgumentAndRenderStatic
     }
 
     /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile(
-        $argumentsName,
-        $closureName,
-        &$initializationPhpCode,
-        ViewHelperNode $node,
-        TemplateCompiler $compiler,
-    ) {
-        $execution = sprintf(
-            '%s::renderStatic(%s, %s, $renderingContext)',
-            static::class,
-            $argumentsName,
-            $closureName,
-        );
-
-        $contentArgumentName = $this->resolveContentArgumentName();
-        $initializationPhpCode .= sprintf(
-            '%s = (%s[\'%s\'] !== null) ? function() use (%s) { return %s[\'%s\']; } : %s;',
-            $closureName,
-            $argumentsName,
-            $contentArgumentName,
-            $argumentsName,
-            $argumentsName,
-            $contentArgumentName,
-            $closureName,
-        );
-        return $execution;
-    }
-
-    /**
-     * Helper which is mostly needed when calling renderStatic() from within
-     * render().
-     *
-     * No public API yet.
-     *
-     * @return \Closure
-     */
-    protected function buildRenderChildrenClosure()
-    {
-        $argumentName = $this->resolveContentArgumentName();
-        $arguments = $this->arguments;
-        if (!empty($argumentName) && isset($arguments[$argumentName])) {
-            $renderChildrenClosure = function () use ($arguments, $argumentName) {
-                return $arguments[$argumentName];
-            };
-        } else {
-            $self = clone $this;
-            $renderChildrenClosure = function () use ($self) {
-                return $self->renderChildren();
-            };
-        }
-        return $renderChildrenClosure;
-    }
-
-    /**
      * @return string
      */
     public function resolveContentArgumentName()
     {
+        trigger_error('CompileWithContentArgumentAndRenderStatic has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         if (empty($this->contentArgumentName)) {
-            $registeredArguments = call_user_func_array([$this, 'prepareArguments'], []);
+            $registeredArguments = $this->prepareArguments();
             foreach ($registeredArguments as $registeredArgument) {
                 if (!$registeredArgument->isRequired()) {
                     $this->contentArgumentName = $registeredArgument->getName();
@@ -158,5 +99,10 @@ trait CompileWithContentArgumentAndRenderStatic
             );
         }
         return $this->contentArgumentName;
+    }
+
+    public function getContentArgumentName(): ?string
+    {
+        return $this->resolveContentArgumentName();
     }
 }

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -7,9 +7,6 @@
 
 namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
 
-use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-
 /**
  * Class CompilableWithRenderStatic
  *
@@ -41,27 +38,4 @@ trait CompileWithRenderStatic
      * @return \Closure
      */
     abstract protected function buildRenderChildrenClosure();
-
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile(
-        $argumentsName,
-        $closureName,
-        &$initializationPhpCode,
-        ViewHelperNode $node,
-        TemplateCompiler $compiler,
-    ) {
-        return sprintf(
-            '%s::renderStatic(%s, %s, $renderingContext)',
-            static::class,
-            $argumentsName,
-            $closureName,
-        );
-    }
 }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -10,7 +10,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper counts elements of the specified array or countable object.
@@ -44,7 +44,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CountViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -88,7 +88,7 @@ class CountViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'subject';
     }

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -9,7 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping and wraps it with CDATA tags.
@@ -57,7 +57,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class CdataViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -88,7 +88,7 @@ class CdataViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/JsonViewHelper.php
+++ b/src/ViewHelpers/Format/JsonViewHelper.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Wrapper for PHPs :php:`json_encode` function.
@@ -50,7 +50,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 final class JsonViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -88,7 +88,7 @@ final class JsonViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/Nl2brViewHelper.php
+++ b/src/ViewHelpers/Format/Nl2brViewHelper.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Wrapper for PHPs :php:`nl2br` function.
@@ -40,7 +40,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 final class Nl2brViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -60,7 +60,7 @@ final class Nl2brViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -9,7 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * A ViewHelper for formatting values with printf. Either supply an array for
@@ -70,7 +70,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class PrintfViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     public function initializeArguments()
     {
@@ -95,7 +95,7 @@ class PrintfViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -11,7 +11,7 @@ use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping. Is normally used to output
@@ -60,7 +60,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class RawViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * @var bool
@@ -98,7 +98,7 @@ class RawViewHelper extends AbstractViewHelper
      */
     public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
     {
-        $contentArgumentName = $this->resolveContentArgumentName();
+        $contentArgumentName = $this->getContentArgumentName();
         return sprintf(
             'isset(%s[\'%s\']) ? %s[\'%s\'] : %s()',
             $argumentsName,
@@ -112,7 +112,7 @@ class RawViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/StripTagsViewHelper.php
+++ b/src/ViewHelpers/Format/StripTagsViewHelper.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 use Stringable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Removes tags from the given string (applying PHPs :php:`strip_tags()` function)
@@ -66,7 +66,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 final class StripTagsViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * No output escaping as some tags may be allowed
@@ -111,7 +111,7 @@ final class StripTagsViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/Format/UrlencodeViewHelper.php
+++ b/src/ViewHelpers/Format/UrlencodeViewHelper.php
@@ -12,7 +12,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 use Stringable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Encodes the given string according to http://www.faqs.org/rfcs/rfc3986.html
@@ -45,7 +45,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 final class UrlencodeViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * Output is escaped already. We must not escape children, to avoid double encoding.
@@ -80,7 +80,7 @@ final class UrlencodeViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -9,7 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Inline Fluid rendering ViewHelper
@@ -34,7 +34,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class InlineViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     protected $escapeChildren = false;
 
@@ -66,7 +66,7 @@ class InlineViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'code';
     }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -9,7 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Or ViewHelper
@@ -36,7 +36,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class OrViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     /**
      * Initialize
@@ -79,7 +79,7 @@ class OrViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'content';
     }

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -9,7 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Variable assigning ViewHelper
@@ -36,7 +36,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  */
 class VariableViewHelper extends AbstractViewHelper
 {
-    use CompileWithContentArgumentAndRenderStatic;
+    use CompileWithRenderStatic;
 
     public function initializeArguments()
     {
@@ -61,7 +61,7 @@ class VariableViewHelper extends AbstractViewHelper
     /**
      * Explicitly set argument name to be used as content.
      */
-    public function resolveContentArgumentName(): string
+    public function getContentArgumentName(): string
     {
         return 'value';
     }

--- a/tests/Functional/Core/ViewHelper/ContentArgumentNameTest.php
+++ b/tests/Functional/Core/ViewHelper/ContentArgumentNameTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ContentArgumentNameTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): array
+    {
+        return [
+            'self-closing tag without argument value' => ['<test:contentArgumentName />', null],
+            'only children' => ['<test:contentArgumentName>child value</test:contentArgumentName>', 'child value'],
+            'children and empty argument value' => ['<test:contentArgumentName value="">child value</test:contentArgumentName>', ''],
+            'children and argument value' => ['<test:contentArgumentName value="argument value">child value</test:contentArgumentName>', 'argument value'],
+            'self-closing tag with argument value' => ['<test:contentArgumentName value="argument value" />', 'argument value'],
+            'empty children and argument value' => ['<test:contentArgumentName value="argument value"></test:contentArgumentName>', 'argument value'],
+        ];
+    }
+
+    #[DataProvider('renderDataProvider')]
+    #[Test]
+    public function render(string $source, ?string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render());
+    }
+}

--- a/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
+++ b/tests/Functional/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStaticTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper\Traits;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
@@ -90,6 +91,7 @@ final class CompileWithContentArgumentAndRenderStaticTest extends AbstractFuncti
 
     #[DataProvider('compileWithContentArgumentAndRenderStaticDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function compileWithContentArgumentAndRenderStatic(string $source, array $expected): void
     {
         $view = new TemplateView();
@@ -112,6 +114,7 @@ final class CompileWithContentArgumentAndRenderStaticTest extends AbstractFuncti
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function resolveContentArgumentNameThrowsExceptionIfNoArgumentsAvailable(): void
     {
         $this->expectException(Exception::class);

--- a/tests/Functional/Fixtures/ViewHelpers/ContentArgumentNameViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/ContentArgumentNameViewHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class ContentArgumentNameViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('value', 'string', '');
+    }
+
+    public function render(): ?string
+    {
+        return $this->renderChildren();
+    }
+
+    public function getContentArgumentName(): string
+    {
+        return 'value';
+    }
+}


### PR DESCRIPTION
Previously, `CompileWithContentArgumentAndRenderStatic` could
be used to create ViewHelpers that can get their default input both
from their child content and from a defined argument. This feature
has now been integrated into AbstractViewHelper. To use it, the
ViewHelper class needs to override the method
`resolveContentArgumentName()` and return the name of the
argument to be used.

Example:

```
public function initializeArguments(): void
{
    $this->registerArgument('value', 'string', '');
}

public function resolveContentArgumentName(): string
{
    return 'value';
}
```

`$this->renderChildren()` can then be used to get either the
defined argument or as fallback the ViewHelper's child content.

With this definition, the ViewHelper can be used in the following
ways:

```
<my:viewhelper value="test" />
<my:viewhelper>test</my:viewhelper>
{myInput -> my:viewhelper()}
```

Since it's no longer necessary, the trait is now deprecated and
will be removed with Fluid v5. There will be a soft deprecation
in Fluid v2 to let users know that this API will no longer be available
with Fluid v5 and will throw a deprecation error in v4.

All ViewHelpers still using the trait have been migrated to
`CompileWithRenderStatic`, which has been modified to support
the new implementation.