### PR TITLE
[DOCS] Re-enable cross reference to TYPO3 doc for new ViewHelpers

### DIFF
--- a/Documentation/ViewHelpers/Fluid/Flatten.rst
+++ b/Documentation/ViewHelpers/Fluid/Flatten.rst
@@ -12,10 +12,10 @@
 Flatten ViewHelper `<f:flatten>`
 ================================
 
-.. ..  note::
-..     This reference is part of the documentation of Fluid Standalone.
-..     If you are working with Fluid in TYPO3 CMS, please refer to
-..     :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Flatten>` instead.
+..  note::
+    This reference is part of the documentation of Fluid Standalone.
+    If you are working with Fluid in TYPO3 CMS, please refer to
+    :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Flatten>` instead.
 
 ..  typo3:viewhelper:: flatten
     :source: ../Fluid.json

--- a/Documentation/ViewHelpers/Fluid/Fragment.rst
+++ b/Documentation/ViewHelpers/Fluid/Fragment.rst
@@ -12,10 +12,10 @@
 Fragment ViewHelper `<f:fragment>`
 ==================================
 
-.. ..  note::
-..     This reference is part of the documentation of Fluid Standalone.
-..     If you are working with Fluid in TYPO3 CMS, please refer to
-..     :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Fragment>` instead.
+..  note::
+    This reference is part of the documentation of Fluid Standalone.
+    If you are working with Fluid in TYPO3 CMS, please refer to
+    :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Fragment>` instead.
 
 ..  typo3:viewhelper:: fragment
     :source: ../Fluid.json

--- a/Documentation/ViewHelpers/Fluid/Shuffle.rst
+++ b/Documentation/ViewHelpers/Fluid/Shuffle.rst
@@ -12,10 +12,10 @@
 Shuffle ViewHelper `<f:shuffle>`
 ================================
 
-.. ..  note::
-..     This reference is part of the documentation of Fluid Standalone.
-..     If you are working with Fluid in TYPO3 CMS, please refer to
-..     :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Shuffle>` instead.
+..  note::
+    This reference is part of the documentation of Fluid Standalone.
+    If you are working with Fluid in TYPO3 CMS, please refer to
+    :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Shuffle>` instead.
 
 ..  typo3:viewhelper:: shuffle
     :source: ../Fluid.json

--- a/Documentation/ViewHelpers/Fluid/Slot.rst
+++ b/Documentation/ViewHelpers/Fluid/Slot.rst
@@ -12,10 +12,10 @@
 Slot ViewHelper `<f:slot>`
 ==========================
 
-.. ..  note::
-..     This reference is part of the documentation of Fluid Standalone.
-..     If you are working with Fluid in TYPO3 CMS, please refer to
-..     :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Slot>` instead.
+..  note::
+    This reference is part of the documentation of Fluid Standalone.
+    If you are working with Fluid in TYPO3 CMS, please refer to
+    :doc:`TYPO3's ViewHelper reference <t3viewhelper:Global/Slot>` instead.
 
 ..  typo3:viewhelper:: slot
     :source: ../Fluid.json


### PR DESCRIPTION
Resolves: #1108