### PR TITLE
[TASK] Treat f:argument with default value as optional (#1150)

### DIFF
--- a/src/ViewHelpers/ArgumentViewHelper.php
+++ b/src/ViewHelpers/ArgumentViewHelper.php
@@ -128,14 +128,18 @@ final class ArgumentViewHelper extends AbstractViewHelper implements ViewHelperN
             ), 1744908509);
         }
 
+        // Automatically make the argument definition optional if it has a default value
+        $hasDefaultValue = array_key_exists('default', $evaluatedArguments);
+        $optional = ($evaluatedArguments['optional'] ?? false) || $hasDefaultValue;
+
         // Create argument definition to be interpreted later during rendering
         // This will also be written to the cache by the TemplateCompiler
         $argumentDefinitions[$argumentName] = new ArgumentDefinition(
             $argumentName,
             (string)$evaluatedArguments['type'],
             array_key_exists('description', $evaluatedArguments) ? (string)$evaluatedArguments['description'] : '',
-            array_key_exists('optional', $evaluatedArguments) ? !$evaluatedArguments['optional'] : true,
-            array_key_exists('default', $evaluatedArguments) ? $evaluatedArguments['default'] : null,
+            !$optional,
+            $hasDefaultValue ? $evaluatedArguments['default'] : null,
         );
         $parsingState->setArgumentDefinitions($argumentDefinitions);
     }

--- a/tests/Functional/Fixtures/Layouts/LayoutWithArgumentDefinitions.html
+++ b/tests/Functional/Fixtures/Layouts/LayoutWithArgumentDefinitions.html
@@ -1,5 +1,6 @@
 <f:argument name="title" type="string" />
 <f:argument name="tags" type="string[]" optional="{true}" />
 <f:argument name="user" type="string" optional="{true}" default="admin" />
+<f:argument name="autoOptional" type="string" default="default-value" />
 
 {_all -> f:format.json() -> f:format.raw()}

--- a/tests/Functional/Fixtures/Partials/PartialWithArgumentDefinitions.html
+++ b/tests/Functional/Fixtures/Partials/PartialWithArgumentDefinitions.html
@@ -1,5 +1,6 @@
 <f:argument name="title" type="string" />
 <f:argument name="tags" type="string[]" optional="{true}" />
 <f:argument name="user" type="string" optional="{true}" default="admin" />
+<f:argument name="autoOptional" type="string" default="default-value" />
 
 {_all -> f:format.json() -> f:format.raw()}

--- a/tests/Functional/Fixtures/Templates/TemplateWithArgumentDefinitions.html
+++ b/tests/Functional/Fixtures/Templates/TemplateWithArgumentDefinitions.html
@@ -1,5 +1,6 @@
 <f:argument name="title" type="string" />
 <f:argument name="tags" type="string[]" optional="{true}" />
 <f:argument name="user" type="string" optional="{true}" default="admin" />
+<f:argument name="autoOptional" type="string" default="default-value" />
 
 {_all -> f:format.json() -> f:format.raw()}

--- a/tests/Functional/ViewHelpers/ArgumentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ArgumentViewHelperTest.php
@@ -20,24 +20,24 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
     {
         return [
             'all parameters provided with correct types' => [
-                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me'],
-                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me'],
+                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me', 'autoOptional' => 'custom-value'],
+                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me', 'autoOptional' => 'custom-value'],
             ],
             'all parameters provided with type conversion' => [
-                ['title' => 123, 'tags' => ['tag1', 'tag2'], 'user' => 1.23],
-                ['title' => '123', 'tags' => ['tag1', 'tag2'], 'user' => '1.23'],
+                ['title' => 123, 'tags' => ['tag1', 'tag2'], 'user' => 1.23, 'autoOptional' => 456],
+                ['title' => '123', 'tags' => ['tag1', 'tag2'], 'user' => '1.23', 'autoOptional' => '456'],
             ],
             'fallback to default value' => [
                 ['title' => 'My title', 'tags' => ['tag1', 'tag2']],
-                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'admin'],
+                ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'admin', 'autoOptional' => 'default-value'],
             ],
             'optional parameter not provided' => [
                 ['title' => 'My title'],
-                ['title' => 'My title', 'tags' => null, 'user' => 'admin'],
+                ['title' => 'My title', 'tags' => null, 'user' => 'admin', 'autoOptional' => 'default-value'],
             ],
             'additional parameter provided' => [
                 ['title' => 'My title', 'additional' => 'foo'],
-                ['title' => 'My title', 'additional' => 'foo', 'tags' => null, 'user' => 'admin'],
+                ['title' => 'My title', 'additional' => 'foo', 'tags' => null, 'user' => 'admin', 'autoOptional' => 'default-value'],
             ],
         ];
     }
@@ -197,7 +197,7 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
     public function templateArgumentsAreIgnoredWithLayout(string $templateSource): void
     {
         $layoutRootPath = __DIR__ . '/../Fixtures/Layouts/';
-        $variables = ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me'];
+        $variables = ['title' => 'My title', 'tags' => ['tag1', 'tag2'], 'user' => 'me', 'autoOptional' => 'custom-value'];
         $view = new TemplateView();
         $view->assignMultiple($variables);
         $view->getRenderingContext()->setCache(self::$cache);


### PR DESCRIPTION
If `<f:argument>` is used with the `default` argument, it is now assumed that the argument is optional without specifying `optional="{true}"`.

Resolves: #1149