### PR TITLE
[TASK] Make namespace inheritance tests more consistent

### DIFF
--- a/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
+++ b/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
@@ -20,38 +20,131 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     public static function namespacesAreInheritedToLayoutAndPartialsDataProvider(): array
     {
         return [
-            'namespace provided via php api' => [
-                '<f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+            'namespace provided via php api, call viewhelper from layout' => [
+                '<f:layout name="NamespaceInheritance/CallViewHelper" />',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
                 [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
             ],
-            // @todo this should probably not work
-            'namespace provided to layout and partials via inline namespace declaration in template' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+            'namespace provided via php api, call section from layout' => [
+                '<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Template" />',
+            ],
+            'namespace provided via php api, call partial from layout' => [
+                '<f:layout name="NamespaceInheritance/CallPartial" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+            'namespace provided via php api, call section with partial from layout' => [
+                '<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+
+            // @todo the following cases should probably not work
+            'namespace provided via inline namespace declaration in template, call viewhelper from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallViewHelper" />',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
                 [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
             ],
-            // @todo this should probably not work
-            'namespace provided to layout and partials via xml namespace declaration in template' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:cache.disable /><f:layout name="NamespaceInheritanceLayout" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+            'namespace provided via inline namespace declaration in template, call section from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
                 [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Template" />',
             ],
-            // // @todo this should probably not work
-            'namespace inherited from template to dynamic layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers"><f:cache.disable /><f:layout name="{myLayout}" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+            'namespace provided via inline namespace declaration in template, call partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallPartial" />',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                ['myLayout' => 'NamespaceInheritanceLayout'],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+            'namespace provided via inline namespace declaration in template, call section with partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+
+            // @todo the following cases should probably not work
+            'namespace provided via xml namespace declaration in template, call viewhelper from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallViewHelper" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
+            ],
+            'namespace provided via xml namespace declaration in template, call section from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Template" />',
+            ],
+            'namespace provided via xml namespace declaration in template, call partial from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallPartial" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+            'namespace provided via xml namespace declaration in template, call section with partial from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+
+            // @todo the following cases should probably not work
+            'dynamic layout name in template, call viewhelper from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallViewHelper'],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
+            ],
+            'dynamic layout name in template, call section from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallSection'],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Template" />',
+            ],
+            'dynamic layout name in template, call partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallPartial'],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ],
+            'dynamic layout name in template, call section with partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallSection'],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
             ],
         ];
     }
 
     #[Test]
     #[DataProvider('namespacesAreInheritedToLayoutAndPartialsDataProvider')]
-    public function namespacesAreInheritedToLayoutAndPartials(string $source, array $initialNamespaces, array $variables): void
+    public function namespacesAreInheritedToLayoutAndPartials(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
     {
-        $expectedResult = "\n" . '<div location="Layout" />' . "\n\n" . '<div location="Template" />' . "\n\n\n\n" . '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />' . "\n\n";
-
         // Uncached
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
@@ -60,11 +153,22 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
         $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
         $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
-        self::assertSame($expectedResult, $view->render());
+        // self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'uncached');
+        self::assertSame($expectedResult, trim($view->render()), 'uncached');
 
-        // @todo Cached state is currently not relevant here, since caching needs to be disabled for all affected templates to get robust testing results
+        // Cached
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->setNamespaces($initialNamespaces);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        // self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'cached');
+        // @todo Rendering result might still be inconsistent here.
         //       With enabled caching, there is interference between the test cases because the "in-memory" cache of TemplateCompiler is re-used and thus
         //       test cases might be green even if they should actually be red. See https://github.com/TYPO3/Fluid/issues/975
+        self::assertSame($expectedResult, trim($view->render()), 'cached');
     }
 
     public static function namespaceDefinedInParentNotValidInChildrenDataProvider(): array
@@ -121,5 +225,25 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
         $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
         $view->render();
+    }
+
+    #[Test]
+    public function namespaceDefinedDuringCompilationNotRendering(): void
+    {
+        $source = '<f:format.case value="test" mode="upper" />';
+        $expected = 'TEST';
+
+        // Uncached with f namespace
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render(), 'uncached');
+
+        // Cached without f namespace
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->setNamespaces([]);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render(), 'cached');
     }
 }

--- a/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
+++ b/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
@@ -153,8 +153,8 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
         $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
         $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
-        // self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'uncached');
         self::assertSame($expectedResult, trim($view->render()), 'uncached');
+        self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'uncached');
 
         // Cached
         $view = new TemplateView();
@@ -164,11 +164,11 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
         $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
         $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
-        // self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'cached');
         // @todo Rendering result might still be inconsistent here.
         //       With enabled caching, there is interference between the test cases because the "in-memory" cache of TemplateCompiler is re-used and thus
         //       test cases might be green even if they should actually be red. See https://github.com/TYPO3/Fluid/issues/975
         self::assertSame($expectedResult, trim($view->render()), 'cached');
+        self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'cached');
     }
 
     public static function namespaceDefinedInParentNotValidInChildrenDataProvider(): array

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallPartial.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallPartial.html
@@ -1,0 +1,1 @@
+<f:render partial="NamespaceInheritancePartial" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallSection.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallSection.html
@@ -1,0 +1,1 @@
+<f:render section="Main" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallViewHelper.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallViewHelper.html
@@ -1,0 +1,1 @@
+<test:tagBasedTest location="Layout" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/DefineNamespaceCallPartial.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/DefineNamespaceCallPartial.html
@@ -1,0 +1,2 @@
+{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}
+<f:render partial="NamespaceInheritancePartial" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/DefineNamespaceCallSection.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/DefineNamespaceCallSection.html
@@ -1,6 +1,2 @@
 {namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}
-<test:tagBasedTest location="Layout" />
-
 <f:render section="Main" />
-
-<f:render partial="NamespaceInheritancePartial" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritanceLayout.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritanceLayout.html
@@ -1,6 +1,0 @@
-<f:cache.disable />
-<test:tagBasedTest location="Layout" />
-
-<f:render section="Main" />
-
-<f:render partial="NamespaceInheritancePartial" />


### PR DESCRIPTION
This expands our test cases for the more obscure feature
of namespace inheritance, which is due to be deprecated
and removed. It allowed partials to access ViewHelpers
by "reusing" the import from their parent template.

The tests now cover more use cases and should also be
more reliable with cached templates.