### PR TITLE
[!!!][TASK] Remove setChildNodes() on ViewHelpers

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -1,0 +1,17 @@
+.. include:: /Includes.rst.txt
+
+.. _changelog-5.x:
+
+=============
+Changelog 5.x
+=============
+
+5.0
+---
+
+* Breaking: Property :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::$childNodes`
+  has been removed.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::setChildNodes()`
+  has been removed.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface::setChildNodes()`
+  has been removed.

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -14,3 +14,4 @@ The Changelog lists notable deprecation and breaking changes.
 
     2.x
     4.x
+    5.x

--- a/src/Core/Component/ComponentAdapter.php
+++ b/src/Core/Component/ComponentAdapter.php
@@ -268,14 +268,6 @@ final class ComponentAdapter implements ViewHelperInterface
 
     /**
      * Not relevant for component rendering
-     *
-     * @param NodeInterface[] $nodes
-     * @todo remove with Fluid v5
-     */
-    public function setChildNodes(array $nodes): void {}
-
-    /**
-     * Not relevant for component rendering
      */
     public function getContentArgumentName(): ?string
     {

--- a/src/Core/Parser/SyntaxTree/ViewHelperNode.php
+++ b/src/Core/Parser/SyntaxTree/ViewHelperNode.php
@@ -122,13 +122,6 @@ class ViewHelperNode extends AbstractNode
         return $this->arguments;
     }
 
-    public function addChildNode(NodeInterface $childNode): void
-    {
-        parent::addChildNode($childNode);
-        /** @todo remove with Fluid v5 */
-        $this->uninitializedViewHelper->setChildNodes($this->childNodes);
-    }
-
     /**
      * Call the view helper associated with this object.
      *

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -51,13 +51,6 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     protected $arguments = [];
 
     /**
-     * @var NodeInterface[] array
-     * @api
-     * @deprecated will be removed with Fluid v5. Use $viewHelperNode->getChildNodes() instead
-     */
-    protected $childNodes = [];
-
-    /**
      * Current variable container reference.
      * @var VariableProviderInterface
      * @api
@@ -226,18 +219,6 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     public function setViewHelperNode(ViewHelperNode $node)
     {
         $this->viewHelperNode = $node;
-    }
-
-    /**
-     * Sets all needed attributes needed for the rendering. Called by the
-     * framework. Populates $this->viewHelperNode.
-     * @param NodeInterface[] $childNodes
-     * @internal
-     * @deprecated will be removed with Fluid v5. Use $viewHelperNode->getChildNodes() instead
-     */
-    public function setChildNodes(array $childNodes)
-    {
-        $this->childNodes = $childNodes;
     }
 
     /**

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -40,12 +40,6 @@ interface ViewHelperInterface
 
     public function getContentArgumentName(): ?string;
 
-    /**
-     * @param NodeInterface[] $nodes
-     * @deprecated will be removed with Fluid v5
-     */
-    public function setChildNodes(array $nodes);
-
     public function setViewHelperNode(ViewHelperNode $node);
 
     /**


### PR DESCRIPTION
The method and the associated property have been deprecated with Fluid v4.3 and are now removed.