### PR TITLE
[FEATURE] Introduce new nodeInitializedEvent for ViewHelpers

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -19,7 +19,9 @@ Changelog 4.x
   now emits a E_USER_DEPRECATED level error.
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::getFirstElementOfNonEmpty()`
   now emits a E_USER_DEPRECATED level error.
-
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::postParseEvent()`
+  now emits a E_USER_DEPRECATED level error. It will be removed with Fluid v5. ViewHelpers using this event
+  should switch to the new :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface`
 
 4.0
 ---

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,6 +19,12 @@ parameters:
 			path: src/Core/Parser/TemplateParser.php
 
 		-
+			message: '#^Call to an undefined method TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface\:\:getViewHelperClassName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Core/Parser/TemplateParser.php
+
+		-
 			message: '#^Method TYPO3Fluid\\Fluid\\Core\\Parser\\TemplateParser\:\:initializeViewHelperAndAddItToStack\(\) should return TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode\|null but returns TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -9,7 +9,6 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
@@ -562,16 +561,6 @@ abstract class AbstractViewHelper implements ViewHelperInterface
 
         return $execution;
     }
-
-    /**
-     * Save the associated ViewHelper node in a static public class variable.
-     * called directly after the ViewHelper was built.
-     *
-     * @param ViewHelperNode $node
-     * @param array<string, TextNode> $arguments
-     * @param VariableProviderInterface $variableContainer
-     */
-    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer) {}
 
     /**
      * Resets the ViewHelper state.

--- a/src/Core/ViewHelper/ViewHelperNodeInitializedEventInterface.php
+++ b/src/Core/ViewHelper/ViewHelperNodeInitializedEventInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+
+interface ViewHelperNodeInitializedEventInterface
+{
+    /**
+     * Event method that is called after the ViewHelper node has been initialized
+     * during template parsing. This can be used by ViewHelpers to alter or
+     * append information to the PHP representation of the template. Note that
+     * additional changes in the TemplateCompiler might be necessary to also
+     * affect cached templates, which is why the utility for third-party ViewHelpers
+     * is currently limited.
+     *
+     * This event aims to replace the previous postParseEvent(), which was never part
+     * of this interface. The previous event received the parsing state's variable
+     * container as its third argument instead of the whole parsing state, which was
+     * limiting its utility. This has been corrected with the new implementation.
+     *
+     * @param array<string, NodeInterface> $arguments Unevaluated ViewHelper arguments
+     */
+    public static function nodeInitializedEvent(ViewHelperNode $node, array $arguments, ParsingState $parsingState): void;
+}

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -8,9 +8,11 @@
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface;
 
 /**
  * With this tag, you can select a layout to be used for the current template.
@@ -28,7 +30,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class LayoutViewHelper extends AbstractViewHelper
+class LayoutViewHelper extends AbstractViewHelper implements ViewHelperNodeInitializedEventInterface
 {
     /**
      * Initialize arguments
@@ -60,23 +62,18 @@ class LayoutViewHelper extends AbstractViewHelper
     }
 
     /**
-     * On the post parse event, add the "layoutName" variable to the variable container so it can be used by the TemplateView.
+     * On the node initialized event, add the "layoutName" variable to the variable container so it can
+     * be used by the TemplateView.
      *
-     * @param ViewHelperNode $node
-     * @param array $arguments
-     * @param VariableProviderInterface $variableContainer
+     * @param array<string, NodeInterface> $arguments Unevaluated ViewHelper arguments
      */
-    public static function postParseEvent(
-        ViewHelperNode $node,
-        array $arguments,
-        VariableProviderInterface $variableContainer,
-    ) {
+    public static function nodeInitializedEvent(ViewHelperNode $node, array $arguments, ParsingState $parsingState): void
+    {
         if (isset($arguments['name'])) {
             $layoutNameNode = $arguments['name'];
         } else {
             $layoutNameNode = 'Default';
         }
-
-        $variableContainer->add('layoutName', $layoutNameNode);
+        $parsingState->getVariableContainer()->add('layoutName', $layoutNameNode);
     }
 }

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -8,10 +8,12 @@
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface;
 
 /**
  * A ViewHelper to declare sections in templates for later use with e.g. the ``f:render`` ViewHelper.
@@ -64,7 +66,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @api
  */
-class SectionViewHelper extends AbstractViewHelper
+class SectionViewHelper extends AbstractViewHelper implements ViewHelperNodeInitializedEventInterface
 {
     /**
      * @var bool
@@ -115,14 +117,13 @@ class SectionViewHelper extends AbstractViewHelper
      * Save the associated ViewHelper node in a static public class variable.
      * called directly after the ViewHelper was built.
      *
-     * @param ViewHelperNode $node
-     * @param TextNode[] $arguments
-     * @param VariableProviderInterface $variableContainer
+     * @param array<string, NodeInterface> $arguments Unevaluated ViewHelper arguments
      */
-    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer)
+    public static function nodeInitializedEvent(ViewHelperNode $node, array $arguments, ParsingState $parsingState): void
     {
+        $variableContainer = $parsingState->getVariableContainer();
         $nameArgument = $arguments['name'];
-        $sectionName = $nameArgument->getText();
+        $sectionName = $nameArgument->evaluate(new RenderingContext());
         $sections = $variableContainer[TemplateCompiler::SECTIONS_VARIABLE] ? $variableContainer[TemplateCompiler::SECTIONS_VARIABLE] : [];
         $sections[$sectionName] = $node;
         $variableContainer[TemplateCompiler::SECTIONS_VARIABLE] = $sections;

--- a/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
+
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ViewHelperEventsTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function nodeInitializedEvent(): void
+    {
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('nodeInitializedEvent triggered');
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<test:nodeInitializedEvent />');
+        $view->render();
+
+        // No second execution here because event only triggers for uncached templates
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function postParseEvent(): void
+    {
+        self::expectException(\Exception::class);
+        self::expectExceptionMessage('postParseEvent triggered');
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<test:postParseEvent />');
+        $view->render();
+
+        // No second execution here because event only triggers for uncached templates
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/NodeInitializedEventViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/NodeInitializedEventViewHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface;
+
+final class NodeInitializedEventViewHelper extends AbstractViewHelper implements ViewHelperNodeInitializedEventInterface
+{
+    public function render(): string
+    {
+        return '';
+    }
+
+    public static function nodeInitializedEvent(ViewHelperNode $node, array $arguments, ParsingState $parsingState): void
+    {
+        throw new \Exception('nodeInitializedEvent triggered');
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/PostParseEventViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/PostParseEventViewHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class PostParseEventViewHelper extends AbstractViewHelper
+{
+    public function render(): string
+    {
+        return '';
+    }
+
+    public static function postParseEvent(ViewHelperNode $node, array $arguments, VariableProviderInterface $variableContainer): void
+    {
+        throw new \Exception('postParseEvent triggered');
+    }
+}


### PR DESCRIPTION
In the current implementation, there already exists a "postParseEvent"
method which allows ViewHelpers to hook into the rendering process.
This is currently used by the f:layout ViewHelper to set the template's
layout. It is also used by the f:section ViewHelper to collect all sections
within a template. Currently, both implementation use the variable
container to transport that information to the compiler and the renderer,
which will then interpret that data.

While it makes sense to provide a generic way to transport data to
allow third-parties to extend Fluid, both cases described above are part
of Fluid's core functionality. Thus, we should aim to append that data
directly to the `ParsingState` instead of using magic strings as variable
names. This patch creates a new event, which has now access to the
whole `ParsingState` object, which can be extended in follow-up
patches to get rid of those magic strings.

Another advantage of direct access to the `ParsingState` is that
ViewHelpers can make more informed decisions during template
parsing. For example, it could be possible to allow certain ViewHelpers
only on the root-level of templates, but not nested within other
ViewHelpers. This will become necessary for the implementation of
upcoming Fluid component features.

For compatibility reasons, the old event keeps getting called by
`TemplateParser`, but emits a deprecation warning. This compatibility
layer will be removed with Fluid v5. ViewHelpers should be migrated
to the new `ViewHelperNodeInitializedEventInterface`.

This patch also adjust existing ViewHelpers to use the new event.