### PR TITLE
[BUGFIX] Improved argument validation in TagBuilder (#937)

### DIFF
--- a/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
+++ b/tests/Functional/Cases/Escaping/ViewHelperEscapingTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Escaping;
 
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\Interceptor\Escape;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
@@ -320,8 +323,24 @@ final class ViewHelperEscapingTest extends AbstractFunctionalTestCase
         self::assertSame('<div class="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test class="{value}" />'), 'Tag attribute is escaped');
         self::assertSame('<div data-foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test data="{foo: value}" />'), 'Tag data attribute values are escaped');
         self::assertSame('<div foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test additionalAttributes="{foo: value}" />'), 'Tag additional attributes values are escaped');
-        self::assertSame('<div data-&gt;' . self::ESCAPED . '&lt;="1" />', $this->renderCode($viewHelper, '<test:test data=\'{"><script>alert(1)</script><": 1}\' />'), 'Tag data attribute keys are escaped');
-        self::assertSame('<div &gt;' . self::ESCAPED . '&lt;="1" />', $this->renderCode($viewHelper, '<test:test additionalAttributes=\'{"><script>alert(1)</script><": 1}\' />'), 'Tag additional attributes keys are escaped');
         self::assertSame('<div data-foo="' . self::ESCAPED . '" />', $this->renderCode($viewHelper, '<test:test data-foo="{value}" />'), 'Tag unregistered data attribute is escaped');
+    }
+
+    public static function tagBasedViewHelperValidatesAttributeNamesDataProvider(): array
+    {
+        return [
+            ['<test:test data=\'{"><script>alert(1)</script><": 1}\' />'],
+            ['<test:test additionalAttributes=\'{"><script>alert(1)</script><": 1}\' />'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('tagBasedViewHelperValidatesAttributeNamesDataProvider')]
+    public function tagBasedViewHelperValidatesAttributeNames(string $template): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionCode(1721982367);
+        $viewHelper = new TagBasedTestViewHelper();
+        $this->renderCode($viewHelper, $template);
     }
 }

--- a/tests/Unit/Core/ViewHelper/TagBuilderTest.php
+++ b/tests/Unit/Core/ViewHelper/TagBuilderTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
@@ -96,8 +98,8 @@ final class TagBuilderTest extends TestCase
         $tagBuilder = new TagBuilder('tag');
         $tagBuilder->addAttribute('attribute1', 'attribute1value');
         $tagBuilder->addAttribute('attribute2', 'attribute2value');
-        $tagBuilder->addAttribute('attribute3', 'attribute3value');
-        self::assertEquals('<tag attribute1="attribute1value" attribute2="attribute2value" attribute3="attribute3value" />', $tagBuilder->render());
+        $tagBuilder->addAttribute(':at-tr$ib.ut_e3#', 'attribute3value');
+        self::assertEquals('<tag attribute1="attribute1value" attribute2="attribute2value" :at-tr$ib.ut_e3#="attribute3value" />', $tagBuilder->render());
     }
 
     #[Test]
@@ -117,6 +119,29 @@ final class TagBuilderTest extends TestCase
         self::expectExceptionMessage('Value of tag attribute "custom" cannot be of type array.');
         $tagBuilder = new TagBuilder('tag');
         $tagBuilder->addAttribute('custom', ['attribute1' => 'data1', 'attribute2' => 'data2']);
+    }
+
+    public static function attributeNamesAreProperlyValidatedDataProvider(): array
+    {
+        return [
+            ['onclick="alert(1)"'],
+            ['onblur=\'alert(1)\''],
+            ['onchange=alert(1)'],
+            ['on \t\n\rchange'],
+            ['on&change'],
+            ['foo/>'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('attributeNamesAreProperlyValidatedDataProvider')]
+    public function attributeNamesAreProperlyValidated(string $attributeName): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionCode(1721982367);
+
+        $tagBuilder = new TagBuilder('tag');
+        $tagBuilder->addAttribute($attributeName, '');
     }
 
     #[Test]


### PR DESCRIPTION
The current approach to sanitize HTML tag attributes by
TagBuilder can be improved to only allow certain characters.
As TagBuilder is a low-level API to create arbitrary HTML tags,
the goal is not to prevent any JavaScript from being executed
because this might be a desired behavior in some use cases.

We would like to prevent the following:

```php
$unsafeInput = "onclick='alert(1)'";
$tagBuilder->addAttribute($unsafeInput, 'some value');
```

While still allowing the following:

```php
$tagBuilder->addAttribute('onclick', 'doSomething()');
```

Thus, this patch applies a strict allow-list to argument names
and throws an exception if any other characters are used.
The characters are limited to ASCII characters except for
select characters that are problematic in HTML attributes,
such as single and double quotes, equal signs, less/greater than,
forward slashes, ampersants and white space.

Developers are advised to be very careful when using user input
as attribute names as this change cannot prevent all accidential
and thus potentially malicious JavaScript execution.

Thanks to @GatekeeperBuster for making us aware of this.