### PR TITLE
[BUGFIX] Ensure consistent handling of multiple f:else

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -176,7 +176,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     if ($arguments['if']->evaluate($this->renderingContext)) {
                         return $childNode->evaluate($this->renderingContext);
                     }
-                } else {
+                } elseif ($elseNode === null) {
                     $elseNode = $childNode;
                 }
             }


### PR DESCRIPTION
If a f:if ViewHelper contains multiple f:else ViewHelpers, cached templates chose the first else node, while uncached templates chose the last one. This patch restores consistent behavior by adjusting the code for uncached templates.

This can be validated by temporarily commenting out the second test execution code in IfThenElseViewHelperTest::render(). This testing setup issue should also be fixed in the future, but this is out of scope for the specific issue. A follow-up patch will fix a similar issue.