### PR TITLE
[FEATURE] StrictArgumentProcessor

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+use ArrayAccess;
+use Stringable;
+use Traversable;
+
+/**
+ * The StrictArgumentProcessor offers an alternative, stricter implementation
+ * for Fluid's argument validation. Noteworthy differences:
+ *
+ * 1. The validation either ends with a negative result or with a valid
+ *    type of the variable. In the previous implementation, there could be
+ *    situations where the type wasn't ensured properly.
+ * 2. Scalar values are implicitly converted to the correct type.
+ * 3. Common type aliases are considered (e. g. int and integer)
+ *
+ * @internal
+ */
+final readonly class StrictArgumentProcessor implements ArgumentProcessorInterface
+{
+    public function process(mixed $value, ArgumentDefinition $definition): mixed
+    {
+        if (!$definition->isRequired() && $value === $definition->getDefaultValue()) {
+            return $value;
+        }
+        // bool/boolean is not handled separately here because Fluid's BooleanParser
+        // already ensures valid boolean values
+        return match ($definition->getType()) {
+            'string' => is_scalar($value) ? (string)$value : $value,
+            'int', 'integer' => is_scalar($value) ? (int)$value : $value,
+            'float', 'double' => is_scalar($value) ? (float)$value : $value,
+            default => $value,
+        };
+    }
+
+    public function isValid(mixed $value, ArgumentDefinition $definition): bool
+    {
+        // Allow everything for mixed type
+        if ($definition->getType() === 'mixed') {
+            return true;
+        }
+
+        // Always allow default value if argument is not required
+        if (!$definition->isRequired() && $value === $definition->getDefaultValue()) {
+            return true;
+        }
+
+        // Perform type validation
+        return $this->isValidType($definition->getType(), $value);
+    }
+
+    /**
+     * Check whether the defined type matches the value type
+     */
+    private function isValidType(string $type, mixed $value): bool
+    {
+        if ($type === 'object') {
+            return is_object($value);
+        }
+        if ($type === 'string') {
+            return is_string($value) || $value instanceof Stringable;
+        }
+        if ($type === 'int' || $type === 'integer') {
+            return is_int($value);
+        }
+        if ($type === 'float' || $type === 'double') {
+            return is_float($value);
+        }
+        if ($type === 'bool' || $type === 'boolean') {
+            return is_bool($value);
+        }
+        if ($type === 'array' || str_ends_with($type, '[]')) {
+            if (!is_array($value) && !$value instanceof ArrayAccess && !$value instanceof Traversable) {
+                return false;
+            }
+            if (str_ends_with($type, '[]')) {
+                $firstElement = $this->getFirstElementOfNonEmpty($value);
+                if ($firstElement === null) {
+                    return true;
+                }
+                return $this->isValidType(substr($type, 0, -2), $firstElement);
+            }
+            return true;
+        }
+        if (class_exists($type) && $value instanceof $type) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return the first element of the given array, ArrayAccess or Traversable
+     * that is not empty
+     */
+    private function getFirstElementOfNonEmpty(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return reset($value);
+        }
+        if ($value instanceof Traversable) {
+            foreach ($value as $element) {
+                return $element;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -1,0 +1,578 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
+
+final class StrictArgumentProcessorTest extends TestCase
+{
+    public static function isValidAndProcessDataProvider(): iterable
+    {
+        $dateTime = new \DateTime('now');
+        $stdClass = new stdClass();
+        $arrayIterator = new \ArrayIterator(['bar']);
+        $stringable = new UserWithToString('foo');
+
+        //
+        // Boolean types
+        //
+        foreach (['boolean', 'bool'] as $type) {
+            yield [
+                'type' => $type,
+                'value' => true,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => true,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => false,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => false,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => ['bad'],
+                'expectedValidity' => false,
+                'expectedProcessedValue' => ['bad'],
+                'expectedProcessedValidity' => false,
+            ];
+            // De-facto, all non-boolean values are converted by the parser
+            yield [
+                'type' => $type,
+                'value' => (new BooleanNode(123))->evaluate(new RenderingContext()),
+                'expectedValidity' => true,
+                'expectedProcessedValue' => true,
+                'expectedProcessedValidity' => true,
+            ];
+        }
+
+        //
+        // String
+        //
+        yield [
+            'type' => 'string',
+            'value' => true,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '1',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => false,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => 2,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '2',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => 1,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '1',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => 0,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '0',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => -1,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '-1',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => 1.5,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '1.5',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => '',
+            'expectedValidity' => true,
+            'expectedProcessedValue' => '',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => 'test',
+            'expectedValidity' => true,
+            'expectedProcessedValue' => 'test',
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => null,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => $stdClass,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $stdClass,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => $dateTime,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $dateTime,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => [],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [],
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => ['test'],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => ['test'],
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => $arrayIterator,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $arrayIterator,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string',
+            'value' => $stringable,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => $stringable,
+            'expectedProcessedValidity' => true,
+        ];
+
+        //
+        // Integer types
+        //
+        foreach (['int', 'integer'] as $type) {
+            yield [
+                'type' => $type,
+                'value' => true,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 1,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => false,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 2,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => 2,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 1,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => 1,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 0,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => 0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => -1,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => -1,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 1.5,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 1,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => '',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 'test',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => null,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => null,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $stdClass,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $stdClass,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $dateTime,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $dateTime,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => [],
+                'expectedValidity' => false,
+                'expectedProcessedValue' => [],
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => ['test'],
+                'expectedValidity' => false,
+                'expectedProcessedValue' => ['test'],
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $arrayIterator,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $arrayIterator,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $stringable,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $stringable,
+                'expectedProcessedValidity' => false,
+            ];
+        }
+
+        //
+        // Float types
+        //
+        foreach (['float', 'double'] as $type) {
+            yield [
+                'type' => $type,
+                'value' => true,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 1.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => false,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 2,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 2.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 1,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 1.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 0,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => -1,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => -1.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 1.5,
+                'expectedValidity' => true,
+                'expectedProcessedValue' => 1.5,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => '',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 'test',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => 0.0,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => null,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => null,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $stdClass,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $stdClass,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $dateTime,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $dateTime,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => [],
+                'expectedValidity' => false,
+                'expectedProcessedValue' => [],
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => ['test'],
+                'expectedValidity' => false,
+                'expectedProcessedValue' => ['test'],
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $arrayIterator,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $arrayIterator,
+                'expectedProcessedValidity' => false,
+            ];
+            yield [
+                'type' => $type,
+                'value' => $stringable,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => $stringable,
+                'expectedProcessedValidity' => false,
+            ];
+        }
+
+        //
+        // Objects
+        //
+        yield [
+            'type' => 'object',
+            'value' => $dateTime,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => $dateTime,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'object',
+            'value' => null,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'DateTime',
+            'value' => $dateTime,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => $dateTime,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'DateTime',
+            'value' => $arrayIterator,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $arrayIterator,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'DateTime',
+            'value' => 'test',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'test',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'DateTime',
+            'value' => null,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+
+        //
+        // Arrays and collections
+        //
+        yield [
+            'type' => 'array',
+            'value' => [],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => [],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'array',
+            'value' => [1, 2, 3],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => [1, 2, 3],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'array',
+            'value' => $arrayIterator,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => $arrayIterator,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'array',
+            'value' => 'test',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'test',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'array',
+            'value' => null,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string[]',
+            'value' => ['foo', 'bar'],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => ['foo', 'bar'],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string[]',
+            'value' => [1, 'foo', 3],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [1, 'foo', 3],
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string[]',
+            'value' => [$dateTime, 'foo'],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [$dateTime, 'foo'],
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'string[]',
+            'value' => [$stringable, 'foo'],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => [$stringable, 'foo'],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string[]',
+            'value' => null,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+        // @todo should we check all items?
+        yield [
+            'type' => 'string[]',
+            'value' => ['foo', 1, 2, 3],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => ['foo', 1, 2, 3],
+            'expectedProcessedValidity' => true,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('isValidAndProcessDataProvider')]
+    public function isValidAndProcess(string $type, mixed $value, bool $expectedValidity, mixed $expectedProcessedValue, bool $expectedProcessedValidity): void
+    {
+        $argumentProcessor = new StrictArgumentProcessor();
+        $definition = new ArgumentDefinition('test', $type, '', true);
+        $processedValue = $argumentProcessor->process($value, $definition);
+        self::assertSame($expectedValidity, $argumentProcessor->isValid($value, $definition));
+        self::assertSame($expectedProcessedValue, $processedValue);
+        self::assertSame($expectedProcessedValidity, $argumentProcessor->isValid($processedValue, $definition));
+    }
+
+    public static function optionalArgumentAllowsDefaultValueDataProvider(): array
+    {
+        return [
+            ['string', null],
+            ['object', null],
+            ['DateTime', null],
+            ['array', []],
+            ['int[]', ['string']],
+            ['array', 'my default'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('optionalArgumentAllowsDefaultValueDataProvider')]
+    public function optionalArgumentAllowsDefaultValue(string $type, mixed $defaultValue): void
+    {
+        $definition = new ArgumentDefinition('test', $type, '', false, $defaultValue);
+        self::assertTrue((new StrictArgumentProcessor())->isValid($defaultValue, $definition));
+    }
+}


### PR DESCRIPTION
The `StrictArgumentProcessor` is a stricter variant to the newly
introduced `LenientArgumentProcessor`. This patch only contributes
the implementation of the argument processor itself, without
actually using it in the code.

The plan is to use the new strict processor for upcoming new
features and to switch the existing ViewHelper implementation
to the stricter variant with Fluid v5. There probably will also be
an API to provide alternative implementations to Fluid in the
future once the `StrictArgumentProcessor` is used across
the whole code.