### PR TITLE
[TASK] Prevent template compilation in inheritance test

### DIFF
--- a/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
+++ b/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
@@ -21,25 +21,25 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     {
         return [
             'namespace provided via php api' => [
-                '<f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                '<f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 ['test' => 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers'],
                 [],
             ],
             // @todo this should probably not work
             'namespace provided to layout and partials via inline namespace declaration in template' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 [],
                 [],
             ],
             // @todo this should probably not work
             'namespace provided to layout and partials via xml namespace declaration in template' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 [],
                 [],
             ],
             // @todo this should probably not work
             'namespace inherited from template to dynamic layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:layout name="{myLayout}" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:cache.disable /><f:layout name="{myLayout}" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 [],
                 ['myLayout' => 'NamespaceInheritanceLayout'],
             ],
@@ -50,7 +50,7 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     #[DataProvider('namespacesAreInheritedToLayoutAndPartialsDataProvider')]
     public function namespacesAreInheritedToLayoutAndPartials(string $source, array $predefinedNamespaces, array $variables): void
     {
-        $expectedResult = '<div location="Layout" />' . "\n\n" . '<div location="Template" />' . "\n\n" . '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />' . "\n\n";
+        $expectedResult = "\n" . '<div location="Layout" />' . "\n\n" . '<div location="Template" />' . "\n\n\n\n" . '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />' . "\n\n";
 
         // Uncached
         $view = new TemplateView();
@@ -62,15 +62,9 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
         self::assertSame($expectedResult, $view->render());
 
-        // Cached
-        $view = new TemplateView();
-        $view->getRenderingContext()->setCache(self::$cache);
-        $view->getRenderingContext()->getViewHelperResolver()->addNamespaces($predefinedNamespaces);
-        $view->assignMultiple($variables);
-        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
-        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
-        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
-        self::assertSame($expectedResult, $view->render());
+        // @todo Cached state is currently not relevant here, since caching needs to be disabled for all affected templates to get robust testing results
+        //       With enabled caching, there is interference between the test cases because the "in-memory" cache of TemplateCompiler is re-used and thus
+        //       test cases might be green even if they should actually be red. See https://github.com/TYPO3/Fluid/issues/975
     }
 
     public static function namespaceDefinedInParentNotValidInChildrenDataProvider(): array

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritanceLayout.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritanceLayout.html
@@ -1,3 +1,4 @@
+<f:cache.disable />
 <test:tagBasedTest location="Layout" />
 
 <f:render section="Main" />

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartial.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartial.html
@@ -1,1 +1,2 @@
+<f:cache.disable />
 <test:tagBasedTest location="NestedPartial" />

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritancePartial.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritancePartial.html
@@ -1,2 +1,3 @@
+<f:cache.disable />
 <f:render partial="NamespaceInheritanceNestedPartial" />
 <test:tagBasedTest location="Partial" />


### PR DESCRIPTION
This is an ugly workaround to prevent the interfering runtime
cache until #975 is resolved. Currently, subsequent test cases
are successful even if the rendering is modified to not inherit
ViewHelper namespaces to sub templates because they
re-use the "in-memory" template classes from previous tests.
As there is currently no way to configure this, we need to use
the ugly f:cache.disable ViewHelper in the affected template
to get robust testing results.