### PR TITLE
[TASK] Allow argument types to be interfaces

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -101,7 +101,7 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
             }
             return true;
         }
-        if (class_exists($type) && $value instanceof $type) {
+        if ((class_exists($type) || interface_exists($type)) && $value instanceof $type) {
             return true;
         }
         return false;


### PR DESCRIPTION
This change does not only allow `$type` to be a class but also an interface.

Resolves #1160