### PR TITLE
[FEATURE] Introduce ArgumentProcessor API

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -15,6 +15,10 @@ Changelog 4.x
   now emits a E_USER_DEPRECATED level error.
 * Deprecation: Constant :php:`TYPO3Fluid\Fluid\Core\Parser\Patterns::NAMESPACESUFFIX`
   has been marked as deprecated and will be removed in Fluid v5.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::isValidType()`
+  now emits a E_USER_DEPRECATED level error.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::getFirstElementOfNonEmpty()`
+  now emits a E_USER_DEPRECATED level error.
 
 
 4.0

--- a/src/Core/ViewHelper/ArgumentProcessorInterface.php
+++ b/src/Core/ViewHelper/ArgumentProcessorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @internal
+ */
+interface ArgumentProcessorInterface
+{
+    public function process(mixed $value, ArgumentDefinition $definition): mixed;
+    public function isValid(mixed $value, ArgumentDefinition $definition): bool;
+}

--- a/src/Core/ViewHelper/LenientArgumentProcessor.php
+++ b/src/Core/ViewHelper/LenientArgumentProcessor.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+use ArrayAccess;
+use Traversable;
+
+/**
+ * The LenientArgumentProcessor mimicks the ViewHelper argument validation
+ * logic used by Fluid up to (and including) 4.x:
+ *
+ * 1. Argument types are validated against the isValidType() implementation
+ *    which previously was part of AbstractViewHelper. For clear violations
+ *    (e. g. a string instead of an array), validation fails.
+ * 2. Valid types are NOT guaranteed to ViewHelpers in all cases, since scalar
+ *    types are not converted implicitly (meaning: You might receive an integer,
+ *    even if the ViewHelper specifies "string" as argument type)
+ * 3. ArrayAccess and Traversible are valid array arguments
+ * 4. Objects implementing Stringable are valid string arguments
+ * 5. In addition to PHP's internal types, class names can be specified as well
+ * 6. Collection types (e. g. "string[]") are possible. Only the first item
+ *    of a collection is validated.
+ *
+ * @internal
+ */
+final readonly class LenientArgumentProcessor implements ArgumentProcessorInterface
+{
+    public function process(mixed $value, ArgumentDefinition $definition): mixed
+    {
+        // No processing, argument values are passed on unmodified
+        return $value;
+    }
+
+    public function isValid(mixed $value, ArgumentDefinition $definition): bool
+    {
+        // Allow everything for mixed type
+        if ($definition->getType() === 'mixed') {
+            return true;
+        }
+
+        // Always allow default value if argument is not required
+        if (!$definition->isRequired() && $value === $definition->getDefaultValue()) {
+            return true;
+        }
+
+        // Perform type validation
+        return $this->isValidType($definition->getType(), $value);
+    }
+
+    /**
+     * Check whether the defined type matches the value type
+     */
+    private function isValidType(string $type, mixed $value): bool
+    {
+        if ($type === 'object') {
+            if (!is_object($value)) {
+                return false;
+            }
+        } elseif ($type === 'array' || substr($type, -2) === '[]') {
+            if (!is_array($value) && !$value instanceof ArrayAccess && !$value instanceof Traversable && !empty($value)) {
+                return false;
+            }
+            if (substr($type, -2) === '[]') {
+                $firstElement = $this->getFirstElementOfNonEmpty($value);
+                if ($firstElement === null) {
+                    return true;
+                }
+                return $this->isValidType(substr($type, 0, -2), $firstElement);
+            }
+        } elseif ($type === 'string') {
+            if (is_object($value) && !method_exists($value, '__toString')) {
+                return false;
+            }
+        } elseif ($type === 'boolean' && !is_bool($value)) {
+            return false;
+        } elseif (class_exists($type) && $value !== null && !$value instanceof $type) {
+            return false;
+        } elseif (is_object($value) && !is_a($value, $type, true)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Return the first element of the given array, ArrayAccess or Traversable
+     * that is not empty
+     */
+    private function getFirstElementOfNonEmpty(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return reset($value);
+        }
+        if ($value instanceof Traversable) {
+            foreach ($value as $element) {
+                return $element;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -46,6 +46,8 @@ class ViewHelperInvoker
         }
         $argumentDefinitions = $viewHelperResolver->getArgumentDefinitionsForViewHelper($viewHelper);
 
+        // @todo make configurable with Fluid v5
+        $argumentProcessor = new LenientArgumentProcessor();
         try {
             // Convert nodes to actual values (in uncached context)
             $arguments = array_map(
@@ -56,7 +58,9 @@ class ViewHelperInvoker
             // Determine arguments defined by the ViewHelper API
             $registeredArguments = [];
             foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
-                $registeredArguments[$argumentName] = $arguments[$argumentName] ?? $argumentDefinition->getDefaultValue();
+                $registeredArguments[$argumentName] = isset($arguments[$argumentName])
+                    ? $argumentProcessor->process($arguments[$argumentName], $argumentDefinition)
+                    : $argumentDefinition->getDefaultValue();
                 unset($arguments[$argumentName]);
             }
 

--- a/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
@@ -17,6 +17,40 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class ViewHelperArgumentTypesTest extends AbstractFunctionalTestCase
 {
+    #[Test]
+    public function invalidArgumentTypeUncached(): void
+    {
+        $source = '<f:count subject="test" />';
+
+        self::expectExceptionCode(1256475113);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->render();
+    }
+
+    #[Test]
+    public function invalidArgumentTypeCached(): void
+    {
+        $source = '<f:count subject="test" />';
+
+        self::expectExceptionCode(1256475113);
+
+        try {
+            $view = new TemplateView();
+            $view->getRenderingContext()->setCache(self::$cache);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+            $view->render();
+        } catch (\Exception) {
+        }
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->render();
+    }
+
     public static function scalarArgumentsDataProvider(): array
     {
         return [

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -46,6 +46,7 @@ final class AbstractViewHelperTest extends TestCase
 
     #[DataProvider('getFirstElementOfNonEmptyTestValues')]
     #[Test]
+    #[IgnoreDeprecations]
     public function getFirstElementOfNonEmptyReturnsExpectedValue(mixed $input, ?string $expected): void
     {
         $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods([])->getMock();
@@ -64,15 +65,6 @@ final class AbstractViewHelperTest extends TestCase
             'someName' => new ArgumentDefinition('someName', 'integer', 'changed desc', true),
         ];
         self::assertEquals($expected, $subject->prepareArguments());
-    }
-
-    #[Test]
-    public function validateArgumentsAcceptsAllObjectsImplementingArrayAccessAsAnArray(): void
-    {
-        $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods(['prepareArguments'])->getMock();
-        $subject->setArguments(['test' => new \ArrayObject()]);
-        $subject->expects(self::once())->method('prepareArguments')->willReturn(['test' => new ArgumentDefinition('test', 'array', 'documentation', false)]);
-        $subject->validateArguments();
     }
 
     #[Test]
@@ -100,31 +92,6 @@ final class AbstractViewHelperTest extends TestCase
         });
         $result = $subject->renderChildren();
         self::assertEquals('foobar', $result);
-    }
-
-    public static function validateArgumentsErrorsDataProvider(): array
-    {
-        return [
-            [new ArgumentDefinition('test', 'boolean', '', true), ['bad']],
-            [new ArgumentDefinition('test', 'string', '', true), new \ArrayIterator(['bar'])],
-            [new ArgumentDefinition('test', 'DateTime', '', true), new \ArrayIterator(['bar'])],
-            [new ArgumentDefinition('test', 'DateTime', '', true), 'test'],
-            [new ArgumentDefinition('test', 'integer', '', true), new \ArrayIterator(['bar'])],
-            [new ArgumentDefinition('test', 'object', '', true), 'test'],
-            [new ArgumentDefinition('test', 'string[]', '', true), [new \DateTime('now'), 'test']],
-        ];
-    }
-
-    #[DataProvider('validateArgumentsErrorsDataProvider')]
-    #[Test]
-    public function validateArgumentsErrors(ArgumentDefinition $argument, array|string|object $value): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $subject = $this->getMockBuilder(AbstractViewHelper::class)->onlyMethods(['hasArgument', 'prepareArguments'])->getMock();
-        $subject->expects(self::once())->method('prepareArguments')->willReturn([$argument->getName() => $argument]);
-        $subject->expects(self::once())->method('hasArgument')->with($argument->getName())->willReturn(true);
-        $subject->setArguments([$argument->getName() => $value]);
-        $subject->validateArguments();
     }
 
     #[Test]

--- a/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\LenientArgumentProcessor;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
+
+final class LenientArgumentProcessorTest extends TestCase
+{
+    public static function isValidAndProcessDataProvider(): array
+    {
+        // This list demonstrates the "lenient" behavior of the current argument processing.
+        // Most scalar validations are wrong if the values aren't cast to the correct types
+        // later. Also, the code relies on the BooleanParser as preprocessor and has a lot of
+        // inconsistencies.
+        return [
+            [true, 'boolean', true],
+            [false, 'boolean', true],
+            [['bad'], 'boolean', false],
+            // De-facto, all non-boolean values are converted by the parser
+            [(new BooleanNode(123))->evaluate(new RenderingContext()), 'boolean', true],
+
+            [true, 'bool', true],
+            [false, 'bool', true],
+            [['bad'], 'bool', true], // @todo this is clearly wrong
+            // De-facto, all non-boolean values are converted by the parser
+            [(new BooleanNode(123))->evaluate(new RenderingContext()), 'bool', true],
+
+            [true, 'string', true],
+            [false, 'string', true],
+            [2, 'string', true],
+            [1, 'string', true],
+            [0, 'string', true],
+            [-1, 'string', true],
+            [1.5, 'string', true],
+            ['', 'string', true],
+            ['test', 'string', true],
+            [null, 'string', true],
+            [new stdClass(), 'string', false],
+            [new \DateTime('now'), 'string', false],
+            [[], 'string', true], // @todo this can lead to PHP warnings
+            [['test'], 'string', true], // @todo this can lead to PHP warnings
+            [new \ArrayIterator(['bar']), 'string', false],
+            [new UserWithToString('foo'), 'string', true],
+
+            [true, 'integer', true],
+            [false, 'integer', true],
+            [2, 'integer', true],
+            [1, 'integer', true],
+            [0, 'integer', true],
+            [-1, 'integer', true],
+            [1.5, 'integer', true],
+            ['', 'integer', true],
+            ['test', 'integer', true],
+            [null, 'integer', true],
+            [new stdClass(), 'integer', false],
+            [new \DateTime('now'), 'integer', false],
+            [[], 'integer', true], // @todo this can lead to PHP warnings
+            [['test'], 'integer', true], // @todo this can lead to PHP warnings
+            [new \ArrayIterator(['bar']), 'integer', false],
+            [new UserWithToString('foo'), 'integer', false],
+
+            [true, 'int', true],
+            [false, 'int', true],
+            [2, 'int', true],
+            [1, 'int', true],
+            [0, 'int', true],
+            [-1, 'int', true],
+            [1.5, 'int', true],
+            ['', 'int', true],
+            ['test', 'int', true],
+            [null, 'int', true],
+            [new stdClass(), 'int', false],
+            [new stdClass(), 'int', false],
+            [new \DateTime('now'), 'int', false],
+            [[], 'int', true], // @todo this can lead to PHP warnings
+            [['test'], 'int', true], // @todo this can lead to PHP warnings
+            [new \ArrayIterator(['bar']), 'int', false],
+            [new UserWithToString('foo'), 'int', false],
+
+            [true, 'float', true],
+            [false, 'float', true],
+            [2, 'float', true],
+            [1, 'float', true],
+            [0, 'float', true],
+            [-1, 'float', true],
+            [1.5, 'float', true],
+            ['', 'float', true],
+            ['test', 'float', true],
+            [null, 'float', true],
+            [new stdClass(), 'float', false],
+            [new stdClass(), 'float', false],
+            [new \DateTime('now'), 'float', false],
+            [[], 'float', true], // @todo this can lead to PHP warnings
+            [['test'], 'float', true], // @todo this can lead to PHP warnings
+            [new \ArrayIterator(['bar']), 'float', false],
+            [new UserWithToString('foo'), 'float', false],
+
+            [true, 'double', true],
+            [false, 'double', true],
+            [2, 'double', true],
+            [1, 'double', true],
+            [0, 'double', true],
+            [-1, 'double', true],
+            [1.5, 'double', true],
+            ['', 'double', true],
+            ['test', 'double', true],
+            [null, 'double', true],
+            [new stdClass(), 'double', false],
+            [new stdClass(), 'double', false],
+            [new \DateTime('now'), 'double', false],
+            [[], 'double', true], // @todo this can lead to PHP warnings
+            [['test'], 'double', true], // @todo this can lead to PHP warnings
+            [new \ArrayIterator(['bar']), 'double', false],
+            [new UserWithToString('foo'), 'double', false],
+
+            [new \ArrayIterator(['bar']), 'DateTime', false],
+            ['test', 'DateTime', false],
+            [null, 'DateTime', true], // @todo this can lead to PHP warnings
+
+            ['test', 'object', false],
+            [null, 'object', false],
+
+            [[], 'array', true],
+            [[1, 2, 3], 'array', true],
+            [new \ArrayObject(), 'array', true],
+
+            [['foo', 'bar'], 'string[]', true],
+            [new \IteratorIterator(new \ArrayIterator(['foo', 'bar'])), 'string[]', true],
+            [['foo', 1], 'string[]', true],
+            [[1, 'foo', 2], 'string[]', true],
+            [[new \DateTime('now'), 'test'], 'string[]', false],
+            [[new UserWithToString('foo')], 'string[]', true],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('isValidAndProcessDataProvider')]
+    public function isValidAndProcess(mixed $value, string $type, bool $expectedValidity): void
+    {
+        $definition = new ArgumentDefinition('test', $type, '', true);
+        // Check validity
+        self::assertSame($expectedValidity, (new LenientArgumentProcessor())->isValid($value, $definition));
+        // Process should pass values unmodified
+        self::assertSame($value, (new LenientArgumentProcessor())->process($value, $definition));
+    }
+
+    public static function optionalArgumentAllowsDefaultValueDataProvider(): array
+    {
+        return [
+            ['string', null],
+            ['object', null],
+            ['DateTime', null],
+            ['array', []],
+            ['int[]', ['string']],
+            ['array', 'my default'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('optionalArgumentAllowsDefaultValueDataProvider')]
+    public function optionalArgumentAllowsDefaultValue(string $type, mixed $defaultValue): void
+    {
+        $definition = new ArgumentDefinition('test', $type, '', false, $defaultValue);
+        self::assertTrue((new LenientArgumentProcessor())->isValid($defaultValue, $definition));
+    }
+}


### PR DESCRIPTION
Fluid allows ViewHelpers to specify their API by using
`AbstractViewHelper::registerArgument()`, which is usually called in
`initializeArguments()` of the ViewHelper. Internally, `ArgumentDefinition`
is used to represent the provided argument information and constraints.
Among those is the ability to specify the type of an argument as well
as if the argument should be a required argument.

While the required status is already validated at the parser level, the
argument types are validated by the ViewHelper implementation. However,
in most cases, Fluid's built-in validation method by `AbstractViewHelper`
is used. Unfortunately, this implementation has many flaws:

* it only covers a subset of possible types (e. g. it covers "boolean", but
  not "bool")
* It doesn't ensure the correct argument type for scalar arguments (e. g.
  you might receive an integer in your ViewHelper implementation, even
  if the argument has been defined as "string")
* There are several small inconsistencies

In order to fix this in a future Fluid version without introducing too many
hard-to-debug breaking changes, a new API is introduced which extracts
validation functionality from the `AbstractViewHelper` and allows
alternative implementations in the future. It also adds the possibility
to pre-process arguments before their validity is checked, which will
allow implicit type conversions in the future (e. g. convert "int" to "string").

As a first step, the existing helper methods `isValidType()` and
`getFirstElementOfNonEmpty()` are deprecated and extracted into
a `LenientArgumentProcessor`, which mimicks the current validation
behavior. Like the current implementation, it doesn't modify the argument
types, but rather passes them along unmodified.

The new API is then called for the pre-processing step in
`ViewHelperInvoker` as well as the validation step in `AbstractViewHelper`.
In this first implementation, it isn't possible yet to replace the default
implementation with an alternative.