### PR TITLE
[BUGFIX] Skip nonexistent namespace paths

### DIFF
--- a/src/Schema/ViewHelperFinder.php
+++ b/src/Schema/ViewHelperFinder.php
@@ -60,6 +60,9 @@ final class ViewHelperFinder
      */
     private function findViewHelperFilesInPath(string $namespace, string $path): array
     {
+        if (!is_dir($path)) {
+            return [];
+        }
         $viewHelpers = [];
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_PATHNAME),


### PR DESCRIPTION
If a PHP namespace is defined in composer.json, but the
referenced directory doesn't exist, ViewHelperFinder
produced a PHP error. With this change, nonexistent
directories are skipped.