### PR TITLE
[TASK] Deprecate unused methods in ViewHelperResolver

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -6,6 +6,17 @@
 Changelog 4.x
 =============
 
+4.2
+---
+
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver::resolvePhpNamespaceFromFluidNamespace()`
+  now emits a E_USER_DEPRECATED level error.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver::isNamespaceValidOrIgnored()`
+  now emits a E_USER_DEPRECATED level error.
+* Deprecation: Constant :php:`TYPO3Fluid\Fluid\Core\Parser\Patterns::NAMESPACESUFFIX`
+  has been marked as deprecated and will be removed in Fluid v5.
+
+
 4.0
 ---
 

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -14,6 +14,9 @@ abstract class Patterns
 {
     public const NAMESPACEPREFIX = 'http://typo3.org/ns/';
     public const NAMESPACEPREFIX_INVALID = 'https://typo3.org/ns/';
+    /**
+     * @deprecated Will be removed in v5. Constant is not in use anymore.
+     */
     public const NAMESPACESUFFIX = '/ViewHelpers';
 
     /**

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -146,9 +146,11 @@ class ViewHelperResolver
      *
      * @param string $fluidNamespace
      * @return string
+     * @deprecated Will be removed in v5. Method is not in use anymore.
      */
     public function resolvePhpNamespaceFromFluidNamespace(string $fluidNamespace): string
     {
+        trigger_error('resolvePhpNamespaceFromFluidNamespace() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         $namespace = $fluidNamespace;
         $suffixLength = strlen(Patterns::NAMESPACESUFFIX);
         $phpNamespaceSuffix = str_replace('/', '\\', Patterns::NAMESPACESUFFIX);
@@ -208,9 +210,11 @@ class ViewHelperResolver
      *
      * @param string $namespaceIdentifier
      * @return bool true if the given namespace is valid
+     * @deprecated Will be removed in v5. Use combination of isNamespaceIgnored() and isNamespaceValid() instead.
      */
     public function isNamespaceValidOrIgnored(string $namespaceIdentifier): bool
     {
+        trigger_error('isNamespaceValidOrIgnored() has been deprecated and will be removed in Fluid v5.', E_USER_DEPRECATED);
         if ($this->isNamespaceValid($namespaceIdentifier) === true) {
             return true;
         }

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
@@ -137,6 +138,7 @@ final class ViewHelperResolverTest extends TestCase
 
     #[DataProvider('isNamespaceValidOrIgnoredReturnsExpectedValueDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function isNamespaceValidOrIgnoredReturnsExpectedValue(array $namespaces, string $namespace, bool $expected): void
     {
         $subject = new ViewHelperResolver();
@@ -191,6 +193,7 @@ final class ViewHelperResolverTest extends TestCase
 
     #[DataProvider('resolvePhpNamespaceFromFluidNamespaceDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function resolvePhpNamespaceFromFluidNamespace(string $input, string $expected): void
     {
         $subject = new ViewHelperResolver();


### PR DESCRIPTION
Both `resolvePhpNamespaceFromFluidNamespace()` and
`isNamespaceValidOrIgnored()` are deprecated to be removed with
Fluid 5. Also, since this was the only usage of the constant
`Patterns::NAMESPACESUFFIX`, it is depreacted as well.