### PR TITLE
[FEATURE] ViewHelpers without then/else return verdict

### DIFF
--- a/Documentation/Usage/ViewHelpers.rst
+++ b/Documentation/Usage/ViewHelpers.rst
@@ -233,6 +233,38 @@ With the tag syntax, it is also possible to define more advanced conditions:
         <f:else>variable is something else</f:else>
     </f:if>
 
+Get verdict by omitting then/else
+---------------------------------
+
+..  versionadded:: Fluid 4.1
+
+If neither `then` nor `else` in any of the accepted forms is specified, the ViewHelper
+returns the verdict of the condition as boolean. This value can be used for further
+processing in the template, for example in complex conditions:
+
+..  code-block:: xml
+
+    <!-- The variable will contain the result of the condition as boolean -->
+    <f:variable
+        name="isEitherTestOrFoo"
+        value="{f:if(condition: '{myVar} == \'test\' || {myVar} == \'foo\'')}"
+    />
+
+    <!-- This example combines two custom condition ViewHelpers to a larger condition -->
+    <f:if condition="{my:customCondition(value: variableToCheck)} || {my:otherCondition(value: variableToCheck)}">
+        ...
+    </f:if>
+
+This syntax can also be helpful in combination with a
+`Tag-Based ViewHelper <https://docs.typo3.org/permalink/typo3fluid/fluid:tagbased-viewhelpers>`_:
+
+..  code-block:: xml
+
+    <!-- disabled attribute is set if either no first name or no last name is set -->
+    <my:tagBased
+        disabled="{f:if(condition: '!{firstName} || !{lastName}')}"
+    />
+
 .. _understanding-viewhelpers:
 
 Understanding ViewHelpers

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -382,6 +382,27 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             'elseIfChild',
         ];
 
+        yield 'if returns result, verdict false' => [
+            '<f:if condition="{verdict}"></f:if>',
+            ['verdict' => false],
+            false,
+        ];
+        yield 'if returns result, self-closing, verdict false' => [
+            '<f:if condition="{verdict}" />',
+            ['verdict' => false],
+            false,
+        ];
+        yield 'if returns result, verdict true' => [
+            '<f:if condition="{verdict}"></f:if>',
+            ['verdict' => true],
+            true,
+        ];
+        yield 'if returns result, self-closing, verdict true' => [
+            '<f:if condition="{verdict}" />',
+            ['verdict' => true],
+            true,
+        ];
+
         yield 'inline syntax, then argument, verdict true' => [
             '{f:if(condition:\'{verdict}\', then:\'thenArgument\')}',
             ['verdict' => true],
@@ -485,6 +506,18 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             0,
         ];
+
+        yield 'inline syntax, if returns result, verdict false' => [
+            '{f:if(condition: verdict)}',
+            ['verdict' => false],
+            false,
+        ];
+        yield 'inline syntax, if returns result, verdict true' => [
+            '{f:if(condition: verdict)}',
+            ['verdict' => true],
+            true,
+        ];
+
         /*
          * @todo This should work but doesn't at the moment. This is probably related to the boolean
          *       parser not converting variable nodes correctly. There is a related todo in the BooleanParserTest.


### PR DESCRIPTION
ViewHelpers that don't specify any then or else clause in any of the accepted syntax variants now directly return the result of the condition.

Previously, this syntax was not supported and a no-op resulting in an empty string. Thus, this is not considered a breaking change, but an enhancement of the existing behavior.