### PR TITLE
[TASK] Deprecate childNodes property for ViewHelpers

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -6,6 +6,17 @@
 Changelog 4.x
 =============
 
+4.3
+---
+
+* Deprecation: Property :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::$childNodes`
+  has been marked as deprecated and will be removed in Fluid v5. Use `$viewHelperNode->getChildNodes()`
+  instead.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::setChildNodes()`
+  has been marked as deprecated and will be removed in Fluid v5.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface::setChildNodes()`
+  has been marked as deprecated and will be removed in Fluid v5.
+
 4.2
 ---
 

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -93,18 +93,12 @@ class ViewHelperNode extends AbstractNode
     public function addChildNode(NodeInterface $childNode): void
     {
         parent::addChildNode($childNode);
+        /** @todo remove with Fluid v5 */
         $this->uninitializedViewHelper->setChildNodes($this->childNodes);
     }
 
     /**
      * Call the view helper associated with this object.
-     *
-     * First, it evaluates the arguments of the view helper.
-     *
-     * If the view helper implements \TYPO3Fluid\Fluid\Core\ViewHelper\ChildNodeAccessInterface,
-     * it calls setChildNodes(array childNodes) on the view helper.
-     *
-     * Afterward, checks that the view helper did not leave a variable lying around.
      *
      * @param RenderingContextInterface $renderingContext
      * @return mixed evaluated node after the view helper has been called. This can be of any type,

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -53,6 +53,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     /**
      * @var NodeInterface[] array
      * @api
+     * @deprecated will be removed with Fluid v5. Use $viewHelperNode->getChildNodes() instead
      */
     protected $childNodes = [];
 
@@ -232,6 +233,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * framework. Populates $this->viewHelperNode.
      * @param NodeInterface[] $childNodes
      * @internal
+     * @deprecated will be removed with Fluid v5. Use $viewHelperNode->getChildNodes() instead
      */
     public function setChildNodes(array $childNodes)
     {

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -42,6 +42,7 @@ interface ViewHelperInterface
 
     /**
      * @param NodeInterface[] $nodes
+     * @deprecated will be removed with Fluid v5
      */
     public function setChildNodes(array $nodes);
 


### PR DESCRIPTION
Currently, the raw parser nodes are provided twice to each
ViewHelper instance: Once with `setViewHelperNode()` and
once with `setChildNodes()`. The latter is now deprecated,
together with the property `$childNodes`, since it can easily
be subsituted like this within a ViewHelper:

before:

```php
$this->childNodes
```

after:

```php
$this->viewHelperNode->getChildNodes()
```