### PR TITLE
[BUGFIX] allow usage of interfaces in StrictArgumentProcessor

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -104,6 +104,9 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
         if (class_exists($type) && $value instanceof $type) {
             return true;
         }
+        if (interface_exists($type) && $value instanceof $type) {
+            return true;
+        }
         return false;
     }
 

--- a/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
@@ -132,6 +132,8 @@ final class LenientArgumentProcessorTest extends TestCase
             ['test', 'DateTime', false],
             [null, 'DateTime', true], // @todo this can lead to PHP warnings
 
+            [new \Datetime('now'), 'DateTimeInterface', true],
+
             ['test', 'object', false],
             [null, 'object', false],
 

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -18,6 +18,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 
 final class StrictArgumentProcessorTest extends TestCase
@@ -495,6 +496,36 @@ final class StrictArgumentProcessorTest extends TestCase
             'value' => null,
             'expectedValidity' => false,
             'expectedProcessedValue' => null,
+            'expectedProcessedValidity' => false,
+        ];
+        // Interfaces
+        yield [
+            'type' => 'DateTimeInterface',
+            'value' => $dateTime,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => $dateTime,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'DateTimeInterface',
+            'value' => $stdClass,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $stdClass,
+            'expectedProcessedValidity' => false,
+        ];
+        // Enums
+        yield [
+            'type' => BackedEnumExample::class,
+            'value' => BackedEnumExample::BAR,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => BackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => BackedEnumExample::class,
+            'value' => $stdClass,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $stdClass,
             'expectedProcessedValidity' => false,
         ];
 


### PR DESCRIPTION
Got this error:

> The argument "file" for template "Default_action_ContentElements_rte_only_templates_frontend_3a0ee286e27afc95" is registered with type "TYPO3\CMS\Core\Resource\FileInterface", but the provided value is of type "TYPO3\CMS\Core\Resource\File".

This fix makes it possible to use interfaces as typed arguments for components.