### PR TITLE
[FEATURE] Scoped variables

### DIFF
--- a/src/ViewHelpers/ScopeViewHelper.php
+++ b/src/ViewHelpers/ScopeViewHelper.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
+use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * Declares a new variable scope which can be used to add locally scoped variables.
+ *
+ * Takes a "variables"-Parameter which is an associative array that defines the variables
+ * that are initially available within this scope.
+ *
+ * These variables are only declared inside the ``<f:scope>...</f:scope>`` tag.
+ *
+ * After the closing tag, all initially and locally declared variables are removed respectively restored again.
+ *
+ * Examples
+ * ========
+ *
+ * ::
+ *     <f:variable name="foo" value="World" />
+ *     <f:scope variables="{foo: 'Fluid', bar: 'Lorem'}">
+ *         <f:variable name="baz" scope="local" value="Ipsum" />
+ *         {bar} {baz} {foo}!
+ *     </f:scope>
+ *     Hello {foo}!
+ *
+ * Output::
+ *
+ *     Lorem Ipsum Fluid!
+ *     Hello World!
+ *
+ * After the scope ``{foo}`` is restored, ``{bar}`` and ``{baz}`` is removed.
+ *
+ * @see \TYPO3Fluid\Fluid\ViewHelpers\VariableViewHelper
+ * @api
+ */
+final class ScopeViewHelper extends AbstractViewHelper
+{
+    /**
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerArgument('variables', 'array', 'Array of variables that will be initially declared within this scope', false, []);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function render(): mixed
+    {
+        $globalVariableProvider = $this->renderingContext->getVariableProvider();
+        $localVariableProvider = new StandardVariableProvider($this->arguments['variables']);
+        $scopedVariableProvider = new ScopedVariableProvider($globalVariableProvider, $localVariableProvider);
+        $this->renderingContext->setVariableProvider($scopedVariableProvider);
+        $output = $this->renderChildren();
+        $this->renderingContext->setVariableProvider($globalVariableProvider);
+        return $output;
+    }
+}

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -7,6 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
+use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -38,12 +39,17 @@ class VariableViewHelper extends AbstractViewHelper
     {
         $this->registerArgument('value', 'mixed', 'Value to assign. If not in arguments then taken from tag content');
         $this->registerArgument('name', 'string', 'Name of variable to create', true);
+        $this->registerArgument('scope', 'string', 'The scope of this variable', defaultValue: 'global');
     }
 
     public function render()
     {
         $value = $this->renderChildren();
-        $this->renderingContext->getVariableProvider()->add($this->arguments['name'], $value);
+        $variableProvider = $this->renderingContext->getVariableProvider();
+        if ($this->arguments['scope'] === 'local' && $variableProvider instanceof ScopedVariableProvider) {
+            $variableProvider = $variableProvider->getLocalVariableProvider();
+        }
+        $variableProvider->add($this->arguments['name'], $value);
     }
 
     /**


### PR DESCRIPTION
## Short intro

- Extended the `f:variable` view helper to support a new backwards compatible `scope` attribute
  - Value: "global" (default) or "local"
- When `f:variable` is used with `scope="local"` and is placed within a view helper opening a new variable scope via `ScopedVariableProvider`, the variable is only added to the local variable provider
- Added a new `f:scope` view helper to simplify the use of local variables
  - It's actually similar to the `f:alias` view helper but without the need to initially declare variables

## Example

```html
<f:variable name="foo" value="World" />
<f:scope variables="{foo: 'Fluid', bar: 'Lorem'}">
  <f:variable name="baz" scope="local" value="Ipsum" />
  {bar} {baz} {foo}!
</f:scope>
Hello {foo}!
```

Output:

```
Lorem Ipsum Fluid!
Hello World!
```

After the scope `{foo}` is restored, `{bar}` and `{baz}` is removed.