### PR TITLE
[BUGFIX] Prevent interference between functional tests

### DIFF
--- a/tests/Functional/AbstractFunctionalTestCase.php
+++ b/tests/Functional/AbstractFunctionalTestCase.php
@@ -36,14 +36,14 @@ abstract class AbstractFunctionalTestCase extends TestCase
      */
     protected static string $cachePath;
 
-    public static function setUpBeforeClass(): void
+    public function setUp(): void
     {
         self::$cachePath = sys_get_temp_dir() . '/' . 'fluid-functional-tests-' . hash('xxh3', __CLASS__);
         mkdir(self::$cachePath);
         self::$cache = (new SimpleFileCache(self::$cachePath));
     }
 
-    public static function tearDownAfterClass(): void
+    public function tearDown(): void
     {
         self::$cache->flush();
         rmdir(self::$cachePath);

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -11,7 +11,6 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -32,8 +31,8 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionIfSubjectIsInvalid(): void
     {
-        $this->expectException(Exception::class);
-        $this->expectExceptionCode(1248728393);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1256475113);
         $view = new TemplateView();
         $view->assignMultiple(['value' => new \stdClass()]);
         $view->getRenderingContext()->setCache(self::$cache);


### PR DESCRIPTION
The cache is now removed between each test case, not between each test class. This also unveiled one interference between two `ForViewHelper` test cases.

Further interference is still present due to Fluid's runtime cache. This is now documented in #975 to be fixed later.