### PR TITLE
[FEATURE] RangeViewHelper to return a range of integers as array (#1122)

### DIFF
--- a/src/ViewHelpers/RangeViewHelper.php
+++ b/src/ViewHelpers/RangeViewHelper.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * The RangeViewHelper returns an array containing a range of integers.
+ *
+ * This ViewHelper mimicks PHP's :php:`range()` function.
+ *
+ * The following examples store the result in a variable because an array cannot
+ * be outputted directly in a template.
+ *
+ * Examples
+ * ========
+ *
+ * Increasing range
+ * -----------------
+ * ::
+ *
+ *    <f:variable name="result"><f:range start="1" end="5" /></f:variable>
+ *
+ * .. code-block:: text
+ *
+ *    {0: 1, 1: 2, 2: 3, 3: 4, 4: 5}
+ *
+ *
+ * Inline increasing range
+ * ------------------------
+ *
+ * ::
+ *
+ *    <f:variable name="result" value="{f:range(start: 1, end: 5)}" />
+ *
+ * .. code-block:: text
+ *
+ *    {0: 1, 1: 2, 2: 3, 3: 4, 4: 5}
+ *
+ *
+ * Decreasing range
+ * -----------------
+ *
+ * ::
+ *
+ *    <f:variable name="result" value="{f:range(start: 5, end: 0)}" />
+ *
+ * .. code-block:: text
+ *
+ *    {0: 5, 1: 4, 2: 3, 3: 2, 4: 1, 5: 0}
+ *
+ *
+ * Increasing stepped range
+ * -------------------------
+ *
+ * ::
+ *
+ *    <f:variable name="result" value="{f:range(start: 1, end: 6, step: 2)" />
+ *
+ * .. code-block:: text
+ *
+ *    {0: 1, 1: 3, 2: 5}
+ *
+ *
+ * Decreasing stepped range
+ * -------------------------
+ *
+ * ::
+ *
+ *    <f:variable name="result" value="{f:range(start: 5, end: 1, step: 2)" />
+ *
+ * .. code-block:: text
+ *
+ *    {0: 5, 1: 3, 2: 1}
+ */
+final class RangeViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('start', 'integer', 'First value of the sequence.', true);
+        $this->registerArgument('end', 'integer', 'Last possible value of the sequence.', true);
+        $this->registerArgument('step', 'integer', 'indicates by how much is the produced sequence progressed between values of the sequence.', false, 1);
+    }
+
+    public function render(): mixed
+    {
+        $step = $this->arguments['step'];
+        if ($step === 0) {
+            throw new \InvalidArgumentException(
+                'The argument "step" cannot be 0 in view helper "' . static::class . '".',
+                1754596304,
+            );
+        }
+        return range(
+            $this->arguments['start'],
+            $this->arguments['end'],
+            $step,
+        );
+
+    }
+}

--- a/tests/Functional/ViewHelpers/RangeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RangeViewHelperTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class RangeViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderValidDataProvider(): iterable
+    {
+        yield 'single element' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 1,
+            ],
+            'src' => '<f:range start="{start}" end="{end}" />',
+            'expectation' => [1],
+        ];
+        yield 'single element inline' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 1,
+            ],
+            'src' => '{f:range(start: start, end: end)}',
+            'expectation' => [1],
+        ];
+        yield 'multiple elements' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 5,
+            ],
+            'src' => '<f:range start="{start}" end="{end}" />',
+            'expectation' => [1, 2, 3, 4, 5],
+        ];
+        yield 'multiple elements inline' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 5,
+            ],
+            'src' => '{f:range(start: start, end: end)}',
+            'expectation' => [1, 2, 3, 4, 5],
+        ];
+        yield 'step' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 10,
+                'step' => 2,
+            ],
+            'src' => '<f:range start="{start}" end="{end}" step="{step}" />',
+            'expectation' => [1, 3, 5, 7, 9],
+        ];
+        yield 'step inline' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 10,
+                'step' => 2,
+            ],
+            'src' => '{f:range(start: start, end: end, step: step)}',
+            'expectation' => [1, 3, 5, 7, 9],
+        ];
+    }
+
+    #[DataProvider('renderValidDataProvider')]
+    #[Test]
+    public function renderValid(array $arguments, string $src, mixed $expectation): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        self::assertSame($expectation, $view->render());
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        self::assertSame($expectation, $view->render());
+    }
+
+    public static function renderInvalidDataProvider(): iterable
+    {
+        yield 'invalid step' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 1,
+                'step' => 0,
+            ],
+            'src' => '<f:range start="{start}" end="{end}" step="{step}" />',
+        ];
+        yield 'invalid step inline' => [
+            'arguments' => [
+                'start' => 1,
+                'end' => 1,
+                'step' => 0,
+            ],
+            'src' => '{f:range(start: start, end: end, step: step)}',
+        ];
+    }
+
+    #[DataProvider('renderInvalidDataProvider')]
+    #[Test]
+    public function renderInvalid(array $arguments, string $src): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionCode(1754596304);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        $view->render();
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($src);
+        $view->assignMultiple($arguments);
+        $view->render();
+    }
+}


### PR DESCRIPTION
The RangeViewHelper returns a sequence of integers.

The sequence is increasing if `start` is less than equal to `end`. Otherwise, the sequence is decreasing.

`step` indicates by how much is the produced sequence progressed between values of the sequence.

```xml
<f:range start="1" end="3" /> <!--  {0: 1, 1: 2, 2: 3} -->
<f:range start="3" end="1" /> <!--  {0: 3, 1: 2, 2: 1} -->
<f:range start="1" end="5" step="2" /> <!--  {0: 1, 1: 3, 2: 5} -->
```