### PR TITLE
[BUGFIX] Use null instead of empty string as default for condition VHs

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -97,14 +97,14 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // Closure might be present if ViewHelper is called from a cached template
         if ($this->thenClosure !== null) {
-            return ($this->thenClosure)() ?? '';
+            return ($this->thenClosure)();
         }
 
         // The following code can only be evaluated for uncached templates where the node structure
         // is still available. If it's not, it has already been executed during compilation and we can
         // assume that the condition wasn't met
         if (!$this->viewHelperNode instanceof ViewHelperNode) {
-            return '';
+            return null;
         }
 
         $elseViewHelperEncountered = false;
@@ -122,7 +122,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // If there's a f:else viewhelper, but no matching f:then, the ViewHelper should return a string
         if ($elseViewHelperEncountered) {
-            return '';
+            return null;
         }
 
         // If there's no f:then or f:else, the direct children of the ViewHelper are used as f:then
@@ -134,7 +134,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         // If there were no children present, but an else handling is specified as ViewHelper argument,
         // the Viewhelper again should return a string (same behavior as above). If no then/else handling
         // is present at all, the ViewHelper should return the verdict as boolean
-        return $this->hasArgument('else') ? '' : true;
+        return $this->hasArgument('else') ? null : true;
     }
 
     /**
@@ -153,7 +153,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
             // the "body" closure if condition is met
             foreach ($this->elseIfClosures as $elseIf) {
                 if ($elseIf['condition']()) {
-                    return $elseIf['body']() ?? '';
+                    return $elseIf['body']();
                 }
             }
         }
@@ -167,14 +167,14 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // Closure might be present if ViewHelper is called from a cached template
         if ($this->elseClosure !== null) {
-            return ($this->elseClosure)() ?? '';
+            return ($this->elseClosure)();
         }
 
         // The following code can only be evaluated for uncached templates where the node structure
         // is still available. If it's not, it has already been executed during compilation and we can
         // assume that the condition wasn't met
         if (!$this->viewHelperNode instanceof ViewHelperNode) {
-            return '';
+            return null;
         }
 
         /** @var ViewHelperNode|null $elseNode */
@@ -201,7 +201,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
 
         // If a f:else node exists, evaluate its content
         if ($elseNode instanceof ViewHelperNode) {
-            return $elseNode->evaluate($this->renderingContext) ?? '';
+            return $elseNode->evaluate($this->renderingContext);
         }
 
         // If only the condition is specified, but no then/else handling, the whole ViewHelper should
@@ -212,7 +212,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         }
 
         // If some kind of then handling has been specified, the ViewHelper always returns a string
-        return '';
+        return null;
     }
 
     /**

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -39,7 +39,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then argument, verdict false' => [
             '<f:if condition="{verdict}" then="thenArgument" />',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then argument, else argument, verdict true' => [
             '<f:if condition="{verdict}" then="thenArgument" else="elseArgument" />',
@@ -54,7 +54,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'else argument, verdict true' => [
             '<f:if condition="{verdict}" else="elseArgument" />',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'else argument, verdict false' => [
             '<f:if condition="{verdict}" else="elseArgument" />',
@@ -73,7 +73,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 'thenBody' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
@@ -89,7 +89,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then body, else child, verdict true, ignores then body' => [
             '<f:if condition="{verdict}">' .
@@ -97,7 +97,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else>elseChild</f:else>' .
             '</f:if>',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'then body, else child, verdict false' => [
             '<f:if condition="{verdict}">' .
@@ -121,7 +121,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild2</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'else child1, else child2, verdict true' => [
             '<f:if condition="{verdict}">' .
@@ -129,7 +129,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else>elseChild2</f:else>' .
             '</f:if>',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'else child1, else child2, verdict false' => [
             '<f:if condition="{verdict}">' .
@@ -167,7 +167,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:then>thenChild</f:then>' .
             '</f:if>',
             ['verdict' => false],
-            '',
+            null,
         ];
         yield 'then argument, then child, else argument, else child, verdict false, prefers else argument' => [
             '<f:if condition="{verdict}" then="thenArgument" else="elseArgument">' .
@@ -200,7 +200,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => false, 'verdictElseIf' => false],
-            '',
+            null,
         ];
 
         yield 'then child, else if child, else child, if verdict true, elseif verdict true' => [
@@ -327,7 +327,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => true, 'verdictElseIf' => true],
-            '',
+            null,
         ];
         yield 'else if child, if verdict false, elseif verdict true' => [
             '<f:if condition="{verdict}">' .
@@ -341,7 +341,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
                 '<f:else if="{verdictElseIf}">elseIfChild</f:else>' .
             '</f:if>',
             ['verdict' => false, 'verdictElseIf' => false],
-            '',
+            null,
         ];
 
         yield 'then variable argument, else variable argument, verdict true' => [
@@ -357,7 +357,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then variable argument missing, else variable argument, verdict true' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
             ['verdict' => true, 'elseVariable' => 'elseArgument'],
-            '',
+            null,
         ];
         yield 'then variable argument missing, else variable argument, verdict false' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
@@ -372,7 +372,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'then variable argument, else variable missing, verdict false' => [
             '<f:if condition="{verdict}" then="{thenVariable}" else="{elseVariable}" />',
             ['verdict' => false, 'thenVariable' => 'thenArgument'],
-            '',
+            null,
         ];
         yield 'else argument, else if child, if verdict false, elseif verdict true' => [
             '<f:if condition="{verdict}" else="elseArgument">' .
@@ -411,13 +411,13 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'inline syntax, then argument, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:\'thenArgument\')}',
             ['verdict' => false],
-            '',
+            null,
         ];
 
         yield 'inline syntax, else argument, verdict true' => [
             '{f:if(condition:\'{verdict}\', else:\'elseArgument\')}',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'inline syntax, else argument, verdict false' => [
             '{f:if(condition:\'{verdict}\', else:\'elseArgument\')}',


### PR DESCRIPTION
This partially reverts 3084952: Now all condition-based ViewHelpers use
`null` as default return value instead of `''` because this is more
consistent when `then` or `else` returns `null`, for example if a
non-existent variable is used there:

```
{f:if(condition: true, then: nonExistingVariable)}
```

This should return `null`, but now returns `''`. Note that this change
is only a pre-patch, a follow-up will actually achieve the desired
behavior from that example.

For all other use-cases, this change shouldn't be a problem because
`null` will be converted to `''` anyways.