### PR TITLE
[TASK] Deprecate ViewHelper namespace inheritance

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -22,6 +22,11 @@ Changelog 4.x
 * Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::postParseEvent()`
   now emits a E_USER_DEPRECATED level error. It will be removed with Fluid v5. ViewHelpers using this event
   should switch to the new :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface`
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver::addNamespaces()`
+  now emits a E_USER_DEPRECATED level error.
+* Deprecation: Inheritance of ViewHelper namespaces is deprecated. If a ViewHelper namespace is used in a
+  template that is neither defined globally nor locally directly in the template, Fluid now emits a
+  E_USER_DEPRECATED level error.
 
 4.0
 ---

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -185,7 +185,7 @@ class TemplateCompiler
             '        return %s;' . chr(10) .
             '    }' . chr(10) .
             '    public function addCompiledNamespaces(\TYPO3Fluid\\Fluid\\Core\\Rendering\\RenderingContextInterface $renderingContext): void {' . chr(10) .
-            '        $renderingContext->getViewHelperResolver()->addNamespaces(%s);' . chr(10) .
+            '        $renderingContext->getViewHelperResolver()->setLocalNamespaces(%s);' . chr(10) .
             '    }' . chr(10) .
             '    %s' . chr(10) .
             '    %s' . chr(10) .
@@ -193,7 +193,7 @@ class TemplateCompiler
             'class ' . $identifier . ' extends \TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate',
             $this->generateCodeForLayoutName($storedLayoutName),
             ($parsingState->hasLayout() ? 'true' : 'false'),
-            var_export($this->renderingContext->getViewHelperResolver()->getNamespaces(), true),
+            var_export($this->renderingContext->getViewHelperResolver()->getLocalNamespaces(), true),
             $this->generateArgumentDefinitionsCodeFromParsingState($parsingState),
             $generatedRenderFunctions,
         );

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -21,6 +21,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InheritedNamespaceException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperNodeInitializedEventInterface;
 
@@ -287,8 +288,12 @@ class TemplateParser
         if ($viewHelperResolver->isNamespaceIgnored($namespaceIdentifier)) {
             return null;
         }
-        if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
-            throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+        try {
+            if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
+                throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+            }
+        } catch (InheritedNamespaceException) {
+            // @todo remove with Fluid 5
         }
 
         $viewHelper = $viewHelperResolver->createViewHelperInstance($namespaceIdentifier, $methodIdentifier);
@@ -326,8 +331,18 @@ class TemplateParser
         if ($viewHelperResolver->isNamespaceIgnored($namespaceIdentifier)) {
             return null;
         }
-        if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
-            throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+        try {
+            if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
+                throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+            }
+        } catch (InheritedNamespaceException) {
+            // @todo remove with Fluid 5
+            trigger_error(sprintf(
+                'ViewHelper call <%1$s:%2$s> in "%3$s" only works because "%1$s" namespace was added in parent template. This will break with Fluid v5.',
+                $namespaceIdentifier,
+                $methodIdentifier,
+                $state->getIdentifier(),
+            ), E_USER_DEPRECATED);
         }
         try {
             $currentViewHelperNode = new ViewHelperNode(
@@ -379,8 +394,12 @@ class TemplateParser
         if ($viewHelperResolver->isNamespaceIgnored($namespaceIdentifier)) {
             return false;
         }
-        if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
-            throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+        try {
+            if (!$viewHelperResolver->isNamespaceValid($namespaceIdentifier)) {
+                throw new UnknownNamespaceException('Unknown Namespace: ' . $namespaceIdentifier);
+            }
+        } catch (InheritedNamespaceException) {
+            // @todo remove with Fluid 5
         }
         $lastStackElement = $state->popNodeFromStack();
         if (!($lastStackElement instanceof ViewHelperNode)) {
@@ -430,8 +449,12 @@ class TemplateParser
             // which is invalid will be reported as an error regardless of whether the namespace is marked as ignored.
             $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
             foreach (array_reverse($matches) as $singleMatch) {
-                if (!$viewHelperResolver->isNamespaceValid($singleMatch['NamespaceIdentifier'])) {
-                    throw new UnknownNamespaceException('Unknown Namespace: ' . $singleMatch['NamespaceIdentifier']);
+                try {
+                    if (!$viewHelperResolver->isNamespaceValid($singleMatch['NamespaceIdentifier'])) {
+                        throw new UnknownNamespaceException('Unknown Namespace: ' . $singleMatch['NamespaceIdentifier']);
+                    }
+                } catch (InheritedNamespaceException) {
+                    // @todo remove with Fluid 5
                 }
                 $viewHelper = $viewHelperResolver->createViewHelperInstance($singleMatch['NamespaceIdentifier'], $singleMatch['MethodIdentifier']);
                 if (strlen($singleMatch['ViewHelperArguments']) > 0) {

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -101,7 +101,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
                 } else {
                     $namespacePhp = null;
                 }
-                $viewHelperResolver->addNamespace($set[1], $namespacePhp);
+                $viewHelperResolver->addLocalNamespace($set[1], $namespacePhp);
             }
             if (strpos($matches[0], 'data-namespace-typo3-fluid="true"')) {
                 $templateSource = str_replace($matches[0], '', $templateSource);
@@ -133,7 +133,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
                 if (strlen($namespace) === 0) {
                     $namespace = null;
                 }
-                $viewHelperResolver->addNamespace($identifier, $namespace);
+                $viewHelperResolver->addLocalNamespace($identifier, $namespace);
             }
             foreach ($namespaces[0] as $removal) {
                 $templateSource = str_replace($removal, '', $templateSource);

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -420,4 +420,15 @@ class RenderingContext implements RenderingContextInterface
     {
         $this->controllerAction = $action;
     }
+
+    public function __clone(): void
+    {
+        // Clone all properties that have references to rendering context
+        $this->setTemplateCompiler(clone $this->getTemplateCompiler());
+        $this->setTemplateParser(clone $this->getTemplateParser());
+        $this->setTemplateProcessors(array_map(
+            static fn(TemplateProcessorInterface $processor): TemplateProcessorInterface => clone $processor,
+            $this->getTemplateProcessors(),
+        ));
+    }
 }

--- a/src/Core/ViewHelper/InheritedNamespaceException.php
+++ b/src/Core/ViewHelper/InheritedNamespaceException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @internal
+ * @deprecated will be removed with Fluid v5
+ */
+class InheritedNamespaceException extends Exception {}

--- a/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
+++ b/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Rendering;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
@@ -17,7 +18,150 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
 {
-    public static function namespacesAreInheritedToLayoutAndPartialsDataProvider(): array
+    public static function namespacesAreInheritedToLayoutAndPartialsDataProvider(): iterable
+    {
+        // @todo the following cases are deprecated and will be removed with Fluid v5
+        foreach ([false, true] as $inlineSyntax) {
+            $casePrefix = $inlineSyntax ? 'Inline Syntax' : 'Tag Syntax';
+            $templateNameSuffix = $inlineSyntax ? 'InlineSyntax' : '';
+            yield $casePrefix . ': namespace provided via inline namespace declaration in template, call viewhelper from partial' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:render partial="NamespaceInheritancePartial' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+            yield $casePrefix . ': namespace provided via inline namespace declaration in template, call viewhelper from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallViewHelper' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
+            ];
+            yield $casePrefix . ': namespace provided via inline namespace declaration in template, call partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallPartial' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+            yield $casePrefix . ': namespace provided via inline namespace declaration in template, call section with partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial' . $templateNameSuffix . '" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+
+            yield $casePrefix . ': namespace provided via xml namespace declaration in template, call viewhelper from partial' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:render partial="NamespaceInheritancePartial' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+            yield $casePrefix . ': namespace provided via xml namespace declaration in template, call viewhelper from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallViewHelper' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
+            ];
+            yield $casePrefix . ': namespace provided via xml namespace declaration in template, call partial from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallPartial' . $templateNameSuffix . '" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+            yield $casePrefix . ': namespace provided via xml namespace declaration in template, call section with partial from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial' . $templateNameSuffix . '" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                [],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+
+            yield $casePrefix . ': dynamic layout name in template, call viewhelper from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallViewHelper' . $templateNameSuffix],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="Layout" />',
+            ];
+            yield $casePrefix . ': dynamic layout name in template, call partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallPartial' . $templateNameSuffix],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+            yield $casePrefix . ': dynamic layout name in template, call section with partial from layout' => [
+                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial' . $templateNameSuffix . '" /></f:section>',
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
+                ['myLayout' => 'NamespaceInheritance/CallSection'],
+                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
+                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
+            ];
+        }
+    }
+
+    #[Test]
+    #[DataProvider('namespacesAreInheritedToLayoutAndPartialsDataProvider')]
+    #[IgnoreDeprecations]
+    public function namespacesAreInheritedToLayoutAndPartialsUncached(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
+    {
+        // We need to make sure that all test cases actually trigger the deprecation for uncached templates
+        // @todo switch to exception check with Fluid v5
+        // self::expectException(UnknownNamespaceException::class);
+        self::expectUserDeprecationMessageMatches('#^ViewHelper call <test:tagBasedTest> in ".+" only works because "test" namespace was added in parent template. This will break with Fluid v5.$#');
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->setNamespaces($initialNamespaces);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        self::assertSame($expectedResult, trim($view->render()));
+        self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces());
+    }
+
+    #[Test]
+    #[DataProvider('namespacesAreInheritedToLayoutAndPartialsDataProvider')]
+    #[IgnoreDeprecations]
+    public function namespacesAreInheritedToLayoutAndPartialsCached(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
+    {
+        // Cached templates don't need to trigger deprecations
+        // @todo activate exception check with Fluid v5
+        // self::expectException(UnknownNamespaceException::class);
+
+        // Uncached
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->setNamespaces($initialNamespaces);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        $view->render();
+
+        // Cached
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->setNamespaces($initialNamespaces);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        // @todo Rendering result might still be inconsistent here.
+        //       With enabled caching, there is interference between the test cases because the "in-memory" cache of TemplateCompiler is re-used and thus
+        //       test cases might be green even if they should actually be red. See https://github.com/TYPO3/Fluid/issues/975
+        self::assertSame($expectedResult, trim($view->render()));
+        self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces());
+    }
+
+    public static function templatesCanUseNamespacesTheyDefinedDataProvider(): array
     {
         return [
             'namespace provided via php api, call viewhelper from layout' => [
@@ -49,13 +193,12 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
                 '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
             ],
 
-            // @todo the following cases should probably not work
-            'namespace provided via inline namespace declaration in template, call viewhelper from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallViewHelper" />',
+            'namespace provided via xml namespace declaration in template, call section from layout' => [
+                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
                 [],
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="Layout" />',
+                '<div location="Template" />',
             ],
             'namespace provided via inline namespace declaration in template, call section from layout' => [
                 '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
@@ -64,59 +207,6 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
                 '<div location="Template" />',
             ],
-            'namespace provided via inline namespace declaration in template, call partial from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallPartial" />',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
-            'namespace provided via inline namespace declaration in template, call section with partial from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
-
-            // @todo the following cases should probably not work
-            'namespace provided via xml namespace declaration in template, call viewhelper from layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallViewHelper" />',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="Layout" />',
-            ],
-            'namespace provided via xml namespace declaration in template, call section from layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="Template" />',
-            ],
-            'namespace provided via xml namespace declaration in template, call partial from layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallPartial" />',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
-            'namespace provided via xml namespace declaration in template, call section with partial from layout' => [
-                '<html xmlns:test="http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ViewHelpers" data-namespace-typo3-fluid="true"><f:layout name="NamespaceInheritance/CallSection" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                [],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
-
-            // @todo the following cases should probably not work
-            'dynamic layout name in template, call viewhelper from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                ['myLayout' => 'NamespaceInheritance/CallViewHelper'],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="Layout" />',
-            ],
             'dynamic layout name in template, call section from layout' => [
                 '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" /><f:section name="Main"><test:tagBasedTest location="Template" /></f:section>',
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
@@ -124,26 +214,12 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
                 ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
                 '<div location="Template" />',
             ],
-            'dynamic layout name in template, call partial from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" />',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                ['myLayout' => 'NamespaceInheritance/CallPartial'],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
-            'dynamic layout name in template, call section with partial from layout' => [
-                '{namespace test=TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers}<f:layout name="{myLayout}" /><f:section name="Main"><f:render partial="NamespaceInheritancePartial" /></f:section>',
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers']],
-                ['myLayout' => 'NamespaceInheritance/CallSection'],
-                ['f' => ['TYPO3Fluid\Fluid\ViewHelpers'], 'test' => ['TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers']],
-                '<div location="NestedPartial" />' . "\n\n" . '<div location="Partial" />',
-            ],
         ];
     }
 
     #[Test]
-    #[DataProvider('namespacesAreInheritedToLayoutAndPartialsDataProvider')]
-    public function namespacesAreInheritedToLayoutAndPartials(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
+    #[DataProvider('templatesCanUseNamespacesTheyDefinedDataProvider')]
+    public function templatesCanUseNamespacesTheyDefined(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
     {
         // Uncached
         $view = new TemplateView();
@@ -156,7 +232,7 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         self::assertSame($expectedResult, trim($view->render()), 'uncached');
         self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'uncached');
 
-        // Cached
+        // // Cached
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getViewHelperResolver()->setNamespaces($initialNamespaces);
@@ -171,7 +247,7 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
         self::assertSame($expectedNamespaces, $view->getRenderingContext()->getViewHelperResolver()->getNamespaces(), 'cached');
     }
 
-    public static function namespaceDefinedInParentNotValidInChildrenDataProvider(): array
+    public static function namespaceDefinedInLayoutNotValidInTemplateDataProvider(): array
     {
         return [
             'namespace provided via namespace declaration in layout' => [
@@ -186,8 +262,8 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    #[DataProvider('namespaceDefinedInParentNotValidInChildrenDataProvider')]
-    public function namespaceDefinedInParentNotValidInChildren(string $source, array $variables): void
+    #[DataProvider('namespaceDefinedInLayoutNotValidInTemplateDataProvider')]
+    public function namespaceDefinedInLayoutNotValidInTemplate(string $source, array $variables): void
     {
         self::expectException(UnknownNamespaceException::class);
         $view = new TemplateView();
@@ -200,8 +276,8 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    #[DataProvider('namespaceDefinedInParentNotValidInChildrenDataProvider')]
-    public function namespaceDefinedInParentNotValidInChildrenInCachedTemplates(string $source, array $variables): void
+    #[DataProvider('namespaceDefinedInLayoutNotValidInTemplateDataProvider')]
+    public function namespaceDefinedInLayoutNotValidInCachedTemplates(string $source, array $variables): void
     {
         self::expectException(UnknownNamespaceException::class);
 
@@ -228,7 +304,7 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function namespaceDefinedDuringCompilationNotRendering(): void
+    public function namespaceDefinedDuringCompilationAreValidDuringRendering(): void
     {
         $source = '<f:format.case value="test" mode="upper" />';
         $expected = 'TEST';

--- a/tests/Functional/Core/ViewHelper/ViewHelperEscapingTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperEscapingTest.php
@@ -40,7 +40,7 @@ final class ViewHelperEscapingTest extends AbstractFunctionalTestCase
         $configuration->addEscapingInterceptor(new Escape());
 
         $context = $this->getMockBuilder(RenderingContext::class)->onlyMethods(['buildParserConfiguration'])->getMock();
-        $context->expects(self::once())->method('buildParserConfiguration')->willReturn($configuration);
+        $context->expects(self::atLeastOnce())->method('buildParserConfiguration')->willReturn($configuration);
         $context->getTemplateParser()->setRenderingContext($context);
         $context->getTemplateCompiler()->setRenderingContext($context);
         $context->setVariableProvider(new StandardVariableProvider());

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallPartialInlineSyntax.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallPartialInlineSyntax.html
@@ -1,0 +1,1 @@
+<f:render partial="NamespaceInheritancePartialInlineSyntax" />

--- a/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallViewHelperInlineSyntax.html
+++ b/tests/Functional/Fixtures/Layouts/NamespaceInheritance/CallViewHelperInlineSyntax.html
@@ -1,0 +1,1 @@
+{test:tagBasedTest(location: 'Layout')}

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartial.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartial.html
@@ -1,2 +1,1 @@
-<f:cache.disable />
 <test:tagBasedTest location="NestedPartial" />

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartialInlineSyntax.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritanceNestedPartialInlineSyntax.html
@@ -1,0 +1,1 @@
+{test:tagBasedTest(location: 'NestedPartial')}

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritancePartial.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritancePartial.html
@@ -1,3 +1,2 @@
-<f:cache.disable />
 <f:render partial="NamespaceInheritanceNestedPartial" />
 <test:tagBasedTest location="Partial" />

--- a/tests/Functional/Fixtures/Partials/NamespaceInheritancePartialInlineSyntax.html
+++ b/tests/Functional/Fixtures/Partials/NamespaceInheritancePartialInlineSyntax.html
@@ -1,0 +1,2 @@
+<f:render partial="NamespaceInheritanceNestedPartialInlineSyntax" />
+{test:tagBasedTest(location: 'Partial')}

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -140,6 +140,7 @@ final class AbstractTemplateViewTest extends TestCase
         $renderingContext = $this->createMock(RenderingContextInterface::class);
         $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
         $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
+        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(false);
         $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
@@ -158,6 +159,7 @@ final class AbstractTemplateViewTest extends TestCase
         $renderingContext = $this->createMock(RenderingContextInterface::class);
         $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
         $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
+        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(true);
         $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
@@ -174,6 +176,7 @@ final class AbstractTemplateViewTest extends TestCase
         $renderingContext = $this->createMock(RenderingContextInterface::class);
         $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
         $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
+        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(true);
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();


### PR DESCRIPTION
Fluid v5 will no longer support inheritance of ViewHelper namespaces
from a template to its layout or partials. Namespace must either be
added globally (by using the public `ViewHelperResolver` API) or
by using the `{namespace x=…}` or `xmlns:x="…"` syntax in the
template file that uses the ViewHelper.

This patch prepares the removal of this feature by implementing
separate namespace collections for global, local and inherited
ViewHelper namespaces. Depending on the context, ViewHelpers
will be added to the appropriate collection. When a ViewHelper
is called, the different collections will be checked for a matching
namespace. Also, contexts get their own `ViewHelperResolver`
instances to isolate them properly.

If a namespace is only defined in a parent template, but not in
the template itself or in the global collection, a deprecation
will be emitted, which allows to prepare existing templates
before switching to Fluid v5 later on. To resolve a deprecation,
all ViewHelper namespaces that are used within a template
need to be either defined globally (like f:*) or directly in the
template file.

With Fluid v5, the backwards compatibility layer for inherited
namespaces will be removed, which will be a breaking change.
This change is a hard requirement for a more reasonable
cache warmup feature for Fluid templates.

Resolves: #985