### PR TITLE
[TASK] Improve ViewHelperNode creation in parser

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: src/Core/Parser/TemplateParser.php
 
 		-
+			message: '#^Call to an undefined method TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface\:\:getArguments\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Core/Parser/TemplateParser.php
+
+		-
 			message: '#^Call to an undefined method TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface\:\:getUninitializedViewHelper\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -41,7 +41,7 @@ class ViewHelperNode extends AbstractNode
      * @param string $identifier the name of the ViewHelper to render, inside the namespace provided.
      * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
      */
-    public function __construct(RenderingContextInterface $renderingContext, string $namespace, string $identifier, array $arguments)
+    public function __construct(RenderingContextInterface $renderingContext, string $namespace, string $identifier, array $arguments = [])
     {
         $resolver = $renderingContext->getViewHelperResolver();
         $this->arguments = $arguments;
@@ -78,6 +78,15 @@ class ViewHelperNode extends AbstractNode
     public function getViewHelperClassName(): string
     {
         return $this->viewHelperClassName;
+    }
+
+    /**
+     * @internal only for parser
+     * @param NodeInterface[] $arguments Arguments of view helper - each value is a RootNode.
+     */
+    public function setArguments(array $arguments): void
+    {
+        $this->arguments = $arguments;
     }
 
     /**


### PR DESCRIPTION
The main responsibility of the Fluid parser is to create a tree of
`NodeInterface` instances from a template string. However, it
also performs another task: It pre-validates the supplied
arguments to ViewHelpers. If a certain argument is required,
but not supplied in the template, processing of that template
already fails in the parsing step. Also, if arguments are supplied
to a ViewHelper which have not been registered, the
`validateAdditionalArguments()` method of the ViewHelper is
called in the parsing step. It is also possible to modify the
escaping behavior for each ViewHelper, which is applied
by the parser as well.

In order to achieve that, the ViewHelper instance needs to be
created at parse time already to obtain its argument definitions.
However, this poses a problem in the implementation: The
`ViewHelperNode` can only be created once its arguments
are validated, but to do that, the ViewHelper instance needs
to be present, which is done by the constructor of the
`ViewHelperNode` (which doesn't exist yet). The previous
implementation solved this by creating "throw-away"
instances of the ViewHelpers to obtain their argument definitions.

This patch aims to simplify that: The `ViewHelperNode` no longer
needs the arguments for its constructor. Instead, they can be
provided later with a `setArguments()` method. This allows the
parser to create the `ViewHelperNode` early and then use its
API to perform the validation of its arguments. In order to avoid
bigger refactoring of the parser, the closure approach is taken
to minimize unintended consequences of this change in Fluid v4.
In addition, the tests of the `TemplateParser` have been refactored
to functional tests in #1094 to ensure that the parser still works
as expected.

In addition to the cleanup aspect, this change is necessary for
the "reusable components" feature because it allows to provide
argument definitions to the parser more dynamically.