### PR TITLE
[DOC] Incorrect path specified in the Contribution Guide – ViewHelper documentation is not referenced correctly (#1167)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,7 +85,7 @@ To generate the Fluid documentation, you can use the following commands.
 Generate RST files from ViewHelpers:
 
 ```bash
-FLUID_DOCUMENTATION_OUTPUT_DIR=Documentation/Fluid vendor/bin/fluidDocumentation generate vendor/t3docs/fluid-documentation-generator/config/fluidStandalone/*
+FLUID_DOCUMENTATION_OUTPUT_DIR=Documentation/ViewHelpers vendor/bin/fluidDocumentation generate vendor/t3docs/fluid-documentation-generator/config/fluidStandalone/*
 ```
 
 Build the documentation:


### PR DESCRIPTION
The contribution guide states:

Generate RST files from ViewHelpers:
FLUID_DOCUMENTATION_OUTPUT_DIR=Documentation/Fluid vendor/bin/fluidDocumentation generate vendor/t3docs/fluid-documentation-generator/config/fluidStandalone/*

But in my opinion:
FLUID_DOCUMENTATION_OUTPUT_DIR=Documentation/Fluid

is wrong and should be:
FLUID_DOCUMENTATION_OUTPUT_DIR=Documentation/ViewHelpers
