### PR TITLE
[BUGFIX] Differentiate between null and unset then/else condition branches

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/Core/Variables/JSONVariableProvider.php
 
 		-
-			message: '#^Instanceof between TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface and TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: src/Core/ViewHelper/AbstractConditionViewHelper.php
-
-		-
 			message: '#^Call to TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) on a separate line has no effect\.$#'
 			identifier: staticMethod.resultUnused
 			count: 1
@@ -47,12 +41,6 @@ parameters:
 			identifier: staticMethod.resultUnused
 			count: 1
 			path: src/Core/ViewHelper/AbstractTagBasedViewHelper.php
-
-		-
-			message: '#^Instanceof between TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface and TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: src/Core/ViewHelper/AbstractViewHelper.php
 
 		-
 			message: '#^Method TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) has TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception in PHPDoc @throws tag but it''s not thrown\.$#'

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -268,6 +268,28 @@ class TemplateCompiler
     }
 
     /**
+     * Generates PHP code for the arguments part of ViewHelper calls in cached templates
+     *
+     * @param array{string: string|array{string: string}} $argumentsCode
+     * @return string
+     */
+    public function generateViewHelperArgumentsCode(array $argumentsCode): string
+    {
+        $lines = [];
+        foreach ($argumentsCode as $argumentName => $argumentCode) {
+            $lines[] = sprintf(
+                '\'%s\' => %s,',
+                $argumentName,
+                is_array($argumentCode) ? $this->generateViewHelperArgumentsCode($argumentCode) : $argumentCode,
+            );
+        }
+        return sprintf(
+            '[' . chr(10) . '%s' . chr(10) . ']',
+            implode(chr(10), $lines),
+        );
+    }
+
+    /**
      * Returns a unique variable name by appending a global index to the given prefix
      */
     public function variableName(string $prefix): string

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -82,7 +82,8 @@ class ViewHelperNode extends AbstractNode
 
     /**
      * @internal only needed for compiling templates
-     * @return NodeInterface[]
+     * @return array<NodeInterface|scalar> For simple values, an argument might also be scalar
+     *                                     because of Fluid's compiler optimizations
      */
     public function getArguments(): array
     {

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -126,9 +126,8 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
         }
 
         // If there's no f:then or f:else, the direct children of the ViewHelper are used as f:then
-        $children = $this->renderChildren();
-        if ($children !== null) {
-            return $children;
+        if (count($this->viewHelperNode->getChildNodes()) > 0) {
+            return $this->renderChildren();
         }
 
         // If there were no children present, but an else handling is specified as ViewHelper argument,

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -308,7 +308,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'function () use ($renderingContext) { return ' . $converted['execution'] . ';}',
+                        'fn () => (' . $converted['execution'] . ')',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(
@@ -324,7 +324,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'function () use ($renderingContext) { return ' . $arguments[$argumentName] . ';}',
+                        'fn () => (' . $arguments[$argumentName] . ')',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -301,16 +301,15 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                 );
             } elseif ($arguments[$argumentName] instanceof NodeInterface) {
                 // Argument *is* given to VH and is a node, resolve
-                $converted = $arguments[$argumentName]->convert($templateCompiler);
-                $accumulatedArgumentInitializationCode .= $converted['initialization'];
-
                 if ($argumentName === 'then' || $argumentName === 'else') {
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'fn () => (' . $converted['execution'] . ')',
+                        $templateCompiler->wrapViewHelperNodeArgumentEvaluationInClosure($node, $argumentName),
                     );
                 } else {
+                    $converted = $arguments[$argumentName]->convert($templateCompiler);
+                    $accumulatedArgumentInitializationCode .= $converted['initialization'];
                     $argumentInitializationCode .= sprintf(
                         '\'%s\' => %s,' . chr(10),
                         $argumentName,
@@ -324,7 +323,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
                     $argumentInitializationCode .= sprintf(
                         '\'__%s\' => %s,' . chr(10),
                         $argumentName,
-                        'fn () => (' . $arguments[$argumentName] . ')',
+                        'function () use ($renderingContext) { return ' . $arguments[$argumentName] . ';}',
                     );
                 } else {
                     $argumentInitializationCode .= sprintf(

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -80,6 +80,21 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             ' ',
         ];
+        yield 'leading whitespace, empty result body with whitespaces, verdict true' => [
+            ' <f:if condition="{verdict}"><f:format.trim> <f:variable name="foo" value="bar" /> </f:format.trim></f:if>',
+            ['verdict' => true],
+            ' ',
+        ];
+        yield 'leading whitespace, empty result in then, verdict true' => [
+            ' <f:if condition="{verdict}" then="{f:variable(name: \'foo\', value: \'bar\')}" />',
+            ['verdict' => true],
+            ' ',
+        ];
+        yield 'inline syntax, leading whitespace, empty result body, verdict true' => [
+            ' {f:if(condition: verdict, then: "{f:variable(name: \'foo\', value: \'bar\')}")}',
+            ['verdict' => true],
+            ' ',
+        ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
                 'thenBody' .
@@ -531,6 +546,9 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             0,
         ];
+        // This is a special case to test a compiled template where one of the variables, used in the condition "then", is in another scope.
+        // This is important to check if the compiled template does still have access to the variable as it does use an anonymous function which
+        // changes the variable access scope in PHP.
         yield 'inline syntax, then argument using variable, verdict false' => [
             '<f:variable name="foo" value="valueOfFoo" /><f:section name="mySection">{f:if(condition: true, then: "{foo}{baz}")}</f:section><f:render section="mySection" arguments="{baz: foo}" />',
             [],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -504,7 +504,7 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         yield 'inline syntax, then argument non existing variable, verdict true' => [
             '{f:if(condition:\'{verdict}\', then: foo)}',
             ['verdict' => true],
-            '',
+            null,
         ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -531,6 +531,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             0,
         ];
+        yield 'inline syntax, then argument using variable, verdict false' => [
+            '<f:variable name="foo" value="valueOfFoo" /><f:section name="mySection">{f:if(condition: true, then: "{foo}{baz}")}</f:section><f:render section="mySection" arguments="{baz: foo}" />',
+            [],
+            'valueOfFoo',
+        ];
 
         yield 'inline syntax, if returns result, verdict false' => [
             '{f:if(condition: verdict)}',

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -501,6 +501,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             1,
         ];
+        yield 'inline syntax, then argument non existing variable, verdict true' => [
+            '{f:if(condition:\'{verdict}\', then: foo)}',
+            ['verdict' => true],
+            '',
+        ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',
             ['verdict' => false],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -506,6 +506,21 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             null,
         ];
+        yield 'inline syntax, then argument null, verdict true' => [
+            '{f:if(condition:\'{verdict}\', then: null)}',
+            ['verdict' => true],
+            null,
+        ];
+        yield 'inline syntax, else argument non existing variable, verdict false' => [
+            '{f:if(condition:\'{verdict}\', else: foo)}',
+            ['verdict' => false],
+            null,
+        ];
+        yield 'inline syntax, else argument null, verdict false' => [
+            '{f:if(condition:\'{verdict}\', else: null)}',
+            ['verdict' => false],
+            null,
+        ];
         yield 'inline syntax, then argument int 1, else argument int 0, verdict false' => [
             '{f:if(condition:\'{verdict}\', then:1, else:0)}',
             ['verdict' => false],

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -75,6 +75,11 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => false],
             null,
         ];
+        yield 'leading whitespace, empty result body, verdict true' => [
+            ' <f:if condition="{verdict}"><f:variable name="foo" value="bar" /></f:if>',
+            ['verdict' => true],
+            ' ',
+        ];
         yield 'then body, then child, verdict true, prefers child' => [
             '<f:if condition="{verdict}">' .
                 'thenBody' .


### PR DESCRIPTION
With Fluid 4.1 (in 96099a6ba60bcb6a73187d289a781903a05882e3) it became possible to
use `f:if` and other condition-based ViewHelpers without `then` or `else`, which
would return the result of the condition as boolean. However, the current
implementation of this feature didn't consider the difference between a ViewHelper
without any `then` or `else` and one with `then` that returns `null`. These two
examples would both return the boolean:

```
{f:if(condition: myCondition, then: myUndefinedVariable)}
{f:if(condition: myCondition)}
```

With this change, the two examples are treated differently. Instead of checking
the arguments of the ViewHelper (which are already merged with the defined
default values), the ViewHelperNode is used to find out if the argument has
actually been specified. This applies both for uncached rendering and compilation,
which is used for cached templates.

Since the implementation in `AbstractConditionViewHelper` became more and more
convoluted, both the rendering and the compilation step have been refactored.
Also, more test cases are added, which make sure that the issues of the current
implementation are still addressed with the refactored code.

Resolves: #1049