### PR TITLE
[!!!][TASK] Extend ViewHelperInterface to cover current API

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,27 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
-			count: 1
-			path: src/Core/Parser/Interceptor/Escape.php
-
-		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isOutputEscapingEnabled\\(\\)\\.$#"
-			count: 1
-			path: src/Core/Parser/Interceptor/Escape.php
-
-		-
 			message: "#^Binary operation \"\\+\" between non\\-empty\\-string and 0 results in an error\\.$#"
-			count: 1
-			path: src/Core/Parser/TemplateParser.php
-
-		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:getContentArgumentName\\(\\)\\.$#"
-			count: 1
-			path: src/Core/Parser/TemplateParser.php
-
-		-
-			message: "#^Call to an undefined method TYPO3Fluid\\\\Fluid\\\\Core\\\\ViewHelper\\\\ViewHelperInterface\\:\\:isChildrenEscapingEnabled\\(\\)\\.$#"
 			count: 1
 			path: src/Core/Parser/TemplateParser.php
 

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -11,7 +11,6 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 
@@ -48,9 +47,7 @@ class ViewHelperNode extends AbstractNode
         $this->arguments = $arguments;
         $this->viewHelperClassName = $resolver->resolveViewHelperClassName($namespace, $identifier);
         $this->uninitializedViewHelper = $resolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
-        if ($this->uninitializedViewHelper instanceof AbstractViewHelper) {
-            $this->uninitializedViewHelper->setViewHelperNode($this);
-        }
+        $this->uninitializedViewHelper->setViewHelperNode($this);
         // Note: RenderingContext required here though replaced later. See https://github.com/TYPO3Fluid/Fluid/pull/93
         $this->uninitializedViewHelper->setRenderingContext($renderingContext);
         $this->argumentDefinitions = $resolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
@@ -146,11 +143,6 @@ class ViewHelperNode extends AbstractNode
         // the current ViewHelperNode to a viewhelper instance to ensure correct context.
         // See https://github.com/TYPO3/Fluid/issues/804
         // @todo We should evaluate if we can get rid of this state and better pass it around.
-        // @todo The ViewHelperInterface does not contain the setViewHelperNode() method. Most likely ViewHelper are
-        //       created using the AbstractViewHelper class as base, which contains this method. However, we need
-        //       to check for method to exists before calling it.
-        if (method_exists($this->uninitializedViewHelper, 'setViewHelperNode')) {
-            $this->uninitializedViewHelper->setViewHelperNode($this);
-        }
+        $this->uninitializedViewHelper->setViewHelperNode($this);
     }
 }

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -260,7 +260,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     protected function callRenderMethod()
     {
         if (method_exists($this, 'render')) {
-            return call_user_func([$this, 'render']);
+            return $this->render();
         }
         if ((new \ReflectionMethod($this, 'renderStatic'))->getDeclaringClass()->getName() !== AbstractViewHelper::class) {
             // Method is safe to call - will not recurse through ViewHelperInvoker via the default
@@ -490,8 +490,30 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * are doing*, and really want to influence the generated PHP code during
      * template compilation directly.
      *
-     * @param string $argumentsName
-     * @param string $closureName
+     * This method is called on compilation time.
+     *
+     * It has to return a *single* PHP statement without semi-colon or newline
+     * at the end, which will be embedded at various places.
+     *
+     * Furthermore, it can append PHP code to the variable $initializationPhpCode.
+     * In this case, all statements have to end with semi-colon and newline.
+     *
+     * Outputting new variables
+     * ========================
+     * If you want create a new PHP variable, you need to use
+     * $templateCompiler->variableName('nameOfVariable') for this, as all variables
+     * need to be globally unique.
+     *
+     * Return Value
+     * ============
+     * Besides returning a single string, it can also return the constant
+     * \TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION
+     * which means that after the $initializationPhpCode, the ViewHelper invocation
+     * is built as normal. This is especially needed if you want to build new arguments
+     * at run-time, as it is done for the AbstractConditionViewHelper.
+     *
+     * @param string $argumentsName Name of the variable in which the ViewHelper arguments are stored
+     * @param string $closureName Name of the closure which can be executed to render the child nodes
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -19,7 +19,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *           extend AbstractViewHelper or some other abstract that
  *           extends AbstractViewHelper with own view helper
  *           implementations.
- *           This interface ships a couple of methods for internal use
+ *           This interface currently only ships internal Fluid API,
  *           which may change. Those methods are "correctly" implemented
  *           in the AbstractViewHelper and maintained.
  *           We'll try to resolve this restriction midterm, but you should
@@ -38,10 +38,14 @@ interface ViewHelperInterface
      */
     public function setArguments(array $arguments);
 
+    public function getContentArgumentName(): ?string;
+
     /**
      * @param NodeInterface[] $nodes
      */
     public function setChildNodes(array $nodes);
+
+    public function setViewHelperNode(ViewHelperNode $node);
 
     /**
      * @param RenderingContextInterface $renderingContext
@@ -54,34 +58,6 @@ interface ViewHelperInterface
      * @return mixed the rendered ViewHelper.
      */
     public function initializeArgumentsAndRender();
-
-    /**
-     * Initializes the view helper before invoking the render method.
-     *
-     * Override this method to solve tasks before the view helper content is rendered.
-     */
-    public function initialize();
-
-    /**
-     * Helper method which triggers the rendering of everything between the
-     * opening and the closing tag.
-     *
-     * @return mixed The finally rendered child nodes.
-     */
-    public function renderChildren();
-
-    /**
-     * Validate arguments, and throw exception if arguments do not validate.
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function validateArguments();
-
-    /**
-     * Initialize all arguments. You need to override this method and call
-     * $this->registerArgument(...) inside this method, to register all your arguments.
-     */
-    public function initializeArguments();
 
     /**
      * Method which can be implemented in any ViewHelper if that ViewHelper desires
@@ -123,38 +99,6 @@ interface ViewHelperInterface
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext);
 
     /**
-     * This method is called on compilation time.
-     *
-     * It has to return a *single* PHP statement without semi-colon or newline
-     * at the end, which will be embedded at various places.
-     *
-     * Furthermore, it can append PHP code to the variable $initializationPhpCode.
-     * In this case, all statements have to end with semi-colon and newline.
-     *
-     * Outputting new variables
-     * ========================
-     * If you want create a new PHP variable, you need to use
-     * $templateCompiler->variableName('nameOfVariable') for this, as all variables
-     * need to be globally unique.
-     *
-     * Return Value
-     * ============
-     * Besides returning a single string, it can also return the constant
-     * \TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::SHOULD_GENERATE_VIEWHELPER_INVOCATION
-     * which means that after the $initializationPhpCode, the ViewHelper invocation
-     * is built as normal. This is especially needed if you want to build new arguments
-     * at run-time, as it is done for the AbstractConditionViewHelper.
-     *
-     * @param string $argumentsName Name of the variable in which the ViewHelper arguments are stored
-     * @param string $closureName Name of the closure which can be executed to render the child nodes
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler);
-
-    /**
      * Called when being inside a cached template.
      *
      * @param \Closure $renderChildrenClosure
@@ -185,4 +129,14 @@ interface ViewHelperInterface
      * @return array{initialization: string, execution: string}
      */
     public function convert(TemplateCompiler $templateCompiler): array;
+
+    /**
+     * @return bool
+     */
+    public function isChildrenEscapingEnabled();
+
+    /**
+     * @return bool
+     */
+    public function isOutputEscapingEnabled();
 }


### PR DESCRIPTION
In the past, some ViewHelper API methods that were used by Fluid
internally were only part of `AbstractViewHelper`, which lead to
either `method_exists()` checks or phpstan warnings in the baseline.

With this change, the `ViewHelperInterface` becomes the internal
API definition for ViewHelpers, only to be used by Fluid internally.
Thus, missing API methods are added to the interface, while
user-facing API only used by `AbstractViewHelper` has been
removed.

In the future, we might consider adding a separate interface for the
used-facing API of ViewHelpers. For now we highly recommend
to keep using `AbstractViewHelper` as the basis for all custom
ViewHelper implementations.