### PR TITLE
[TASK] Bump dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "friendsofphp/php-cs-fixer": "^3.59.3",
-        "phpstan/phpstan": "^2.0.2",
-        "phpstan/phpstan-phpunit": "^2.0.1",
-        "phpunit/phpunit": "^11.4.3",
+        "phpstan/phpstan": "^2.1.17",
+        "phpstan/phpstan-phpunit": "^2.0.6",
+        "phpunit/phpunit": "^11.5.22 || ^12.2.1",
         "psr/container": "^2.0",
         "t3docs/fluid-documentation-generator": "^4.3"
     },

--- a/tests/Functional/Core/ViewHelper/ViewHelperResolverDelegateTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperResolverDelegateTest.php
@@ -43,7 +43,6 @@ final class ViewHelperResolverDelegateTest extends AbstractFunctionalTestCase
         self::assertSame($expected, $view->render());
     }
 
-    #[DataProvider('renderViewHelpersFromDelegateDataProvider')]
     #[Test]
     public function invalidViewHelpersFromDelegateThrowsException(): void
     {

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -59,14 +59,12 @@ final class EscapingModifierTemplateProcessorTest extends TestCase
     public static function getErrorTestValues(): array
     {
         return [
-            [
-                '{escapingEnabled off}' . PHP_EOL . '{escapingEnabled off}',
-                '{escapingEnabled on}' . PHP_EOL . '{escapingEnabled on}',
-                '{escapingEnabled on}' . PHP_EOL . '{escapingEnabled off}',
-                '{escaping off}' . PHP_EOL . '{escaping off}',
-                '{escaping off}' . PHP_EOL . '{escaping true}',
-                '{escaping off}' . PHP_EOL . '{escaping false}',
-            ],
+            ['{escapingEnabled off}' . PHP_EOL . '{escapingEnabled off}'],
+            ['{escapingEnabled on}' . PHP_EOL . '{escapingEnabled on}'],
+            ['{escapingEnabled on}' . PHP_EOL . '{escapingEnabled off}'],
+            ['{escaping off}' . PHP_EOL . '{escaping off}'],
+            ['{escaping off}' . PHP_EOL . '{escaping true}'],
+            ['{escaping off}' . PHP_EOL . '{escaping false}'],
         ];
     }
 


### PR DESCRIPTION
PHP 8.3 and 8.4 tests now use phpunit v12.
Fix two data providers the more strict
phpunit v12 found.

composer req --dev \
	phpstan/phpstan:^2.1.17 \
	phpunit/phpunit:"^11.5.22 || ^12.2.1" \
	phpstan/phpstan-phpunit:^2.0.6