### PR TITLE
[TASK] Catch errors in schema generation and collect them

### DIFF
--- a/src/Schema/ViewHelperFinder.php
+++ b/src/Schema/ViewHelperFinder.php
@@ -23,7 +23,7 @@ final class ViewHelperFinder
 
     private ViewHelperMetadataFactory $viewHelperMetadataFactory;
     /**
-     * @var string[] $lastErrors
+     * @var \Throwable[] $lastErrors
      */
     private array $lastErrors = [];
 
@@ -93,7 +93,7 @@ final class ViewHelperFinder
             } catch (\Throwable $t) {
                 // Catch all Throwables to mitigate technical debt of a ViewHelper
                 // and avoid aborting the whole generation
-                $this->lastErrors[] = $t->getMessage();
+                $this->lastErrors[] = $t;
             }
         }
         return $viewHelpers;

--- a/src/Schema/ViewHelperFinder.php
+++ b/src/Schema/ViewHelperFinder.php
@@ -91,6 +91,8 @@ final class ViewHelperFinder
             } catch (\InvalidArgumentException) {
                 // Just ignore this class
             } catch (\Throwable $t) {
+                // Catch all Throwables to mitigate technical debt of a ViewHelper
+                // and avoid aborting the whole generation
                 $this->lastErrors[] = $t->getMessage();
             }
         }

--- a/src/Schema/ViewHelperFinder.php
+++ b/src/Schema/ViewHelperFinder.php
@@ -48,7 +48,7 @@ final class ViewHelperFinder
     }
 
     /**
-     * @return string[]
+     * @return \Throwable[]
      */
     public function getLastErrors(): array
     {

--- a/src/Schema/ViewHelperFinder.php
+++ b/src/Schema/ViewHelperFinder.php
@@ -22,6 +22,10 @@ final class ViewHelperFinder
     private const FILE_SUFFIX = 'ViewHelper.php';
 
     private ViewHelperMetadataFactory $viewHelperMetadataFactory;
+    /**
+     * @var string[] $lastErrors
+     */
+    private array $lastErrors = [];
 
     public function __construct(?ViewHelperMetadataFactory $viewHelperMetadataFactory = null)
     {
@@ -33,6 +37,7 @@ final class ViewHelperFinder
      */
     public function findViewHelpersInComposerProject(ClassLoader $autoloader): array
     {
+        $this->lastErrors = [];
         $viewHelpers = [];
         foreach ($autoloader->getPrefixesPsr4() as $namespace => $paths) {
             foreach ($paths as $path) {
@@ -40,6 +45,14 @@ final class ViewHelperFinder
             }
         }
         return $viewHelpers;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLastErrors(): array
+    {
+        return $this->lastErrors;
     }
 
     /**
@@ -77,6 +90,8 @@ final class ViewHelperFinder
                 $viewHelpers[] = $this->viewHelperMetadataFactory->createFromViewhelperClass($className);
             } catch (\InvalidArgumentException) {
                 // Just ignore this class
+            } catch (\Throwable $t) {
+                $this->lastErrors[] = $t->getMessage();
             }
         }
         return $viewHelpers;


### PR DESCRIPTION
There are cases when errors occur on iterating through the installed view helpers. The generation of the XSDs then break hard with an exception. Currently, this occurs with the TYPO3 extension "schema".

Now, these errors are catched and collected. A calling script can get and display these errors. This way, the generation of XSDs is not cancelled, but proceed without the erroneous view helpers.

This is especially useful for the TYPO3 command "fluid:schema:generate".

Related: #1005 