### PR TITLE
[FEATURE] Introduce ViewHelperResolver delegates

### DIFF
--- a/src/Core/ViewHelper/UnresolvableViewHelperException.php
+++ b/src/Core/ViewHelper/UnresolvableViewHelperException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * Exception to be thrown if a ViewHelperResolverDelegate
+ * is unable to resolve the given ViewHelper name to the
+ * matching ViewHelper implementation
+ *
+ * @api
+ */
+class UnresolvableViewHelperException extends Exception {}

--- a/src/Core/ViewHelper/ViewHelperCollection.php
+++ b/src/Core/ViewHelper/ViewHelperCollection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * Default ViewHelper resolving implementation that is used if
+ * a PHP namespace prefix is given that doesn't have a custom
+ * ViewHelperResolverDelegate implementation.
+ */
+final readonly class ViewHelperCollection implements ViewHelperResolverDelegateInterface
+{
+    private string $namespace;
+
+    public function __construct(string $namespace)
+    {
+        $this->namespace = rtrim($namespace, '\\');
+    }
+
+    public function resolveViewHelperClassName(string $name): string
+    {
+        $explodedViewHelperName = explode('.', $name);
+        $className = implode('\\', array_map('ucfirst', $explodedViewHelperName));
+        $fullClassName = $this->namespace . '\\' . $className . 'ViewHelper';
+        if (!class_exists($fullClassName)) {
+            throw new UnresolvableViewHelperException(sprintf(
+                'Based on your spelling, the system would load the class "%s", however this class does not exist.',
+                $fullClassName,
+            ), 1746975989);
+        }
+        return $fullClassName;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+}

--- a/src/Core/ViewHelper/ViewHelperResolverDelegateInterface.php
+++ b/src/Core/ViewHelper/ViewHelperResolverDelegateInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * The ViewHelperResolverDelegateInterface can be used to provide custom
+ * ViewHelper resolving to a specific ViewHelper namespace. If a ViewHelper
+ * namespace is registered, Fluid first checks if the provided class string
+ * represents an actual PHP class (which must then implement this interface)
+ * or if it's just a partial PHP namespace that refers to multiple ViewHelper
+ * files. The latter will be handled by the fallback implementation
+ * TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperCollection.
+ *
+ * @api
+ */
+interface ViewHelperResolverDelegateInterface
+{
+    /**
+     * Resolves the appropriate ViewHelper PHP class for the given
+     * ViewHelper name, throws exception if no class can be resolved.
+     *
+     * @throws UnresolvableViewHelperException
+     * @param string $name   ViewHelper name as written in the template,
+     *                       e. g. "format.trim"
+     * @return class-string  ViewHelper class as full PHP namespace
+     */
+    public function resolveViewHelperClassName(string $name): string;
+
+    /**
+     * Returns the PHP namespace this delegate has been registered for
+     * This string representation will be used to restore the delegate
+     * object from the cache in the future.
+     *
+     * @return class-string
+     */
+    public function getNamespace(): string;
+}

--- a/tests/Functional/Core/ViewHelper/ViewHelperResolverDelegateTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperResolverDelegateTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\Parser\Exception as ParserException;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class ViewHelperResolverDelegateTest extends AbstractFunctionalTestCase
+{
+    public static function renderViewHelpersFromDelegateDataProvider(): array
+    {
+        return [
+            'Rendering ViewHelpers from ViewHelperResolver delegate' => [
+                '{namespace my=TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\TestViewHelperResolverDelegate}<my:render /> <my:render.sub />',
+                'Render Render_Sub',
+            ],
+        ];
+    }
+
+    #[DataProvider('renderViewHelpersFromDelegateDataProvider')]
+    #[Test]
+    public function renderViewHelpersFromDelegate(string $source, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render());
+
+        // Second run to verify cached behavior.
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expected, $view->render());
+    }
+
+    #[DataProvider('renderViewHelpersFromDelegateDataProvider')]
+    #[Test]
+    public function invalidViewHelpersFromDelegateThrowsException(): void
+    {
+        self::expectException(ParserException::class);
+        self::expectExceptionCode(1407060572);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource(
+            '{namespace my=TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\TestViewHelperResolverDelegate}<my:invalid />',
+        );
+        $view->render();
+    }
+}

--- a/tests/Functional/Fixtures/Various/TestViewHelperResolverDelegate.php
+++ b/tests/Functional/Fixtures/Various/TestViewHelperResolverDelegate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\UnresolvableViewHelperException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
+
+final class TestViewHelperResolverDelegate implements ViewHelperResolverDelegateInterface
+{
+    public function resolveViewHelperClassName(string $name): string
+    {
+        // ViewHelpers in different location, without "ViewHelper" suffix and with _ as directory separator
+        $name = implode('_', array_map(ucfirst(...), explode('.', $name)));
+        $className = 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers\\TestViewHelperResolverDelegate\\' . $name;
+        if (!class_exists($className)) {
+            throw new UnresolvableViewHelperException('Class ' . $className . ' does not exist.', 1747931176);
+        }
+        return $className;
+    }
+
+    public function getNamespace(): string
+    {
+        return self::class;
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolverDelegate/Render.php
+++ b/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolverDelegate/Render.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TestViewHelperResolverDelegate;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class Render extends AbstractViewHelper
+{
+    protected $escapeOutput = false;
+
+    public function render(): string
+    {
+        return 'Render';
+    }
+}

--- a/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolverDelegate/Render_Sub.php
+++ b/tests/Functional/Fixtures/ViewHelpers/TestViewHelperResolverDelegate/Render_Sub.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers\TestViewHelperResolverDelegate;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class Render_Sub extends AbstractViewHelper
+{
+    protected $escapeOutput = false;
+
+    public function render(): string
+    {
+        return 'Render_Sub';
+    }
+}


### PR DESCRIPTION
It has always been possible to set a custom `ViewHelperResolver` for
Fluid in the rendering context. One major use case was (and still is)
to use a custom ViewHelper factory or dependency injection. However,
because there can only be one `ViewHelperResolver`, it becomes quite
hard to extend/adjust Fluid's ViewHelper resolving (= which class should
handle which ViewHelper call in a template) to special needs.

With the introduction of ViewHelperResolver delegates, the main
ViewHelperResolver can delegate the actual resolving within a
namespace to a custom implementation. This means that the logic
behind `<f:format.trim>` and `<my:custom>` can now be
different: Class names can have a different structure, and it's no longer
strictly necessary to have one ViewHelper class per ViewHelper. The
reasoning behind this new API is the ongoing work on the "reusable
components" feature, but this might also offer other opportunities
in the future, like bridges to other templating engines or more dynamic
ViewHelper resolving by third-party packages.

This patch introduces a new `ViewHelperResolverDelegateInterface`,
which needs to be implemented by custom delegates. The current
resolving logic is moved from `ViewHelperResolver` to a new
`ViewHelperCollection` class, which implements the new interface.

The `ViewHelperResolver` is now responsible for creating and
managing these delegate instances and to find the appropriate
delegate for a specified PHP namespace. Delegates implement
the interface method `resolveViewHelperClassName()`, which
either returns the PHP class name for the supplied ViewHelper
name or throws `UnresolvableViewHelperException` if the
delegate can't find an appropriate ViewHelper class. If no resolver
is able to find a class name, the `ViewHelperResolver` throws
the same exception as before this change.

The delegate for a namespace is determined by first checking
for the existence of the PHP class name the Fluid namespace refers
to. Only if no class exists, the previous logic applies.

Example:

```xml
{namespace a=Vendor\PackageA\ViewHelpers}
{namespace b=Vendor\PackageB\ViewHelperCollection}

<a:custom />
<b:custom />
```

```php
<?php

namespace Vendor\PackageB;

use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;

final readonly class ViewHelperCollection implements ViewHelperResolverDelegateInterface
{
    public function resolveViewHelperClassName(string $name): string
    {
        // custom resolver logic
    }

    public function getNamespace(): string
    {
        // string representation of the delegate, usually its
        // fully qualified name
        return self::class;
    }
}
```

Namespace `a` would follow the same default rules as before: The
ViewHelper `<a:custom>` would resolve to
`Vendor\PackageA\ViewHelpers\CustomViewHelper`.

Namespace `b` however would follow the custom rules implemented
in the delegate: `Vendor\PackageB\ViewHelperCollection` would be
instantiated by `ViewHelperResolver` and
`resolveViewHelperClassName('custom')` would be called, which
either would return a PHP class name or would throw the exception
as described above.

The patch also makes sure that already instantiated delegates can
be passed directly to the `ViewHelperResolver`.