### PR TITLE
[BUGFIX] Ensure consistent handling of else-if ViewHelpers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: src/Core/ViewHelper/AbstractConditionViewHelper.php
 
 		-
-			message: '#^Instanceof between TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode and TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 2
-			path: src/Core/ViewHelper/AbstractConditionViewHelper.php
-
-		-
 			message: '#^Call to TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) on a separate line has no effect\.$#'
 			identifier: staticMethod.resultUnused
 			count: 1

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -149,8 +149,10 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
             }
         }
 
-        // Prefer "else" ViewHelper argument if present
-        if ($this->hasArgument('else')) {
+        // Prefer "else" ViewHelper argument if present and template is cached
+        // For uncached templates, child ViewHelpers need to be evaluated first to make
+        // sure that no else-if matches (see below)
+        if ($this->hasArgument('else') && !$this->viewHelperNode instanceof ViewHelperNode) {
             return $this->arguments['else'];
         }
 
@@ -180,6 +182,12 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $elseNode = $childNode;
                 }
             }
+        }
+
+        // If no else-if matches here and an else argument exists, this is prefered over
+        // a possible f:else ViewHelper. See above for the same implementation for cached templates
+        if ($this->hasArgument('else')) {
+            return $this->arguments['else'];
         }
 
         return $elseNode instanceof ViewHelperNode ? $elseNode->evaluate($this->renderingContext) : '';

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -39,8 +39,9 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     private static array $argumentDefinitionCache = [];
 
     /**
-     * Current view helper node
-     * @var ViewHelperNode
+     * Current view helper node; null if template is cached
+     *
+     * @var ViewHelperNode|null
      */
     protected $viewHelperNode;
 

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -374,9 +374,6 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false, 'thenVariable' => 'thenArgument'],
             '',
         ];
-
-        /*
-         * @todo: broken non-compiled, ok compiled
         yield 'else argument, else if child, if verdict false, elseif verdict true' => [
             '<f:if condition="{verdict}" else="elseArgument">' .
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
@@ -384,7 +381,6 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false, 'verdictElseIf' => true],
             'elseIfChild',
         ];
-        */
 
         yield 'inline syntax, then argument, verdict true' => [
             '{f:if(condition:\'{verdict}\', then:\'thenArgument\')}',


### PR DESCRIPTION
A f:if ViewHelper that contains else-if ViewHelpers and also sets the else attribute behaved differently for cached and uncached templates. With this change, uncached templates now behave just like cached templates.

This can be validated by temporarily commenting out the second test execution code in IfThenElseViewHelperTest::render(). This testing setup issue should also be fixed in the future, but this is out of scope for the specific issue.