### PR TITLE
[TASK] Remove obsolete method from ViewHelperNode

### DIFF
--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -90,14 +90,6 @@ class ViewHelperNode extends AbstractNode
         return $this->arguments;
     }
 
-    /**
-     * @internal only needed for compiling templates
-     */
-    public function getArgumentDefinition($argumentName): ?ArgumentDefinition
-    {
-        return $this->argumentDefinitions[$argumentName] ?? null;
-    }
-
     public function addChildNode(NodeInterface $childNode): void
     {
         parent::addChildNode($childNode);


### PR DESCRIPTION
This method hasn't been used since before the extraction of Fluid
from TYPO3 core. It is marked as internal and isn't used by any
extension in TYPO3 TER nor by any of the known Fluid extensions
or integrations.