### PR TITLE
[!!!][TASK] Remove wildly unknown VH namespace syntax

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -62,3 +62,4 @@ Changelog 5.x
   has been removed.
 * Breaking: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper->registerTagAttribute()`
   has been removed.
+* Breaking: Using the `xmlns` namespace syntax with a PHP namespace instead of an url is no longer possible.


### PR DESCRIPTION
Remove this namespace syntax variant:

```
<html xmlns:my="Vendor\MyPackage\ViewHelpers" data-namespace-typo3-fluid="true">
```

These are kept:

```
{namespace my=Vendor\MyPackage\ViewHelpers}

<html xmlns:my="http://typo3.org/ns/Vendor/MyPackage/ViewHelpers" data-namespace-typo3-fluid="true">
```

Related: #1079