### PR TITLE
[!!!][TASK] CDATA sections remain in templates

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -88,4 +88,5 @@ Changelog 5.x
 * Breaking: Custom implementations of the `validateArguments()` methods in ViewHelpers are no longer called.
 * Deprecation: Class :php:`TYPO3Fluid\Fluid\Core\ViewHelper\LenientArgumentProcessor`
   is no longer being used by Fluid v5 and will be removed with Fluid v6.
-
+* Breaking: CDATA sections are no longer removed from Fluid templates. Use `<f:comment>` instead
+  if you want to comment out code in Fluid templates.

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -17,7 +17,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * This template processor takes care of the following things:
  *
- *   - replace cdata sections with empty lines (including nested cdata)
  *   - register/ignore namespaces through xmlns and shorthand syntax
  *   - report any unregistered/unignored namespaces through exception
  */
@@ -39,37 +38,8 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      */
     public function preProcessSource(string $templateSource): string
     {
-        $templateSource = $this->replaceCdataSectionsByEmptyLines($templateSource);
         $templateSource = $this->registerNamespacesFromTemplateSource($templateSource);
         return $templateSource;
-    }
-
-    /**
-     * Replaces all cdata sections with empty lines to exclude it from further
-     * processing in the templateParser while maintaining the line-count
-     * of the template string for the exception handler to reference to.
-     *
-     * @todo It should be evaluated if this is really necessary. If it is, it should
-     *       be moved to a separate TemplateProcessor (which would be a breaking change)
-     */
-    public function replaceCdataSectionsByEmptyLines(string $templateSource): string
-    {
-        $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
-
-        $balance = 0;
-        foreach ($parts as $index => $part) {
-            if ($part === '<![CDATA[') {
-                $balance++;
-            }
-            if ($balance > 0) {
-                $parts[$index] = str_repeat(PHP_EOL, substr_count($part, PHP_EOL));
-            }
-            if ($part === ']]>') {
-                $balance--;
-            }
-        }
-
-        return implode('', $parts);
     }
 
     /**

--- a/tests/Functional/Core/Parser/CDataTest.php
+++ b/tests/Functional/Core/Parser/CDataTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class CDataTest extends AbstractFunctionalTestCase
+{
+    public static function handleCdataInTemplateDataProvider(): array
+    {
+        return [
+            'simple string' => [
+                'some content <![CDATA[some content within cdata]]> more content',
+                [],
+                'some content <![CDATA[some content within cdata]]> more content',
+            ],
+            'ViewHelper tag syntax' => [
+                'some content <![CDATA[<f:format.trim>  some content within cdata  </f:format.trim>]]> more content',
+                [],
+                'some content <![CDATA[<f:format.trim>  some content within cdata  </f:format.trim>]]> more content',
+            ],
+            'ViewHelper inline syntax' => [
+                'some content <![CDATA[{f:format.trim(value: \'  some content within cdata  \')}]]> more content',
+                [],
+                'some content <![CDATA[some content within cdata]]> more content',
+            ],
+            'undefined variable' => [
+                'some content <![CDATA[some {content} within cdata]]> more content',
+                [],
+                'some content <![CDATA[some  within cdata]]> more content',
+            ],
+            'defined variable' => [
+                'some content <![CDATA[some {content} within cdata]]> more content',
+                ['content' => 'content'],
+                'some content <![CDATA[some content within cdata]]> more content',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('handleCdataInTemplateDataProvider')]
+    public function handleCdataInTemplate(string $template, array $variables, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+    }
+}


### PR DESCRIPTION
The removal of all CDATA sections was introduced with 978071f without any clear indication why this was done. The consequence now is that there is no longer a "parser stop marker", for example for inline CSS interfering with Fluid's inline syntax.

Later, this was documented as a "solution" to hide invalid Fluid syntax from the Fluid parser, for example during development. Since `<f:comment>` now works correctly for invalid Fluid, this patch removes the code responsible for removing the CDATA sections from templates. This is a breaking change because templates might have used `CDATA` in the past to comment out code.

Resolves: #1012