### PR TITLE
[BUGFIX] Attempt to cast boolean arguments

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -32,12 +32,13 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
         if (!$definition->isRequired() && $value === $definition->getDefaultValue()) {
             return $value;
         }
-        // bool/boolean is not handled separately here because Fluid's BooleanParser
-        // already ensures valid boolean values
+        // Boolean expressions are evaluated at the parser level, so we just make sure
+        // that the input has the correct type
         return match ($definition->getType()) {
             'string' => is_scalar($value) ? (string)$value : $value,
             'int', 'integer' => is_scalar($value) ? (int)$value : $value,
             'float', 'double' => is_scalar($value) ? (float)$value : $value,
+            'bool', 'boolean' => is_scalar($value) ? (bool)$value : $value,
             default => $value,
         };
     }

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -62,7 +62,35 @@ final class StrictArgumentProcessorTest extends TestCase
                 'expectedProcessedValue' => ['bad'],
                 'expectedProcessedValidity' => false,
             ];
-            // De-facto, all non-boolean values are converted by the parser
+            yield [
+                'type' => $type,
+                'value' => 1,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => true,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 'foo',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => true,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => 0,
+                'expectedValidity' => false,
+                'expectedProcessedValue' => false,
+                'expectedProcessedValidity' => true,
+            ];
+            yield [
+                'type' => $type,
+                'value' => '',
+                'expectedValidity' => false,
+                'expectedProcessedValue' => false,
+                'expectedProcessedValidity' => true,
+            ];
+            // De-facto, in most circumstances non-boolean values are converted by the parser
             yield [
                 'type' => $type,
                 'value' => (new BooleanNode(123))->evaluate(new RenderingContext()),


### PR DESCRIPTION
The recently introduced `StrictArgumentProcessor` didn't process
boolean arguments because it relied on the `BooleanParser` being
performed during template parsing. However, this is not the case
for templates being rendered directly from PHP:

```php
$myView->assign('booleanArgument', 1);
$myView->render('myTemplate');
```

This change assures that the `1` will be interpreted as valid boolean,
which is consistent with the other scalar types.