### PR TITLE
[TASK] Deprecate TYPO3-specific code in TemplatePaths

### DIFF
--- a/examples/example_multiplepaths.php
+++ b/examples/example_multiplepaths.php
@@ -19,7 +19,6 @@
  * path for Layouts.
  */
 
-use TYPO3Fluid\Fluid\View\TemplatePaths;
 use TYPO3Fluid\FluidExamples\Helper\ExampleHelper;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -27,29 +26,23 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $exampleHelper = new ExampleHelper();
 $view = $exampleHelper->init();
 
-// Filling template paths using a complete array which contains multiple paths.
-// This approach can be used to source path definitions when the configuration
-// is stored in a configuration that can be converted to an array.
 // We are adding two path locations: the original one which acts as fallback
 // plus the secondary one, ResourceOverrides, which contains overrides for some
 // template files but not all. The ResourceOverrides naming is optional;
 // usually you would be using the same name for the Resources folder, but point
 // the overrides to a path in, for example, another package's Resources folder.
-// Specifying this array can also be done as constructor argument for the
-// TemplatePaths class which can be passed to the View; see view_init.php.
-$view->getRenderingContext()->getTemplatePaths()->fillFromConfigurationArray([
-    TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [
-        __DIR__ . '/Resources/Private/Templates/',
-        __DIR__ . '/ResourceOverrides/Private/Templates/',
-    ],
-    TemplatePaths::CONFIG_LAYOUTROOTPATHS => [
-        __DIR__ . '/Resources/Private/Layouts/',
-        __DIR__ . '/ResourceOverrides/Private/Layouts/',
-    ],
-    TemplatePaths::CONFIG_PARTIALROOTPATHS => [
-        __DIR__ . '/Resources/Private/Partials/',
-        __DIR__ . '/ResourceOverrides/Private/Partials/',
-    ],
+$templatePaths = $view->getRenderingContext()->getTemplatePaths();
+$templatePaths->setTemplateRootPaths([
+    __DIR__ . '/Resources/Private/Templates/',
+    __DIR__ . '/ResourceOverrides/Private/Templates/',
+]);
+$templatePaths->setLayoutRootPaths([
+    __DIR__ . '/Resources/Private/Layouts/',
+    __DIR__ . '/ResourceOverrides/Private/Layouts/',
+]);
+$templatePaths->setPartialRootPaths([
+    __DIR__ . '/Resources/Private/Partials/',
+    __DIR__ . '/ResourceOverrides/Private/Partials/',
 ]);
 
 $view->assign('foobar', 'This is foobar');

--- a/src/Tools/ConsoleRunner.php
+++ b/src/Tools/ConsoleRunner.php
@@ -155,7 +155,7 @@ final class ConsoleRunner
     }
 
     /**
-     * @param array<string, string> $arguments
+     * @param array<string, string|array> $arguments
      */
     private function handleRunCommand(array $arguments): string
     {
@@ -190,7 +190,9 @@ final class ConsoleRunner
             $context->setCache($cache);
         }
         $paths = $context->getTemplatePaths();
-        $paths->fillFromConfigurationArray($arguments);
+        $paths->setTemplateRootPaths($arguments[self::ARGUMENT_TEMPLATEROOTPATHS] ?? []);
+        $paths->setLayoutRootPaths($arguments[self::ARGUMENT_LAYOUTROOTPATHS] ?? []);
+        $paths->setPartialRootPaths($arguments[self::ARGUMENT_PARTIALROOTPATHS] ?? []);
         if (isset($arguments[self::ARGUMENT_TEMPLATEFILE])) {
             $paths->setTemplatePathAndFilename($arguments[self::ARGUMENT_TEMPLATEFILE]);
         } elseif (isset($arguments[self::ARGUMENT_CONTROLLERNAME])) {

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -41,10 +41,19 @@ use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
  */
 class TemplatePaths
 {
-    public const DEFAULT_FORMAT = 'html';
+    /**
+     * @deprecated will be removed with Fluid v5
+     */
     public const DEFAULT_TEMPLATES_DIRECTORY = 'Resources/Private/Templates/';
+    /**
+     * @deprecated will be removed with Fluid v5
+     */
     public const DEFAULT_LAYOUTS_DIRECTORY = 'Resources/Private/Layouts/';
+    /**
+     * @deprecated will be removed with Fluid v5
+     */
     public const DEFAULT_PARTIALS_DIRECTORY = 'Resources/Private/Partials/';
+    public const DEFAULT_FORMAT = 'html';
     public const CONFIG_TEMPLATEROOTPATHS = 'templateRootPaths';
     public const CONFIG_LAYOUTROOTPATHS = 'layoutRootPaths';
     public const CONFIG_PARTIALROOTPATHS = 'partialRootPaths';
@@ -103,6 +112,11 @@ class TemplatePaths
 
     protected string $format = self::DEFAULT_FORMAT;
 
+    /**
+     * This constructor will be removed with Fluid v5 as the underlying methods are
+     * deprecated and will be removed with Fluid v5 as well. The appropriate setters
+     * (like setTemplateRootPaths()) should be called instead.
+     */
     public function __construct(array|string|null $packageNameOrArray = null)
     {
         if (is_array($packageNameOrArray)) {
@@ -112,8 +126,13 @@ class TemplatePaths
         }
     }
 
+    /**
+     * @deprecated will be removed in Fluid v5; use the individual getters instead. Sanitation is not necessary
+     *             because setters already sanitize input values
+     */
     public function toArray(): array
     {
+        trigger_error('toArray() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         return [
             self::CONFIG_TEMPLATEROOTPATHS => $this->sanitizePaths($this->getTemplateRootPaths()),
             self::CONFIG_LAYOUTROOTPATHS => $this->sanitizePaths($this->getLayoutRootPaths()),
@@ -327,9 +346,12 @@ class TemplatePaths
      * Will replace any currently configured paths.
      *
      * @api
+     * @deprecated will be removed with Fluid v5; appropriate setters (like setTemplateRootPaths())
+     *             should be called instead
      */
     public function fillFromConfigurationArray(array $paths): void
     {
+        trigger_error('fillFromConfigurationArray() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         list($templateRootPaths, $layoutRootPaths, $partialRootPaths, $format) = $this->extractPathArrays($paths);
         $this->setTemplateRootPaths($templateRootPaths);
         $this->setLayoutRootPaths($layoutRootPaths);
@@ -345,9 +367,12 @@ class TemplatePaths
      * Will replace any currently configured paths.
      *
      * @api
+     * @deprecated will be removed with Fluid v5; appropriate setters (like setTemplateRootPaths())
+     *             should be called instead
      */
     public function fillDefaultsByPackageName(string $packageName): void
     {
+        trigger_error('fillDefaultsByPackageName() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         $path = $this->getPackagePath($packageName);
         $this->setTemplateRootPaths([$path . self::DEFAULT_TEMPLATES_DIRECTORY]);
         $this->setLayoutRootPaths([$path . self::DEFAULT_LAYOUTS_DIRECTORY]);
@@ -409,9 +434,11 @@ class TemplatePaths
      *
      * @param string[] $reference
      * @return string[]
+     * @deprecated will be removed with Fluid v5
      */
     protected function ensureAbsolutePaths(array $reference): array
     {
+        trigger_error('ensureAbsolutePaths() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         return array_map([$this, 'ensureAbsolutePath'], $reference);
     }
 
@@ -430,9 +457,12 @@ class TemplatePaths
      * entries being recorded first and plurals second.
      *
      * Adds legacy singular name as last option, if set.
+     *
+     * @deprecated will be removed with Fluid v5
      */
     protected function extractPathArrays(array $paths): array
     {
+        trigger_error('extractPathArrays() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         $format = $this->getFormat();
         // pre-processing: if special parameters exist, extract them:
         if (isset($paths[self::CONFIG_FORMAT])) {
@@ -456,8 +486,12 @@ class TemplatePaths
         return $pathCollections;
     }
 
+    /**
+     * @deprecated will be removed with Fluid v5
+     */
     protected function getPackagePath(string $packageName): string
     {
+        trigger_error('getPackagePath() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         return '';
     }
 

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\View;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
@@ -92,6 +93,7 @@ final class TemplatePathsTest extends TestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function testFillByPackageName(): void
     {
         $instance = new TemplatePaths('TYPO3Fluid.Fluid');
@@ -99,6 +101,7 @@ final class TemplatePathsTest extends TestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function testFillByConfigurationArray(): void
     {
         $instance = new TemplatePaths([
@@ -130,6 +133,7 @@ final class TemplatePathsTest extends TestCase
     }
 
     #[Test]
+    #[IgnoreDeprecations]
     public function testToArray(): void
     {
         $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();


### PR DESCRIPTION
Ever since Fluid has been extracted from TYPO3, there has been some
TYPO3-specific code in TemplatePaths. This patch removes some of
these code paths and the remaining usages in Fluid itself.

Simultaneously, TemplatePaths in TYPO3 13 has been adjusted accordingly.

Soft-deprecations will be backported to Fluid v2 to let users know in
advance that these methods or constants will no longer be available in
the future.