### PR TITLE
[BUGFIX] Use correct interlink code for Fluid docs

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -33,7 +33,9 @@ output in the TYPO3 CMS. However, it is not dependent on TYPO3 and can be used
 in any PHP project.
 
 If using Fluid in combination with TYPO3 CMS, a look at the documentation of
-:doc:`ext_fsc:Index` can be worth a look.
+`Fluid Styled Content
+ <https://docs.typo3.org/permalink/typo3/cms-fluid-styled-content:start>`_
+can be worth a look.
 
 ----
 

--- a/Documentation/Usage/ViewHelpers.rst
+++ b/Documentation/Usage/ViewHelpers.rst
@@ -256,7 +256,7 @@ processing in the template, for example in complex conditions:
     </f:if>
 
 This syntax can also be helpful in combination with a
-`Tag-Based ViewHelper <https://docs.typo3.org/permalink/typo3fluid/fluid:tagbased-viewhelpers>`_:
+`Tag-Based ViewHelper <https://docs.typo3.org/permalink/fluid:tagbased-viewhelpers>`_:
 
 ..  code-block:: xml
 
@@ -309,7 +309,7 @@ Which translated to human terms means that we:
 *   Describe the argument's behavior in simple terms.
 *   Define that the argument is not required (the 4th argument is :php:`false`).
 *   Set a default value of :php:`false` (5th argument), if the argument is not
-    provided when calling the ViewHelper. 
+    provided when calling the ViewHelper.
 
 The ViewHelper itself would then be callable like this:
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,8 +19,4 @@
              version="main (development)"
              copyright="since 2009 by the Fluid contributors"
     />
-    <inventory id="ext_fsc"
-               url="https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/"
-    />
-    <inventory id="t3viewhelper" url="https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/"/>
 </guides>

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -12,7 +12,7 @@
                edit-on-github-branch="main"
                edit-on-github="TYPO3/Fluid"
                typo3-core-preferred="stable"
-               interlink-shortcode="typo3fluid/fluid"
+               interlink-shortcode="fluid"
     />
     <project title="Fluid Explained"
              release="main (development)"


### PR DESCRIPTION
Like other official manuals the Fluid Explained manual has an explicit shortcode, 'fluid' to be used during linking. 

Using the composer key does not work as this manual is not displayed as extension, so the paths are different.

Additionally use standard shortcodes where possible

Please backport if possible