### PR TITLE
[TASK] Remove obsolete IgnoreDeprecations attribute

### DIFF
--- a/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
+++ b/tests/Functional/Core/Rendering/NamespaceInheritanceTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Rendering;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
@@ -107,7 +106,6 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
 
     #[Test]
     #[DataProvider('namespacesDefinedInTemplateCannotBeUsedInLayoutAndPartialsDataProvider')]
-    #[IgnoreDeprecations]
     public function namespacesDefinedInTemplateCannotBeUsedInLayoutAndPartialsUncached(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
     {
         self::expectException(UnknownNamespaceException::class);
@@ -125,7 +123,6 @@ final class NamespaceInheritanceTest extends AbstractFunctionalTestCase
 
     #[Test]
     #[DataProvider('namespacesDefinedInTemplateCannotBeUsedInLayoutAndPartialsDataProvider')]
-    #[IgnoreDeprecations]
     public function namespacesDefinedInTemplateCannotBeUsedInLayoutAndPartialsCached(string $source, array $initialNamespaces, array $variables, array $expectedNamespaces, string $expectedResult): void
     {
         self::expectException(UnknownNamespaceException::class);

--- a/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable;
 
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
@@ -23,7 +22,6 @@ use TYPO3Fluid\Fluid\View\TemplateView;
 final class SharedStaticCompilableViewHelperTest extends AbstractFunctionalTestCase
 {
     #[Test]
-    #[IgnoreDeprecations]
     public function renderWithSharedCompilableViewHelper(): void
     {
         // TYPO3 implements a custom ViewHelperResolver to provide DI-able ViewHelper instances. This allows


### PR DESCRIPTION
The underlying tests have already been changed in previous patches to not trigger deprecations.