### PR TITLE
[TASK] Add non-critical type hints to ViewHelper classes

### DIFF
--- a/src/ViewHelpers/AliasViewHelper.php
+++ b/src/ViewHelpers/AliasViewHelper.php
@@ -61,15 +61,12 @@ class AliasViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('map', 'array', 'Array that specifies which variables should be mapped to which alias', true);
     }
 
-    /**
-     * @return mixed
-     */
-    public function render()
+    public function render(): mixed
     {
         $globalVariableProvider = $this->renderingContext->getVariableProvider();
         $localVariableProvider = new StandardVariableProvider($this->arguments['map']);

--- a/src/ViewHelpers/Cache/DisableViewHelper.php
+++ b/src/ViewHelpers/Cache/DisableViewHelper.php
@@ -71,21 +71,12 @@ class DisableViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderChildren();
     }
 
-    /**
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @return string
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         $compiler->disable();
         return '';

--- a/src/ViewHelpers/Cache/StaticViewHelper.php
+++ b/src/ViewHelpers/Cache/StaticViewHelper.php
@@ -78,10 +78,7 @@ class StaticViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderChildren();
     }

--- a/src/ViewHelpers/Cache/WarmupViewHelper.php
+++ b/src/ViewHelpers/Cache/WarmupViewHelper.php
@@ -73,7 +73,7 @@ class WarmupViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument(
             'variables',
@@ -93,10 +93,8 @@ class WarmupViewHelper extends AbstractViewHelper
      * operations. If ACTIVE the ViewHelper will assign/overlay
      * replacement variables, call `renderChildren`, restore the
      * original variable provider and finally return the content.
-     *
-     * @return string
      */
-    public function render()
+    public function render(): mixed
     {
         if (!$this->renderingContext->getTemplateCompiler()->isWarmupMode()) {
             return $this->renderChildren();
@@ -138,7 +136,7 @@ class WarmupViewHelper extends AbstractViewHelper
      * @param array $variables
      * @return VariableProviderInterface
      */
-    protected static function overlayVariablesIfNotSet(RenderingContextInterface $renderingContext, array $variables)
+    protected static function overlayVariablesIfNotSet(RenderingContextInterface $renderingContext, array $variables): VariableProviderInterface
     {
         $currentProvider = $renderingContext->getVariableProvider();
         $chainedVariableProvider = new ChainedVariableProvider([

--- a/src/ViewHelpers/CaseViewHelper.php
+++ b/src/ViewHelpers/CaseViewHelper.php
@@ -26,17 +26,17 @@ class CaseViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'mixed', 'Value to match in this case', true);
     }
 
     /**
-     * @return string the contents of this ViewHelper if $value equals the expression of the surrounding switch ViewHelper, otherwise an empty string
+     * @return mixed the contents of this ViewHelper if $value equals the expression of the surrounding switch ViewHelper, otherwise an empty string
      * @throws ViewHelper\Exception
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         $value = $this->arguments['value'];
         $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
@@ -59,9 +59,8 @@ class CaseViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         return '\'\'';
     }

--- a/src/ViewHelpers/CommentViewHelper.php
+++ b/src/ViewHelpers/CommentViewHelper.php
@@ -57,7 +57,7 @@ class CommentViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function render()
+    public function render(): string
     {
         return '';
     }

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -52,15 +52,12 @@ class CountViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('subject', 'array', 'Countable subject, array or \Countable');
     }
 
-    /**
-     * @return int
-     */
-    public function render()
+    public function render(): int
     {
         $countable = $this->renderChildren();
         if ($countable === null) {

--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -71,16 +71,13 @@ class CycleViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('values', 'array', 'The array or object implementing \ArrayAccess (for example \SplObjectStorage) to iterated over');
         $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
     }
 
-    /**
-     * @return mixed
-     */
-    public function render()
+    public function render(): mixed
     {
         $values = $this->arguments['values'];
         $as = $this->arguments['as'];
@@ -105,12 +102,7 @@ class CycleViewHelper extends AbstractViewHelper
         return $output;
     }
 
-    /**
-     * @param mixed $values
-     * @return array
-     * @throws ViewHelper\Exception
-     */
-    protected static function initializeValues($values)
+    protected static function initializeValues(mixed $values): array
     {
         if (is_array($values)) {
             return array_values($values);
@@ -123,16 +115,11 @@ class CycleViewHelper extends AbstractViewHelper
         throw new ViewHelper\Exception('CycleViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
     }
 
-    /**
-     * @param string $as
-     * @param ViewHelper\ViewHelperVariableContainer $viewHelperVariableContainer
-     * @return int
-     */
-    protected static function initializeIndex($as, ViewHelper\ViewHelperVariableContainer $viewHelperVariableContainer)
+    protected static function initializeIndex(string $as, ViewHelper\ViewHelperVariableContainer $viewHelperVariableContainer): int
     {
         $index = 0;
         if ($viewHelperVariableContainer->exists(static::class, $as)) {
-            $index = $viewHelperVariableContainer->get(static::class, $as);
+            $index = (int)$viewHelperVariableContainer->get(static::class, $as);
         }
 
         return $index;

--- a/src/ViewHelpers/DebugViewHelper.php
+++ b/src/ViewHelpers/DebugViewHelper.php
@@ -52,17 +52,14 @@ class DebugViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('typeOnly', 'boolean', 'If true, debugs only the type of variables', false, false);
         $this->registerArgument('levels', 'integer', 'Levels to render when rendering nested objects/arrays', false, 5);
         $this->registerArgument('html', 'boolean', 'Render HTML. If false, output is indented plaintext', false, false);
     }
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         $typeOnly = $this->arguments['typeOnly'];
         $expressionToExamine = $this->renderChildren();
@@ -74,14 +71,7 @@ class DebugViewHelper extends AbstractViewHelper
         return static::dumpVariable($expressionToExamine, $html, 1, $levels);
     }
 
-    /**
-     * @param mixed $variable
-     * @param bool $html
-     * @param int $level
-     * @param int $levels
-     * @return string
-     */
-    protected static function dumpVariable($variable, $html, $level, $levels)
+    protected static function dumpVariable(mixed $variable, bool $html, int $level, int $levels): string
     {
         $typeLabel = is_object($variable) ? get_class($variable) : gettype($variable);
 
@@ -134,11 +124,7 @@ class DebugViewHelper extends AbstractViewHelper
         return $string;
     }
 
-    /**
-     * @param mixed $variable
-     * @return array
-     */
-    protected static function getValuesOfNonScalarVariable($variable)
+    protected static function getValuesOfNonScalarVariable(mixed $variable): array
     {
         if ($variable instanceof \ArrayObject || is_array($variable)) {
             return (array)$variable;

--- a/src/ViewHelpers/DefaultCaseViewHelper.php
+++ b/src/ViewHelpers/DefaultCaseViewHelper.php
@@ -27,11 +27,11 @@ class DefaultCaseViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     /**
-     * @return string the contents of this ViewHelper if no other "Case" ViewHelper of the surrounding switch ViewHelper matches
+     * @return mixed the contents of this ViewHelper if no other "Case" ViewHelper of the surrounding switch ViewHelper matches
      * @throws ViewHelper\Exception
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         $viewHelperVariableContainer = $this->renderingContext->getViewHelperVariableContainer();
         if (!$viewHelperVariableContainer->exists(SwitchViewHelper::class, 'switchExpression')) {
@@ -46,9 +46,8 @@ class DefaultCaseViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         return '\'\'';
     }

--- a/src/ViewHelpers/ElseViewHelper.php
+++ b/src/ViewHelpers/ElseViewHelper.php
@@ -44,16 +44,15 @@ class ElseViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('if', 'boolean', 'Condition expression conforming to Fluid boolean rules');
     }
 
     /**
-     * @return string the rendered string
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderChildren();
     }
@@ -64,9 +63,8 @@ class ElseViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string|null
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         return '\'\'';
     }

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -81,7 +81,7 @@ class ForViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', true);
         $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
@@ -91,10 +91,9 @@ class ForViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @return string
      * @throws ViewHelper\Exception
      */
-    public function render()
+    public function render(): string
     {
         if (!isset($this->arguments['each'])) {
             return '';

--- a/src/ViewHelpers/Format/CdataViewHelper.php
+++ b/src/ViewHelpers/Format/CdataViewHelper.php
@@ -65,15 +65,12 @@ class CdataViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'mixed', 'The value to output');
     }
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         return sprintf('<![CDATA[%s]]>', $this->renderChildren());
     }

--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -57,7 +57,7 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'Value to format');
         $this->registerArgument('keepQuotes', 'boolean', 'If true quotes will not be replaced (ENT_NOQUOTES)', false, false);
@@ -72,7 +72,7 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
      * @see http://www.php.net/manual/function.htmlspecialchars.php
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         $value = $this->arguments['value'];
         $keepQuotes = $this->arguments['keepQuotes'];
@@ -99,9 +99,8 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         $valueVariableName = $compiler->variableName('value');
         $initializationPhpCode .= sprintf('%1$s = (%2$s[\'value\'] !== null ? %2$s[\'value\'] : %3$s());', $valueVariableName, $argumentsName, $closureName) . chr(10);

--- a/src/ViewHelpers/Format/JsonViewHelper.php
+++ b/src/ViewHelpers/Format/JsonViewHelper.php
@@ -71,7 +71,7 @@ final class JsonViewHelper extends AbstractViewHelper
      * @see https://www.php.net/manual/function.json-encode.php
      * @return string|false
      */
-    public function render()
+    public function render(): string|bool
     {
         $value = $this->renderChildren();
         $options = JSON_HEX_TAG;

--- a/src/ViewHelpers/Format/PrintfViewHelper.php
+++ b/src/ViewHelpers/Format/PrintfViewHelper.php
@@ -68,7 +68,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class PrintfViewHelper extends AbstractViewHelper
 {
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'string', 'String to format');
         $this->registerArgument('arguments', 'array', 'The arguments for vsprintf', false, []);
@@ -76,9 +76,8 @@ class PrintfViewHelper extends AbstractViewHelper
 
     /**
      * Applies vsprintf() on the specified value.
-     * @return string
      */
-    public function render()
+    public function render(): string
     {
         return vsprintf($this->renderChildren(), $this->arguments['arguments']);
     }

--- a/src/ViewHelpers/Format/RawViewHelper.php
+++ b/src/ViewHelpers/Format/RawViewHelper.php
@@ -68,7 +68,7 @@ class RawViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'mixed', 'The value to output', false, null, false);
     }
@@ -76,7 +76,7 @@ class RawViewHelper extends AbstractViewHelper
     /**
      * @return mixed
      */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderChildren();
     }
@@ -87,9 +87,8 @@ class RawViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return mixed
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         $contentArgumentName = $this->getContentArgumentName();
         return sprintf(

--- a/src/ViewHelpers/Format/TrimViewHelper.php
+++ b/src/ViewHelpers/Format/TrimViewHelper.php
@@ -98,7 +98,7 @@ final class TrimViewHelper extends AbstractViewHelper
     /**
      * @return string the trimmed value
      */
-    public function render()
+    public function render(): string
     {
         $value = $this->arguments['value'];
         $characters = $this->arguments['characters'];

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -92,7 +92,7 @@ class GroupedForViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('each', 'array', 'The array or \SplObjectStorage to iterated over', true);
         $this->registerArgument('as', 'string', 'The name of the iteration variable', true);
@@ -100,10 +100,7 @@ class GroupedForViewHelper extends AbstractViewHelper
         $this->registerArgument('groupKey', 'string', 'The name of the variable to store the current group', false, 'groupKey');
     }
 
-    /**
-     * @return mixed
-     */
-    public function render()
+    public function render(): string
     {
         $each = $this->arguments['each'];
         $as = $this->arguments['as'];
@@ -143,7 +140,7 @@ class GroupedForViewHelper extends AbstractViewHelper
      * @return array The grouped array in the form array('keys' => array('key1' => [key1value], 'key2' => [key2value], ...), 'values' => array('key1' => array([key1value] => [element1]), ...), ...)
      * @throws ViewHelper\Exception
      */
-    protected static function groupElements(array $elements, $groupBy)
+    protected static function groupElements(array $elements, string $groupBy): array
     {
         $groups = ['keys' => [], 'values' => []];
         foreach ($elements as $key => $value) {

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -150,16 +150,13 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IfViewHelper extends AbstractConditionViewHelper
 {
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         parent::initializeArguments();
         $this->registerArgument('condition', 'boolean', 'Condition expression conforming to Fluid boolean rules', false, false);
     }
 
-    /**
-     * @return bool
-     */
-    public static function verdict(array $arguments, RenderingContextInterface $renderingContext)
+    public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
         return (bool)$arguments['condition'];
     }

--- a/src/ViewHelpers/InlineViewHelper.php
+++ b/src/ViewHelpers/InlineViewHelper.php
@@ -36,7 +36,7 @@ class InlineViewHelper extends AbstractViewHelper
 
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument(
             'code',
@@ -45,10 +45,7 @@ class InlineViewHelper extends AbstractViewHelper
         );
     }
 
-    /**
-     * @return mixed|string
-     */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderingContext->getTemplateParser()->parse((string)$this->renderChildren())->render($this->renderingContext);
     }

--- a/src/ViewHelpers/LayoutViewHelper.php
+++ b/src/ViewHelpers/LayoutViewHelper.php
@@ -41,12 +41,12 @@ class LayoutViewHelper extends AbstractViewHelper implements ViewHelperNodeIniti
      *
      * @api
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('name', 'string', 'Name of layout to use. If none given, "Default" is used.');
     }
 
-    public function render()
+    public function render(): string
     {
         return '';
     }

--- a/src/ViewHelpers/OrViewHelper.php
+++ b/src/ViewHelpers/OrViewHelper.php
@@ -37,17 +37,14 @@ class OrViewHelper extends AbstractViewHelper
     /**
      * Initialize
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('content', 'mixed', 'Content to check if null');
         $this->registerArgument('alternative', 'mixed', 'Alternative if content is null');
         $this->registerArgument('arguments', 'array', 'Arguments to be replaced in the resulting string, using sprintf');
     }
 
-    /**
-     * @return mixed
-     */
-    public function render()
+    public function render(): mixed
     {
         $alternative = $this->arguments['alternative'];
         $sprintfArguments = (array)$this->arguments['arguments'];

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -8,7 +8,6 @@
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
@@ -111,7 +110,7 @@ class RenderViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('section', 'string', 'Section to render - combine with partial to render section in partial');
         $this->registerArgument('partial', 'string', 'Partial to render, with or without section');
@@ -122,10 +121,7 @@ class RenderViewHelper extends AbstractViewHelper
         $this->registerArgument('contentAs', 'string', 'If used, renders the child content and adds it as a template variable with this name for use in the partial/section');
     }
 
-    /**
-     * @return mixed
-     */
-    public function render()
+    public function render(): mixed
     {
         $section = $this->arguments['section'];
         $partial = $this->arguments['partial'];

--- a/src/ViewHelpers/SectionViewHelper.php
+++ b/src/ViewHelpers/SectionViewHelper.php
@@ -78,7 +78,7 @@ class SectionViewHelper extends AbstractViewHelper implements ViewHelperNodeInit
      *
      * @api
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('name', 'string', 'Name of the section', true);
     }
@@ -86,10 +86,9 @@ class SectionViewHelper extends AbstractViewHelper implements ViewHelperNodeInit
     /**
      * Rendering directly returns all child nodes.
      *
-     * @return string HTML String of all child nodes.
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         $content = '';
         if ($this->viewHelperVariableContainer->exists(SectionViewHelper::class, 'isCurrentlyRenderingSection')) {

--- a/src/ViewHelpers/SpacelessViewHelper.php
+++ b/src/ViewHelpers/SpacelessViewHelper.php
@@ -46,10 +46,7 @@ class SpacelessViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         return trim(preg_replace('/\\>\\s+\\</', '><', (string)$this->renderChildren()));
     }

--- a/src/ViewHelpers/SwitchViewHelper.php
+++ b/src/ViewHelpers/SwitchViewHelper.php
@@ -62,16 +62,15 @@ class SwitchViewHelper extends AbstractViewHelper
      */
     protected $backupBreakState = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('expression', 'mixed', 'Expression to switch', true);
     }
 
     /**
-     * @return string the rendered string
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         $expression = $this->arguments['expression'];
         $this->backupSwitchState();
@@ -95,9 +94,8 @@ class SwitchViewHelper extends AbstractViewHelper
 
     /**
      * @param NodeInterface[] $childNodes
-     * @return mixed
      */
-    protected function retrieveContentFromChildNodes(array $childNodes)
+    protected function retrieveContentFromChildNodes(array $childNodes): mixed
     {
         $content = null;
         $defaultCaseViewHelperNode = null;
@@ -121,20 +119,12 @@ class SwitchViewHelper extends AbstractViewHelper
         return $content;
     }
 
-    /**
-     * @param NodeInterface $node
-     * @return bool
-     */
-    protected function isDefaultCaseNode(NodeInterface $node)
+    protected function isDefaultCaseNode(NodeInterface $node): bool
     {
         return $node instanceof ViewHelperNode && $node->getViewHelperClassName() === DefaultCaseViewHelper::class;
     }
 
-    /**
-     * @param NodeInterface $node
-     * @return bool
-     */
-    protected function isCaseNode(NodeInterface $node)
+    protected function isCaseNode(NodeInterface $node): bool
     {
         return $node instanceof ViewHelperNode && $node->getViewHelperClassName() === CaseViewHelper::class;
     }
@@ -142,7 +132,7 @@ class SwitchViewHelper extends AbstractViewHelper
     /**
      * Backups "switch expression" and "break" state of a possible parent switch ViewHelper to support nesting
      */
-    protected function backupSwitchState()
+    protected function backupSwitchState(): void
     {
         if ($this->renderingContext->getViewHelperVariableContainer()->exists(SwitchViewHelper::class, 'switchExpression')) {
             $this->backupSwitchExpression = $this->renderingContext->getViewHelperVariableContainer()->get(SwitchViewHelper::class, 'switchExpression');
@@ -155,7 +145,7 @@ class SwitchViewHelper extends AbstractViewHelper
     /**
      * Restores "switch expression" and "break" states that might have been backed up in backupSwitchState() before
      */
-    protected function restoreSwitchState()
+    protected function restoreSwitchState(): void
     {
         if ($this->backupSwitchExpression !== null) {
             $this->renderingContext->getViewHelperVariableContainer()->addOrUpdate(SwitchViewHelper::class, 'switchExpression', $this->backupSwitchExpression);
@@ -176,9 +166,8 @@ class SwitchViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         $phpCode = 'call_user_func_array(function($arguments) use ($renderingContext) {' . PHP_EOL .
             'switch ($arguments[\'expression\']) {' . PHP_EOL;

--- a/src/ViewHelpers/ThenViewHelper.php
+++ b/src/ViewHelpers/ThenViewHelper.php
@@ -27,10 +27,9 @@ class ThenViewHelper extends AbstractViewHelper
     /**
      * Just render everything.
      *
-     * @return string the rendered string
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         return $this->renderChildren();
     }
@@ -41,9 +40,8 @@ class ThenViewHelper extends AbstractViewHelper
      * @param string $initializationPhpCode
      * @param ViewHelperNode $node
      * @param TemplateCompiler $compiler
-     * @return string
      */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler)
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
     {
         return '\'\'';
     }

--- a/src/ViewHelpers/VariableViewHelper.php
+++ b/src/ViewHelpers/VariableViewHelper.php
@@ -33,16 +33,17 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class VariableViewHelper extends AbstractViewHelper
 {
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('value', 'mixed', 'Value to assign. If not in arguments then taken from tag content');
         $this->registerArgument('name', 'string', 'Name of variable to create', true);
     }
 
-    public function render()
+    public function render(): string
     {
         $value = $this->renderChildren();
         $this->renderingContext->getVariableProvider()->add($this->arguments['name'], $value);
+        return '';
     }
 
     /**

--- a/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
@@ -72,7 +72,7 @@ final class MutableTestViewHelper extends AbstractViewHelper
         return 'content';
     }
 
-    public function render()
+    public function render(): mixed
     {
         $argumentDefinitions = $this->prepareArguments();
         if (isset($argumentDefinitions['output'])) {


### PR DESCRIPTION
In preparation for more type hints in `ViewHelperInterface` and
abstract classes, non-critical type hints are added to all existing
ViewHelper classes. These include:

* return types for `initializeArguments()` and `render()`
* parameter and return types for internal methods

Even though these changes most certainly aren't breaking, we
still apply them to v5 only, just to be sure. In follow-up patches,
the abstract classes will get more type hints (e. g. for properties),
which will require (!) changes to the ViewHelpers and thus will
be breaking changes.