### PR TITLE
[TASK] Remove obsolete prepareArguments() call

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -294,8 +294,6 @@ class TemplateParser
         }
 
         $viewHelper = $viewHelperResolver->createViewHelperInstance($namespaceIdentifier, $methodIdentifier);
-        // @todo: Is this call needed?
-        $viewHelper->prepareArguments();
         $viewHelperNode = $this->initializeViewHelperAndAddItToStack(
             $state,
             $namespaceIdentifier,


### PR DESCRIPTION
As suspected in the todo annotation, this call is obsolete: In the next line,
`$this->parseArguments()` is called, which calls
`ViewHelperResolver::getArgumentDefinitionsForViewHelper()` in its first
line, which then calls (and returns the result of `prepareArguments()`.