### PR TITLE
[TASK] Deprecate unknown VH namespace syntax

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -6,6 +6,12 @@
 Changelog 4.x
 =============
 
+4.5
+---
+
+* Deprecation: Using the `xmlns` namespace syntax with a PHP namespace instead of an url is deprecated
+  and will no longer work in Fluid v5.
+
 4.4
 ---
 

--- a/examples/Resources/Private/Singles/Namespaces.html
+++ b/examples/Resources/Private/Singles/Namespaces.html
@@ -2,10 +2,9 @@
 {namespace wi*}
 <!-- Namespace registrations using container tag. Double and single quoting supported. -->
 <fluid xmlns:f="http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers"
-       xmlns:alias='http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers'
-       xmlns:phpalias="TYPO3Fluid\\Fluid\\ViewHelpers">
+       xmlns:alias='http://typo3.org/ns/TYPO3Fluid/Fluid/ViewHelpers'>
 
-<phpalias:layout name="Default" />
+<alias:layout name="Default" />
 
 <alias:section name="Main">
     Namespaces template

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -96,6 +96,7 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
                         1721467847,
                     );
                 } elseif (!preg_match('/([^a-z0-9_\\\\]+)/i', $namespaceUrl)) {
+                    trigger_error('Using the xmlns namespace syntax with a PHP namespace instead of an url is deprecated and will no longer work in Fluid v5.', E_USER_DEPRECATED);
                     $namespacePhp = $namespaceUrl;
                     $namespacePhp = preg_replace('/\\\\{2,}/', '\\', $namespacePhp);
                 } else {

--- a/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
+++ b/tests/Functional/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessorTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Parser\TemplateProcessor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor;
@@ -243,5 +244,16 @@ final class NamespaceDetectionTemplateProcessorTest extends AbstractFunctionalTe
         $subject = new NamespaceDetectionTemplateProcessor();
         $subject->setRenderingContext(new RenderingContext());
         $subject->preProcessSource('<html xmlns:x="http://typo3.org/ns/X/Y/ViewHelpers" xmlns:z="https://typo3.org/ns/X/Z/ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>');
+    }
+
+    #[Test]
+    #[IgnoreDeprecations]
+    public function phpNamespaceInXmlns(): void
+    {
+        $subject = new NamespaceDetectionTemplateProcessor();
+        $renderingContext = new RenderingContext();
+        $subject->setRenderingContext($renderingContext);
+        $subject->preProcessSource('<html xmlns:x="TYPO3Fluid\\Fluid\\ViewHelpers" data-namespace-typo3-fluid="true">' . PHP_EOL . '</html>');
+        self::assertSame(['TYPO3Fluid\\Fluid\\ViewHelpers'], $renderingContext->getViewHelperResolver()->getNamespaces()['x']);
     }
 }


### PR DESCRIPTION
There are two main syntax variants to import a ViewHelper namespace
in a template:

```
{namespace my=Vendor\MyPackage\ViewHelpers}

<html xmlns:my="http://typo3.org/ns/Vendor/MyPackage/ViewHelpers" data-namespace-typo3-fluid="true">
```

The second variant is mainly used/preferred because it provides
autocompletion for ViewHelpers in supporting IDEs. However, a
third variant is implemented, which mixes the two variants:

```
<html xmlns:my="Vendor\MyPackage\ViewHelpers" data-namespace-typo3-fluid="true">
```

This doesn't make much sense because it neither provides
autocompletion nor is it valid XML syntax because it's
not a valid URL.

This patch deprecates that syntax variant, which will no longer
work in Fluid v5.

Resolves: #1019