### PR TITLE
[BUGIFX] ViewHelpers without then/else return verdict does not work with null values

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -126,9 +126,8 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         }
 
         // If there's no f:then or f:else, the direct children of the ViewHelper are used as f:then
-        $children = $this->renderChildren();
-        if ($children !== null) {
-            return $children;
+        if (count($this->viewHelperNode->getChildNodes()) > 0) {
+            return $this->renderChildren();
         }
 
         // If there were no children present, but an else handling is specified as ViewHelper argument,

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -308,7 +308,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'function () use ($renderingContext) { return ' . $converted['execution'] . ';}',
+                        'fn () => (' . $converted['execution'] . ')',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(
@@ -324,7 +324,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'function () use ($renderingContext) { return ' . $arguments[$argumentName] . ';}',
+                        'fn () => (' . $arguments[$argumentName] . ')',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -301,16 +301,15 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                 );
             } elseif ($arguments[$argumentName] instanceof NodeInterface) {
                 // Argument *is* given to VH and is a node, resolve
-                $converted = $arguments[$argumentName]->convert($templateCompiler);
-                $accumulatedArgumentInitializationCode .= $converted['initialization'];
-
                 if ($argumentName === 'then' || $argumentName === 'else') {
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'fn () => (' . $converted['execution'] . ')',
+                        $templateCompiler->wrapViewHelperNodeArgumentEvaluationInClosure($node, $argumentName),
                     );
                 } else {
+                    $converted = $arguments[$argumentName]->convert($templateCompiler);
+                    $accumulatedArgumentInitializationCode .= $converted['initialization'];
                     $argumentInitializationCode .= sprintf(
                         '\'%s\' => %s,' . chr(10),
                         $argumentName,
@@ -324,7 +323,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'fn () => (' . $arguments[$argumentName] . ')',
+                        'function () use ($renderingContext) { return ' . $arguments[$argumentName] . ';}',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -97,14 +97,14 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // Closure might be present if ViewHelper is called from a cached template
         if ($this->thenClosure !== null) {
-            return ($this->thenClosure)() ?? '';
+            return ($this->thenClosure)();
         }
 
         // The following code can only be evaluated for uncached templates where the node structure
         // is still available. If it's not, it has already been executed during compilation and we can
         // assume that the condition wasn't met
         if (!$this->viewHelperNode instanceof ViewHelperNode) {
-            return '';
+            return null;
         }
 
         $elseViewHelperEncountered = false;
@@ -122,7 +122,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // If there's a f:else viewhelper, but no matching f:then, the ViewHelper should return a string
         if ($elseViewHelperEncountered) {
-            return '';
+            return null;
         }
 
         // If there's no f:then or f:else, the direct children of the ViewHelper are used as f:then
@@ -134,7 +134,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         // If there were no children present, but an else handling is specified as ViewHelper argument,
         // the Viewhelper again should return a string (same behavior as above). If no then/else handling
         // is present at all, the ViewHelper should return the verdict as boolean
-        return $this->hasArgument('else') ? '' : true;
+        return $this->hasArgument('else') ? null : true;
     }
 
     /**
@@ -153,7 +153,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
             // the "body" closure if condition is met
             foreach ($this->elseIfClosures as $elseIf) {
                 if ($elseIf['condition']()) {
-                    return $elseIf['body']() ?? '';
+                    return $elseIf['body']();
                 }
             }
         }
@@ -167,14 +167,14 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // Closure might be present if ViewHelper is called from a cached template
         if ($this->elseClosure !== null) {
-            return ($this->elseClosure)() ?? '';
+            return ($this->elseClosure)();
         }
 
         // The following code can only be evaluated for uncached templates where the node structure
         // is still available. If it's not, it has already been executed during compilation and we can
         // assume that the condition wasn't met
         if (!$this->viewHelperNode instanceof ViewHelperNode) {
-            return '';
+            return null;
         }
 
         /** @var ViewHelperNode|null $elseNode */
@@ -201,7 +201,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // If a f:else node exists, evaluate its content
         if ($elseNode instanceof ViewHelperNode) {
-            return $elseNode->evaluate($this->renderingContext) ?? '';
+            return $elseNode->evaluate($this->renderingContext);
         }
 
         // If only the condition is specified, but no then/else handling, the whole ViewHelper should
@@ -212,7 +212,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         }
 
         // If some kind of then handling has been specified, the ViewHelper always returns a string
-        return '';
+        return null;
     }
 
     /**

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -80,6 +80,21 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             ' ',
         ];
+        yield 'leading whitespace, empty result body with whitespaces, verdict true' => [
+            ' <f:if condition="{verdict}"><f:format.trim> <f:variable name="foo" value="bar" /> </f:format.trim></f:if>',
+            ['verdict' => true],
+            ' ',
+        ];
+        yield 'leading whitespace, empty result in then, verdict true' => [
+            ' <f:if condition="{verdict}" then="{f:variable(name: \'foo\', value: \'bar\')}" />',
+            ['verdict' => true],
+            ' ',
+        ];
+        yield 'inline syntax, leading whitespace, empty result body, verdict true' => [
+            ' {f:if(condition: verdict, then: "{f:variable(name: \'foo\', value: \'bar\')}")}',
+            ['verdict' => true],
+            ' ',
+        ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
                 'thenBody' .
@@ -531,6 +546,9 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             0,
         ];
+        // This is a special case to test a compiled template where one of the variables, used in the condition "then", is in another scope.
+        // This is important to check if the compiled template does still have access to the variable as it does use an anonymous function which
+        // changes the variable access scope in PHP.
         yield 'inline syntax, then argument using variable, verdict false' => [
             '<f:variable name="foo" value="valueOfFoo" /><f:section name="mySection">{f:if(condition: true, then: "{foo}{baz}")}</f:section><f:render section="mySection" arguments="{baz: foo}" />',
             [],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -39,7 +39,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then argument, verdict false' => [
             '<f:if condition="{verdict}" then="thenArgument" />',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then argument, else argument, verdict true' => [
             '<f:if condition="{verdict}" then="thenArgument" else="elseArgument" />',
@@ -54,7 +54,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'else argument, verdict true' => [
             '<f:if condition="{verdict}" else="elseArgument" />',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'else argument, verdict false' => [
             '<f:if condition="{verdict}" else="elseArgument" />',
@@ -73,7 +73,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 'thenBody' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
@@ -89,7 +89,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then body, else child, verdict true, ignores then body' => [
             '<f:if condition="{verdict}">' .
@@ -97,7 +97,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else>elseChild</f:else>' .
             '</f:if>',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'then body, else child, verdict false' => [
             '<f:if condition="{verdict}">' .
@@ -121,7 +121,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild2</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'else child1, else child2, verdict true' => [
             '<f:if condition="{verdict}">' .
@@ -129,7 +129,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else>elseChild2</f:else>' .
             '</f:if>',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'else child1, else child2, verdict false' => [
             '<f:if condition="{verdict}">' .
@@ -167,7 +167,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then argument, then child, else argument, else child, verdict false, prefers else argument' => [
             '<f:if condition="{verdict}" then="thenArgument" else="elseArgument">' .
@@ -200,7 +200,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => false, 'verdictElseIf' => false],
-            '',
+            null,
         ];
 
         yield 'then child, else if child, else child, if verdict true, elseif verdict true' => [
@@ -327,7 +327,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => true, 'verdictElseIf' => true],
-            '',
+            null,
         ];
         yield 'else if child, if verdict false, elseif verdict true' => [
             '<f:if condition="{verdict}">' .
@@ -341,7 +341,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => false, 'verdictElseIf' => false],
-            '',
+            null,
         ];
 
         yield 'then variable argument, else variable argument, verdict true' => [
@@ -357,7 +357,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then variable argument missing, else variable argument, verdict true' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
             ['verdict' => true, 'elseVariable' => 'elseArgument'],
-            '',
+            null,
         ];
         yield 'then variable argument missing, else variable argument, verdict false' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
@@ -372,7 +372,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then variable argument, else variable missing, verdict false' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
             ['verdict' => false, 'thenVariable' => 'thenArgument'],
-            '',
+            null,
         ];
         yield 'else argument, else if child, if verdict false, elseif verdict true' => [
             '<f:if condition="{verdict}" else="elseArgument">' .
@@ -411,13 +411,13 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'inline syntax, then argument, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:\'thenArgument\')}',
             ['verdict' => false],
-            '',
+            null,
         ];
 
         yield 'inline syntax, else argument, verdict true' => [
             '{f:if(condition:\'{verdict}\', else:\'elseArgument\')}',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'inline syntax, else argument, verdict false' => [
             '{f:if(condition:\'{verdict}\', else:\'elseArgument\')}',
@@ -504,7 +504,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'inline syntax, then argument non existing variable, verdict true' => [
             '{f:if(condition:\'{verdict}\', then: foo)}',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -501,6 +501,31 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             1,
         ];
+        yield 'inline syntax, then argument int 0, verdict truthy expression' => [
+            '{f:if(condition:\'{integer} == 0\', then: 1)}',
+            ['integer' => 0],
+            1,
+        ];
+        yield 'inline syntax, then argument int 1, verdict truthy expression' => [
+            '{f:if(condition:\'{integer} == 1\', then: 1)}',
+            ['integer' => 1],
+            '',
+        ];
+        yield 'inline syntax, else argument int 1, verdict falsy expression' => [
+            '{f:if(condition:\'{integer} == 1\', else: 1)}',
+            ['integer' => 0],
+            '',
+        ];
+        yield 'inline syntax, else argument int 1, verdict truthy expression' => [
+            '{f:if(condition:\'{integer} == 1\', else: 1)}',
+            ['integer' => 1],
+            '',
+        ];
+        yield 'inline syntax, else argument int 1, verdict true' => [
+            '{f:if(condition:\'{verdict}\', else: 1)}',
+            ['verdict' => true],
+            '',
+        ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',
             ['verdict' => false],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -526,6 +526,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             '',
         ];
+        yield 'inline syntax, then argument non existing variable, verdict true' => [
+            '{f:if(condition:\'{verdict}\', then: foo)}',
+            ['verdict' => true],
+            '',
+        ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',
             ['verdict' => false],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -531,6 +531,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             0,
         ];
+        yield 'inline syntax, then argument using variable, verdict false' => [
+            '<f:variable name="foo" value="valueOfFoo" /><f:section name="mySection">{f:if(condition: true, then: "{foo}{baz}")}</f:section><f:render section="mySection" arguments="{baz: foo}" />',
+            [],
+            'valueOfFoo',
+        ];
 
         yield 'inline syntax, if returns result, verdict false' => [
             '{f:if(condition: verdict)}',

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -506,6 +506,21 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             null,
         ];
+        yield 'inline syntax, then argument null, verdict true' => [
+            '{f:if(condition:\'{verdict}\', then: null)}',
+            ['verdict' => true],
+            null,
+        ];
+        yield 'inline syntax, else argument non existing variable, verdict false' => [
+            '{f:if(condition:\'{verdict}\', else: foo)}',
+            ['verdict' => false],
+            null,
+        ];
+        yield 'inline syntax, else argument null, verdict false' => [
+            '{f:if(condition:\'{verdict}\', else: null)}',
+            ['verdict' => false],
+            null,
+        ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',
             ['verdict' => false],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -501,31 +501,6 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             1,
         ];
-        yield 'inline syntax, then argument int 0, verdict truthy expression' => [
-            '{f:if(condition:\'{integer} == 0\', then: 1)}',
-            ['integer' => 0],
-            1,
-        ];
-        yield 'inline syntax, then argument int 1, verdict truthy expression' => [
-            '{f:if(condition:\'{integer} == 1\', then: 1)}',
-            ['integer' => 1],
-            1,
-        ];
-        yield 'inline syntax, else argument int 1, verdict falsy expression' => [
-            '{f:if(condition:\'{integer} == 1\', else: 1)}',
-            ['integer' => 0],
-            1,
-        ];
-        yield 'inline syntax, else argument int 1, verdict truthy expression' => [
-            '{f:if(condition:\'{integer} == 1\', else: 1)}',
-            ['integer' => 1],
-            '',
-        ];
-        yield 'inline syntax, else argument int 1, verdict true' => [
-            '{f:if(condition:\'{verdict}\', else: 1)}',
-            ['verdict' => true],
-            '',
-        ];
         yield 'inline syntax, then argument non existing variable, verdict true' => [
             '{f:if(condition:\'{verdict}\', then: foo)}',
             ['verdict' => true],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -509,12 +509,12 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'inline syntax, then argument int 1, verdict truthy expression' => [
             '{f:if(condition:\'{integer} == 1\', then: 1)}',
             ['integer' => 1],
-            '',
+            1,
         ];
         yield 'inline syntax, else argument int 1, verdict falsy expression' => [
             '{f:if(condition:\'{integer} == 1\', else: 1)}',
             ['integer' => 0],
-            '',
+            1,
         ];
         yield 'inline syntax, else argument int 1, verdict truthy expression' => [
             '{f:if(condition:\'{integer} == 1\', else: 1)}',

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -75,6 +75,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             null,
         ];
+        yield 'leading whitespace, empty result body, verdict true' => [
+            ' <f:if condition="{verdict}"><f:variable name="foo" value="bar" /></f:if>',
+            ['verdict' => true],
+            ' ',
+        ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
                 'thenBody' .


### PR DESCRIPTION
This is a follow up for #1031 which somehow breaks if the result is a `null` value