### PR TITLE
[BUGFIX] Fix  path access in `ChainedVariableProvider::get` (#1165)

### DIFF
--- a/src/Core/Variables/ChainedVariableProvider.php
+++ b/src/Core/Variables/ChainedVariableProvider.php
@@ -41,24 +41,11 @@ class ChainedVariableProvider extends StandardVariableProvider implements Variab
         return array_merge($merged, $this->variables);
     }
 
-    public function get(string $identifier): mixed
-    {
-        if (array_key_exists($identifier, $this->variables)) {
-            return $this->variables[$identifier];
-        }
-        foreach ($this->variableProviders as $provider) {
-            $value = $provider->get($identifier);
-            if ($value !== null) {
-                return $value;
-            }
-        }
-        return null;
-    }
-
     public function getByPath(string $path): mixed
     {
-        if (array_key_exists($path, $this->variables)) {
-            return $this->variables[$path];
+        $result = parent::getByPath($path);
+        if ($result !== null) {
+            return $result;
         }
         // We did not resolve with native StandardVariableProvider. Let's try the chain.
         foreach ($this->variableProviders as $provider) {

--- a/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/ChainedVariableProviderTest.php
@@ -19,7 +19,7 @@ final class ChainedVariableProviderTest extends TestCase
 {
     public static function getGetTestValues(): array
     {
-        $a = new StandardVariableProvider(['a' => 'a']);
+        $a = new StandardVariableProvider(['a' => 'a', 'c' => ['c'], 'd' => ['dk' => 'dv']]);
         $b = new StandardVariableProvider(['a' => 'b', 'b' => 'b']);
         return [
             [['a' => 'local'], [$a, $b], 'a', 'local'],
@@ -27,13 +27,22 @@ final class ChainedVariableProviderTest extends TestCase
             [[], [$a, $b], 'b', 'b'],
             [[], [$b, $a], 'a', 'b'],
             [[], [$b, $a], 'b', 'b'],
+            [[], [$a, $b], 'c', [0 => 'c']],
+            [[], [$a, $b], 'c.0', 'c'],
+            [[], [$a, $b], 'd', ['dk' => 'dv']],
+            [[], [$a, $b], 'd.dk', 'dv'],
+            [['e' => 'e'], [$a, $b], 'a', 'a'],
+            [['e' => 'e'], [$a, $b], 'e', 'e'],
+            [['f' => ['f']], [$a, $b], 'f', ['f']],
+            [['g' => ['g']], [$a, $b], 'g.0', 'g'],
+            [['h' => ['hk' => 'hv']], [$a, $b], 'h.hk', 'hv'],
             [[], [$b, $a], 'notfound', null],
         ];
     }
 
     #[DataProvider('getGetTestValues')]
     #[Test]
-    public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, ?string $expected): void
+    public function getReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, null|string|array $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
         $subject->setSource($local);
@@ -42,7 +51,7 @@ final class ChainedVariableProviderTest extends TestCase
 
     #[DataProvider('getGetTestValues')]
     #[Test]
-    public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, ?string $expected): void
+    public function getByPathReturnsPreviouslySetSourceVariables(array $local, array $chain, string $path, null|string|array $expected): void
     {
         $subject = new ChainedVariableProvider($chain);
         $subject->setSource($local);


### PR DESCRIPTION
Removed the `get` method entirely and enhanced `getByPath` to handle both local variables and chain traversal.
Updated tests to cover the new behavior, improving test robustness by adding cases for nested and array-based paths.

Resolves: #1164