### PR TITLE
[TASK] Deprecate CompileWithRenderStatic and renderStatic()

### DIFF
--- a/Documentation/Changelog/2.x.rst
+++ b/Documentation/Changelog/2.x.rst
@@ -9,9 +9,16 @@ Changelog 2.x
 2.15
 ----
 
+* Deprecation: Trait :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic`
+  has been marked as deprecated. It will log a deprecation level error message when called in
+  Fluid v4. It will be removed in Fluid v5.
 * Deprecation: Trait :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic`
   has been marked as deprecated. It will log a deprecation level error message when called in
   Fluid v4. It will be removed in Fluid v5.
+* Deprecation: Static method :php:`renderStatic()` on ViewHelpers that don't use :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic`
+  or :php:`TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic`
+  have been marked as deprecated. They will log a deprecation level error message when called in
+  Fluid v4. `renderStatic()` will no longer be called in Fluid v5.
 * Deprecation: Variable names `true`, `false` and `null` will log a deprecation level error message because these
   identifiers will become a Fluid language feature with v4.
 

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -537,6 +537,10 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      * @return mixed
+     * @deprecated renderStatic() on ViewHelpers will still be called in v4, but will log a
+     *             deprecation level error message. It will no longer be called in v5.
+     *             This concrete fallback implementation in AbstractViewHelper will be removed
+     *             with v4.
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {

--- a/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithContentArgumentAndRenderStatic.php
@@ -20,8 +20,9 @@ use TYPO3Fluid\Fluid\Core\Exception;
  * argument is specified and not empty.
  *
  * @deprecated Will be removed in v5. No longer necessary since getContentArgumentName() has been
- * integrated into AbstractViewHelper with v2.15. Name has to be specified explicitly by overriding the
- * method, implicit definition (= first optional argument) is no longer supported.
+ *             integrated into AbstractViewHelper with v2.15. Name has to be specified explicitly
+ *             by overriding the method, implicit definition (= first optional argument) is no
+ *             longer supported.
  */
 trait CompileWithContentArgumentAndRenderStatic
 {

--- a/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
+++ b/src/Core/ViewHelper/Traits/CompileWithRenderStatic.php
@@ -13,6 +13,9 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper\Traits;
  * Provides default methods for rendering and compiling
  * any ViewHelper that conforms to the `renderStatic`
  * method pattern.
+ *
+ * @deprecated Will be removed in v5. The non-static render() method
+ *             should be used instead
  */
 trait CompileWithRenderStatic
 {


### PR DESCRIPTION
Both the trait `CompileWithRenderStatic` and ViewHelpers implementing
`renderStatic()` without using one of the deprecated traits will be deprecated
with Fluid v4 and will no longer work with v5.

ViewHelpers should use `render()` as their primary rendering method.

Related: #983