### PR TITLE
[TASK] Mark internal parser classes as internal

### DIFF
--- a/src/Core/Compiler/FailedCompilingState.php
+++ b/src/Core/Compiler/FailedCompilingState.php
@@ -15,6 +15,8 @@ use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
  *
  * Replacement ParsingState used when a template fails to compile.
  * Includes additional reasons why compiling failed.
+ *
+ * @internal
  */
 class FailedCompilingState extends ParsingState implements ParsedTemplateInterface
 {

--- a/src/Core/Compiler/UncompilableTemplateInterface.php
+++ b/src/Core/Compiler/UncompilableTemplateInterface.php
@@ -20,5 +20,7 @@ namespace TYPO3Fluid\Fluid\Core\Compiler;
  *
  * The result is that the template parser will always parse the
  * original template.
+ *
+ * @internal This interface should be used for type-checks only.
  */
 interface UncompilableTemplateInterface {}

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -16,6 +16,8 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 /**
  * This interface is returned by \TYPO3Fluid\Fluid\Core\Parser\TemplateParser->parse()
  * method and is a parsed template
+ *
+ * @internal This interface should be used for type-checks only.
  */
 interface ParsedTemplateInterface
 {

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -19,6 +19,8 @@ use TYPO3Fluid\Fluid\View;
  * Stores all information relevant for one parsing pass - that is, the root node,
  * and the current stack of open nodes (nodeStack) and a variable container used
  * for PostParseFacets.
+ *
+ * @internal
  */
 class ParsingState implements ParsedTemplateInterface
 {


### PR DESCRIPTION
The most relevant class `AbstractCompiledTemplate` is already
internal, so are both the `TemplateParser` and the `TemplateCompiler`,
so it makes sense to apply this to related classes/interfaces as well.