### PR TITLE
[BUGFIX] empty array is now valid as typed array (#1139)

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -93,7 +93,7 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
                 return false;
             }
             if (str_ends_with($type, '[]')) {
-                $firstElement = $this->getFirstElementOfNonEmpty($value);
+                $firstElement = $this->getFirstElement($value);
                 if ($firstElement === null) {
                     return true;
                 }
@@ -112,11 +112,10 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
 
     /**
      * Return the first element of the given array, ArrayAccess or Traversable
-     * that is not empty
      */
-    private function getFirstElementOfNonEmpty(mixed $value): mixed
+    private function getFirstElement(mixed $value): mixed
     {
-        if (is_array($value)) {
+        if (is_array($value) && $value !== []) {
             return reset($value);
         }
         if ($value instanceof Traversable) {

--- a/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
@@ -141,6 +141,7 @@ final class LenientArgumentProcessorTest extends TestCase
             [[1, 2, 3], 'array', true],
             [new \ArrayObject(), 'array', true],
 
+            [[], 'string[]', true],
             [['foo', 'bar'], 'string[]', true],
             [new \IteratorIterator(new \ArrayIterator(['foo', 'bar'])), 'string[]', true],
             [['foo', 1], 'string[]', true],

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -686,6 +686,13 @@ final class StrictArgumentProcessorTest extends TestCase
         ];
         yield [
             'type' => 'string[]',
+            'value' => [],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => [],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'string[]',
             'value' => ['foo', 'bar'],
             'expectedValidity' => true,
             'expectedProcessedValue' => ['foo', 'bar'],


### PR DESCRIPTION
A typed array, e.g.: string[] doesn't allow an empty array [] as value until now.

reset() returns false instead of null, that results in the array being invalid.