### PR TITLE
[TASK] Clarify code comments related to escaping (#1151)

### DIFF
--- a/src/Core/Parser/Interceptor/Escape.php
+++ b/src/Core/Parser/Interceptor/Escape.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ObjectAccessorNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
- * An interceptor adding the "Htmlspecialchars" viewhelper to the suitable places.
+ * An interceptor adding EscapingNodes to the suitable places, which execute htmlspecialchars().
  */
 class Escape implements InterceptorInterface
 {
@@ -38,8 +38,7 @@ class Escape implements InterceptorInterface
     protected array $viewHelperNodesWhichDisableTheInterceptor = [];
 
     /**
-     * Adds a ViewHelper node using the Format\HtmlspecialcharsViewHelper to the given node.
-     * If "escapingInterceptorEnabled" in the ViewHelper is false, will disable itself inside the ViewHelpers body.
+     * Adds a special EscapingNode to the given node if escaping for the node is necessary.
      *
      * @param int $interceptorPosition One of the INTERCEPT_* constants for the current interception point
      * @param ParsingState $parsingState the current parsing state. Not needed in this interceptor.

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -95,7 +95,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * Specifies whether the escaping interceptors should be disabled or enabled for the result of renderChildren() calls within this ViewHelper
      * @see isChildrenEscapingEnabled()
      *
-     * Note: If this is null, the value of $this->escapingInterceptorEnabled is considered for backwards compatibility.
+     * Note: If this is null, the value will be determined based on $escapeOutput.
      *
      * @var bool
      * @api

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -71,7 +71,6 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
      * @return mixed the altered string. If a non-string is provided, the value is returned unchanged
      * @see http://www.php.net/manual/function.htmlspecialchars.php
      * @api
-     * @todo change return type to string. This needs further investigation because the ViewHelper is used internally by Fluid
      */
     public function render()
     {


### PR DESCRIPTION
A code search both for "HtmlspecialcharsViewHelper" and "htmlspecialchars" confirmed that the ViewHelper is no longer used internally for escaping. Instead, the `EscapingNode` executes `htmlspecialchars()` directly on the string, both in uncached and cached context.

The `@todo` in `HtmlspecialcharsViewHelper` is removed without changing the return type though, because this would require a breaking change to the ViewHelper's internal behavior.