### PR TITLE
[TASK] Use render() instead of renderStatic() in all ViewHelpers

### DIFF
--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -7,11 +7,9 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Declares new variables which are aliases of other variables.
@@ -58,8 +56,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class AliasViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -74,17 +70,14 @@ class AliasViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $globalVariableProvider = $renderingContext->getVariableProvider();
-        $localVariableProvider = new StandardVariableProvider($arguments['map']);
+        $globalVariableProvider = $this->renderingContext->getVariableProvider();
+        $localVariableProvider = new StandardVariableProvider($this->arguments['map']);
         $scopedVariableProvider = new ScopedVariableProvider($globalVariableProvider, $localVariableProvider);
-        $renderingContext->setVariableProvider($scopedVariableProvider);
-
-        $output = $renderChildrenClosure();
-
-        $renderingContext->setVariableProvider($globalVariableProvider);
-
+        $this->renderingContext->setVariableProvider($scopedVariableProvider);
+        $output = $this->renderChildren();
+        $this->renderingContext->setVariableProvider($globalVariableProvider);
         return $output;
     }
 }

--- a/src/ViewHelpers/ConstantViewHelper.php
+++ b/src/ViewHelpers/ConstantViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Wrapper for PHPs :php:`constant` function.
@@ -46,17 +44,15 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class ConstantViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         parent::initializeArguments();
         $this->registerArgument('name', 'string', 'String representation of a PHP constant or enum');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed
+    public function render(): mixed
     {
-        $name = $arguments['name'] ?? $renderChildrenClosure();
+        $name = $this->arguments['name'] ?? $this->renderChildren();
         return constant($name);
     }
 }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -7,10 +7,8 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper counts elements of the specified array or countable object.
@@ -44,8 +42,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class CountViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -65,9 +61,9 @@ class CountViewHelper extends AbstractViewHelper
     /**
      * @return int
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $countable = $renderChildrenClosure();
+        $countable = $this->renderChildren();
         if ($countable === null) {
             return 0;
         }

--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -7,12 +7,10 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper cycles through the specified values.
@@ -68,8 +66,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class CycleViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -85,34 +81,28 @@ class CycleViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $values = $arguments['values'];
-        $as = $arguments['as'];
+        $values = $this->arguments['values'];
+        $as = $this->arguments['as'];
         if ($values === null) {
-            return $renderChildrenClosure();
+            return $this->renderChildren();
         }
         $values = static::initializeValues($values);
-        $index = static::initializeIndex($as, $renderingContext->getViewHelperVariableContainer());
-
+        $index = static::initializeIndex($as, $this->renderingContext->getViewHelperVariableContainer());
         $currentValue = isset($values[$index]) ? $values[$index] : null;
-
         $scopedVariableProvider = new ScopedVariableProvider(
-            $renderingContext->getVariableProvider(),
+            $this->renderingContext->getVariableProvider(),
             new StandardVariableProvider([$as => $currentValue]),
         );
-        $renderingContext->setVariableProvider($scopedVariableProvider);
-
-        $output = $renderChildrenClosure();
-
-        $renderingContext->setVariableProvider($scopedVariableProvider->getGlobalVariableProvider());
-
+        $this->renderingContext->setVariableProvider($scopedVariableProvider);
+        $output = $this->renderChildren();
+        $this->renderingContext->setVariableProvider($scopedVariableProvider->getGlobalVariableProvider());
         $index++;
         if (!isset($values[$index])) {
             $index = 0;
         }
-        $renderingContext->getViewHelperVariableContainer()->addOrUpdate(static::class, $as, $index);
-
+        $this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(static::class, $as, $index);
         return $output;
     }
 

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -7,10 +7,8 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper is only meant to be used during development.
@@ -44,8 +42,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class DebugViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -67,16 +63,15 @@ class DebugViewHelper extends AbstractViewHelper
     /**
      * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $typeOnly = $arguments['typeOnly'];
-        $expressionToExamine = $renderChildrenClosure();
+        $typeOnly = $this->arguments['typeOnly'];
+        $expressionToExamine = $this->renderChildren();
         if ($typeOnly === true) {
             return is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine);
         }
-
-        $html = $arguments['html'];
-        $levels = $arguments['levels'];
+        $html = $this->arguments['html'];
+        $levels = $this->arguments['levels'];
         return static::dumpVariable($expressionToExamine, $html, 1, $levels);
     }
 

--- a/src/ViewHelpers/FirstViewHelper.php
+++ b/src/ViewHelpers/FirstViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * The FirstViewHelper returns the first item of an array.
@@ -29,17 +27,14 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class FirstViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'array', '');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed
+    public function render(): mixed
     {
-        $value = $arguments['value'] ?? $renderChildrenClosure();
-
+        $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
             throw new \InvalidArgumentException(
@@ -48,9 +43,7 @@ final class FirstViewHelper extends AbstractViewHelper
                 1712220569,
             );
         }
-
         $value = iterator_to_array($value);
-
         return array_shift($value);
     }
 }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -7,12 +7,10 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Loop ViewHelper which can be used to iterate over arrays.
@@ -78,8 +76,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class ForViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -99,50 +95,45 @@ class ForViewHelper extends AbstractViewHelper
      * @return string
      * @throws ViewHelper\Exception
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        if (!isset($arguments['each'])) {
+        if (!isset($this->arguments['each'])) {
             return '';
         }
-        if (is_object($arguments['each']) && !$arguments['each'] instanceof \Traversable) {
+        if (is_object($this->arguments['each']) && !$this->arguments['each'] instanceof \Traversable) {
             throw new ViewHelper\Exception('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
         }
-
-        if ($arguments['reverse'] === true) {
-            $arguments['each'] = array_reverse(iterator_to_array($arguments['each']), true);
+        if ($this->arguments['reverse'] === true) {
+            $this->arguments['each'] = array_reverse(iterator_to_array($this->arguments['each']), true);
         }
-        if (isset($arguments['iteration'])) {
+        if (isset($this->arguments['iteration'])) {
             $iterationData = [
                 'index' => 0,
                 'cycle' => 1,
-                'total' => count($arguments['each']),
+                'total' => count($this->arguments['each']),
             ];
         }
-
-        $globalVariableProvider = $renderingContext->getVariableProvider();
+        $globalVariableProvider = $this->renderingContext->getVariableProvider();
         $localVariableProvider = new StandardVariableProvider();
-        $renderingContext->setVariableProvider(new ScopedVariableProvider($globalVariableProvider, $localVariableProvider));
-
+        $this->renderingContext->setVariableProvider(new ScopedVariableProvider($globalVariableProvider, $localVariableProvider));
         $output = '';
-        foreach ($arguments['each'] as $keyValue => $singleElement) {
-            $localVariableProvider->add($arguments['as'], $singleElement);
-            if (isset($arguments['key'])) {
-                $localVariableProvider->add($arguments['key'], $keyValue);
+        foreach ($this->arguments['each'] as $keyValue => $singleElement) {
+            $localVariableProvider->add($this->arguments['as'], $singleElement);
+            if (isset($this->arguments['key'])) {
+                $localVariableProvider->add($this->arguments['key'], $keyValue);
             }
-            if (isset($arguments['iteration'])) {
+            if (isset($this->arguments['iteration'])) {
                 $iterationData['isFirst'] = $iterationData['cycle'] === 1;
                 $iterationData['isLast'] = $iterationData['cycle'] === $iterationData['total'];
                 $iterationData['isEven'] = $iterationData['cycle'] % 2 === 0;
                 $iterationData['isOdd'] = !$iterationData['isEven'];
-                $localVariableProvider->add($arguments['iteration'], $iterationData);
+                $localVariableProvider->add($this->arguments['iteration'], $iterationData);
                 $iterationData['index']++;
                 $iterationData['cycle']++;
             }
-            $output .= $renderChildrenClosure();
+            $output .= $this->renderChildren();
         }
-
-        $renderingContext->setVariableProvider($globalVariableProvider);
-
+        $this->renderingContext->setVariableProvider($globalVariableProvider);
         return $output;
     }
 }

--- a/src/ViewHelpers/Format/CaseViewHelper.php
+++ b/src/ViewHelpers/Format/CaseViewHelper.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Modifies the case of an input string to upper- or lowercase or capitalization.
@@ -67,8 +65,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class CaseViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * Directs the input string being converted to "lowercase"
      */
@@ -111,15 +107,13 @@ final class CaseViewHelper extends AbstractViewHelper
      * Changes the case of the input string
      * @throws Exception
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $value = $arguments['value'];
-        $mode = $arguments['mode'];
-
+        $value = $this->arguments['value'];
+        $mode = $this->arguments['mode'];
         if ($value === null) {
-            $value = (string)$renderChildrenClosure();
+            $value = (string)$this->renderChildren();
         }
-
         switch ($mode) {
             case self::CASE_LOWER:
                 $output = mb_strtolower($value, 'utf-8');
@@ -145,7 +139,6 @@ final class CaseViewHelper extends AbstractViewHelper
             default:
                 throw new Exception('The case mode "' . $mode . '" supplied to Fluid\'s format.case ViewHelper is not supported.', 1358349150);
         }
-
         return $output;
     }
 }

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping and wraps it with CDATA tags.
@@ -57,8 +55,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class CdataViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -77,12 +73,9 @@ class CdataViewHelper extends AbstractViewHelper
     /**
      * @return string
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext,
-    ) {
-        return sprintf('<![CDATA[%s]]>', $renderChildrenClosure());
+    public function render()
+    {
+        return sprintf('<![CDATA[%s]]>', $this->renderChildren());
     }
 
     /**

--- a/src/ViewHelpers/Format/JsonViewHelper.php
+++ b/src/ViewHelpers/Format/JsonViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Wrapper for PHPs :php:`json_encode` function.
@@ -50,8 +48,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class JsonViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -75,11 +71,11 @@ final class JsonViewHelper extends AbstractViewHelper
      * @see https://www.php.net/manual/function.json-encode.php
      * @return string|false
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $value = $renderChildrenClosure();
+        $value = $this->renderChildren();
         $options = JSON_HEX_TAG;
-        if ($arguments['forceObject'] !== false) {
+        if ($this->arguments['forceObject'] !== false) {
             $options = $options | JSON_FORCE_OBJECT;
         }
         return json_encode($value, $options);

--- a/src/ViewHelpers/Format/Nl2brViewHelper.php
+++ b/src/ViewHelpers/Format/Nl2brViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Wrapper for PHPs :php:`nl2br` function.
@@ -40,8 +38,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class Nl2brViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -52,9 +48,9 @@ final class Nl2brViewHelper extends AbstractViewHelper
         $this->registerArgument('value', 'string', 'string to format');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        return nl2br((string)$renderChildrenClosure());
+        return nl2br((string)$this->renderChildren());
     }
 
     /**

--- a/src/ViewHelpers/Format/NumberViewHelper.php
+++ b/src/ViewHelpers/Format/NumberViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Formats a number with custom precision, decimal point and grouped thousands.
@@ -42,8 +40,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class NumberViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * Output is escaped already. We must not escape children, to avoid double encoding.
      *
@@ -61,12 +57,12 @@ final class NumberViewHelper extends AbstractViewHelper
     /**
      * Format the numeric value as a number with grouped thousands, decimal point and precision.
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $decimals = (int)$arguments['decimals'];
-        $decimalSeparator = $arguments['decimalSeparator'];
-        $thousandsSeparator = $arguments['thousandsSeparator'];
-        $stringToFormat = $renderChildrenClosure();
+        $decimals = (int)$this->arguments['decimals'];
+        $decimalSeparator = $this->arguments['decimalSeparator'];
+        $thousandsSeparator = $this->arguments['thousandsSeparator'];
+        $stringToFormat = $this->renderChildren();
         return number_format((float)$stringToFormat, $decimals, $decimalSeparator, $thousandsSeparator);
     }
 }

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * A ViewHelper for formatting values with printf. Either supply an array for
@@ -70,8 +68,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class PrintfViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments()
     {
         parent::initializeArguments();
@@ -83,9 +79,9 @@ class PrintfViewHelper extends AbstractViewHelper
      * Applies vsprintf() on the specified value.
      * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        return vsprintf($renderChildrenClosure(), $arguments['arguments']);
+        return vsprintf($this->renderChildren(), $this->arguments['arguments']);
     }
 
     /**

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -9,9 +9,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Outputs an argument/value without any escaping. Is normally used to output
@@ -60,8 +58,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class RawViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -80,9 +76,9 @@ class RawViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        return $renderChildrenClosure();
+        return $this->renderChildren();
     }
 
     /**

--- a/src/ViewHelpers/Format/StripTagsViewHelper.php
+++ b/src/ViewHelpers/Format/StripTagsViewHelper.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use Stringable;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Removes tags from the given string (applying PHPs :php:`strip_tags()` function)
@@ -66,8 +64,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class StripTagsViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * No output escaping as some tags may be allowed
      *
@@ -94,11 +90,10 @@ final class StripTagsViewHelper extends AbstractViewHelper
      * @see https://www.php.net/manual/function.strip-tags.php
      * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $value = $renderChildrenClosure();
-        $allowedTags = $arguments['allowedTags'];
-
+        $value = $this->renderChildren();
+        $allowedTags = $this->arguments['allowedTags'];
         if (is_array($value)) {
             throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700819707);
         }

--- a/src/ViewHelpers/Format/TrimViewHelper.php
+++ b/src/ViewHelpers/Format/TrimViewHelper.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This ViewHelper strips whitespace (or other characters) from the beginning and end of a string.
@@ -68,8 +66,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class TrimViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     private const SIDE_BOTH = 'both';
     private const SIDE_LEFT = 'left';
     private const SIDE_START = 'start';
@@ -93,22 +89,19 @@ final class TrimViewHelper extends AbstractViewHelper
     /**
      * @return string the trimmed value
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $value = $arguments['value'];
-        $characters = $arguments['characters'];
-        $side = $arguments['side'];
-
+        $value = $this->arguments['value'];
+        $characters = $this->arguments['characters'];
+        $side = $this->arguments['side'];
         if ($value === null) {
-            $value = (string)$renderChildrenClosure();
+            $value = (string)$this->renderChildren();
         } else {
             $value = (string)$value;
         }
-
         if ($characters === null) {
             $characters = " \t\n\r\0\x0B";
         }
-
         return match ($side) {
             self::SIDE_BOTH => trim($value, $characters),
             self::SIDE_LEFT, self::SIDE_START => ltrim($value, $characters),

--- a/src/ViewHelpers/Format/UrlencodeViewHelper.php
+++ b/src/ViewHelpers/Format/UrlencodeViewHelper.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use Stringable;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Encodes the given string according to http://www.faqs.org/rfcs/rfc3986.html
@@ -45,8 +43,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class UrlencodeViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * Output is escaped already. We must not escape children, to avoid double encoding.
      *
@@ -65,9 +61,9 @@ final class UrlencodeViewHelper extends AbstractViewHelper
      * @see https://www.php.net/manual/function.rawurlencode.php
      * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $value = $renderChildrenClosure();
+        $value = $this->renderChildren();
         if (is_array($value)) {
             throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700821579);
         }

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -7,12 +7,10 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Grouped loop ViewHelper.
@@ -89,8 +87,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class GroupedForViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -108,12 +104,12 @@ class GroupedForViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $each = $arguments['each'];
-        $as = $arguments['as'];
-        $groupBy = $arguments['groupBy'];
-        $groupKey = $arguments['groupKey'];
+        $each = $this->arguments['each'];
+        $as = $this->arguments['as'];
+        $groupBy = $this->arguments['groupBy'];
+        $groupKey = $this->arguments['groupKey'];
         $output = '';
         if ($each === null) {
             return '';
@@ -124,24 +120,19 @@ class GroupedForViewHelper extends AbstractViewHelper
             }
             $each = iterator_to_array($each);
         }
-
         $groups = static::groupElements($each, $groupBy);
-
-        $globalVariableProvider = $renderingContext->getVariableProvider();
+        $globalVariableProvider = $this->renderingContext->getVariableProvider();
         $localVariableProvider = new StandardVariableProvider();
-        $renderingContext->setVariableProvider(new ScopedVariableProvider(
+        $this->renderingContext->setVariableProvider(new ScopedVariableProvider(
             $globalVariableProvider,
             $localVariableProvider,
         ));
-
         foreach ($groups['values'] as $currentGroupIndex => $group) {
             $localVariableProvider->add($groupKey, $groups['keys'][$currentGroupIndex]);
             $localVariableProvider->add($as, $group);
-            $output .= $renderChildrenClosure();
+            $output .= $this->renderChildren();
         }
-
-        $renderingContext->setVariableProvider($globalVariableProvider);
-
+        $this->renderingContext->setVariableProvider($globalVariableProvider);
         return $output;
     }
 

--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Inline Fluid rendering ViewHelper
@@ -34,8 +32,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class InlineViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     protected $escapeChildren = false;
 
     protected $escapeOutput = false;
@@ -52,12 +48,9 @@ class InlineViewHelper extends AbstractViewHelper
     /**
      * @return mixed|string
      */
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext,
-    ) {
-        return $renderingContext->getTemplateParser()->parse((string)$renderChildrenClosure())->render($renderingContext);
+    public function render()
+    {
+        return $this->renderingContext->getTemplateParser()->parse((string)$this->renderChildren())->render($this->renderingContext);
     }
 
     /**

--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * The JoinViewHelper combines elements from an array into a single string.
@@ -58,8 +56,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class JoinViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'array', 'An array');
@@ -70,12 +66,11 @@ final class JoinViewHelper extends AbstractViewHelper
     /**
      * @return string The concatenated string
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $value = $arguments['value'] ?? $renderChildrenClosure();
-        $separator = $arguments['separator'] ?? '';
-        $separatorLast = $arguments['separatorLast'] ?? null;
-
+        $value = $this->arguments['value'] ?? $this->renderChildren();
+        $separator = $this->arguments['separator'] ?? '';
+        $separatorLast = $this->arguments['separatorLast'] ?? null;
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
             throw new \InvalidArgumentException(
@@ -84,17 +79,13 @@ final class JoinViewHelper extends AbstractViewHelper
                 1256475113,
             );
         }
-
         $value = iterator_to_array($value);
-
         if (\count($value) < 2) {
             return (string)array_pop($value);
         }
-
         if ($separatorLast === null || $separatorLast === $separator) {
             return implode($separator, $value);
         }
-
         return implode($separator, \array_slice($value, 0, -1)) . $separatorLast . $value[\count($value) - 1];
     }
 }

--- a/src/ViewHelpers/LastViewHelper.php
+++ b/src/ViewHelpers/LastViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * The LastViewHelper returns the last item of an array.
@@ -29,17 +27,14 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class LastViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'array', '');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): mixed
+    public function render(): mixed
     {
-        $value = $arguments['value'] ?? $renderChildrenClosure();
-
+        $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
             throw new \InvalidArgumentException(
@@ -48,9 +43,7 @@ final class LastViewHelper extends AbstractViewHelper
                 1712221620,
             );
         }
-
         $value = iterator_to_array($value);
-
         return array_pop($value);
     }
 }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Or ViewHelper
@@ -36,8 +34,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class OrViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * Initialize
      */
@@ -51,25 +47,20 @@ class OrViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        $alternative = $arguments['alternative'];
-        $sprintfArguments = (array)$arguments['arguments'];
-
+        $alternative = $this->arguments['alternative'];
+        $sprintfArguments = (array)$this->arguments['arguments'];
         if (empty($sprintfArguments)) {
             $sprintfArguments = null;
         }
-
-        $content = $renderChildrenClosure();
-
+        $content = $this->renderChildren();
         if (null === $content) {
             $content = $alternative;
         }
-
         if (false === empty($content)) {
             $content = null !== $sprintfArguments ? vsprintf($content, $sprintfArguments) : $content;
         }
-
         return $content;
     }
 

--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * The ReplaceViewHelper replaces one or multiple strings with other
@@ -57,8 +55,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class ReplaceViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', '');
@@ -66,16 +62,14 @@ final class ReplaceViewHelper extends AbstractViewHelper
         $this->registerArgument('replace', 'mixed', '', true);
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $value = $arguments['value'] ?? $renderChildrenClosure();
-        $search = $arguments['search'];
-        $replace = $arguments['replace'];
-
+        $value = $this->arguments['value'] ?? $this->renderChildren();
+        $search = $this->arguments['search'];
+        $replace = $this->arguments['replace'];
         if ($value === null || (!is_scalar($value) && !$value instanceof \Stringable)) {
             throw new \InvalidArgumentException('A stringable value must be provided.', 1710441987);
         }
-
         if ($search === null) {
             if (!is_iterable($replace)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -109,7 +103,6 @@ final class ReplaceViewHelper extends AbstractViewHelper
                 throw new \InvalidArgumentException('Count of "search" and "replace" arguments must be the same.', 1710441991);
             }
         }
-
         return str_replace($search, $replace, (string)$value);
     }
 }

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Space Removal ViewHelper
@@ -43,8 +41,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class SpacelessViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -53,8 +49,8 @@ class SpacelessViewHelper extends AbstractViewHelper
     /**
      * @return string
      */
-    public static function renderStatic(array $arguments, \Closure $childClosure, RenderingContextInterface $renderingContext)
+    public function render()
     {
-        return trim(preg_replace('/\\>\\s+\\</', '><', (string)$childClosure()));
+        return trim(preg_replace('/\\>\\s+\\</', '><', (string)$this->renderChildren()));
     }
 }

--- a/src/ViewHelpers/SplitViewHelper.php
+++ b/src/ViewHelpers/SplitViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * The SplitViewHelper splits a string by the specified separator, which
@@ -61,8 +59,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class SplitViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     /**
      * @var bool
      */
@@ -75,13 +71,12 @@ final class SplitViewHelper extends AbstractViewHelper
         $this->registerArgument('limit', 'int', 'If limit is positive, a maximum of $limit items will be returned. If limit is negative, all items except for the last $limit items will be returned. 0 will be treated as 1.', false, PHP_INT_MAX);
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): array
+    public function render(): array
     {
-        $value = $arguments['value'] ?? $renderChildrenClosure();
+        $value = $this->arguments['value'] ?? $this->renderChildren();
         if (!is_string($value)) {
             throw new \InvalidArgumentException('Value to be split must be a string: ' . $value, 1705250408);
         }
-
-        return explode($arguments['separator'], $value, $arguments['limit']);
+        return explode($this->arguments['separator'], $value, $this->arguments['limit']);
     }
 }

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -7,9 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Variable assigning ViewHelper
@@ -36,21 +34,16 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 class VariableViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments()
     {
         $this->registerArgument('value', 'mixed', 'Value to assign. If not in arguments then taken from tag content');
         $this->registerArgument('name', 'string', 'Name of variable to create', true);
     }
 
-    public static function renderStatic(
-        array $arguments,
-        \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext,
-    ) {
-        $value = $renderChildrenClosure();
-        $renderingContext->getVariableProvider()->add($arguments['name'], $value);
+    public function render()
+    {
+        $value = $this->renderChildren();
+        $this->renderingContext->getVariableProvider()->add($this->arguments['name'], $value);
     }
 
     /**

--- a/tests/Unit/Schema/Fixtures/ViewHelpers/Sub/ArbitraryArgumentsViewHelper.php
+++ b/tests/Unit/Schema/Fixtures/ViewHelpers/Sub/ArbitraryArgumentsViewHelper.php
@@ -9,20 +9,16 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\Sub;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 final class ArbitraryArgumentsViewHelper extends AbstractTagBasedViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }

--- a/tests/Unit/Schema/Fixtures/ViewHelpers/Sub/DeprecatedViewHelper.php
+++ b/tests/Unit/Schema/Fixtures/ViewHelpers/Sub/DeprecatedViewHelper.php
@@ -9,23 +9,19 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\Sub;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * @deprecated this is a deprecation message
  */
 final class DeprecatedViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }

--- a/tests/Unit/Schema/Fixtures/ViewHelpers/WithDocumentationViewHelper.php
+++ b/tests/Unit/Schema/Fixtures/ViewHelpers/WithDocumentationViewHelper.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * This is an example documentation with multiple lines
@@ -29,14 +27,12 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
  */
 final class WithDocumentationViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }

--- a/tests/Unit/Schema/Fixtures/ViewHelpers/WithoutClassSuffix.php
+++ b/tests/Unit/Schema/Fixtures/ViewHelpers/WithoutClassSuffix.php
@@ -9,20 +9,16 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 final class WithoutClassSuffix extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }

--- a/tests/Unit/Schema/Fixtures/ViewHelpers/WithoutDocumentationViewHelper.php
+++ b/tests/Unit/Schema/Fixtures/ViewHelpers/WithoutDocumentationViewHelper.php
@@ -9,20 +9,16 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 final class WithoutDocumentationViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }

--- a/tests/Unit/Schema/Fixtures/WrongDirectoryViewHelper.php
+++ b/tests/Unit/Schema/Fixtures/WrongDirectoryViewHelper.php
@@ -9,20 +9,16 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 final class WrongDirectoryViewHelper extends AbstractViewHelper
 {
-    use CompileWithRenderStatic;
-
     public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'A test argument');
     }
 
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
         return '';
     }


### PR DESCRIPTION
Performance tests have shown that the benefits of `renderStatic()` are negligent with current PHP versions. Thus, in preparation of the deprecation of the `CompileWithRenderStatic` trait, we migrate all ViewHelpers to use `render()`.