### PR TITLE
[TASK] Remove micro-optimization from HtmlspecialcharsViewHelper

### DIFF
--- a/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
+++ b/src/ViewHelpers/Format/HtmlspecialcharsViewHelper.php
@@ -7,8 +7,6 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
-use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 /**
@@ -88,27 +86,5 @@ class HtmlspecialcharsViewHelper extends AbstractViewHelper
         $flags = $keepQuotes ? ENT_NOQUOTES : ENT_QUOTES;
 
         return htmlspecialchars($value, $flags, $encoding, $doubleEncode);
-    }
-
-    /**
-     * This ViewHelper is used a *lot* because it is used by the escape interceptor.
-     * Therefore we render it to raw PHP code during compilation
-     *
-     * @param string $argumentsName
-     * @param string $closureName
-     * @param string $initializationPhpCode
-     * @param ViewHelperNode $node
-     * @param TemplateCompiler $compiler
-     */
-    public function compile($argumentsName, $closureName, &$initializationPhpCode, ViewHelperNode $node, TemplateCompiler $compiler): string
-    {
-        $valueVariableName = $compiler->variableName('value');
-        $initializationPhpCode .= sprintf('%1$s = (%2$s[\'value\'] !== null ? %2$s[\'value\'] : %3$s());', $valueVariableName, $argumentsName, $closureName) . chr(10);
-
-        return sprintf(
-            '!is_string(%1$s) && !(is_object(%1$s) && method_exists(%1$s, \'__toString\')) ? %1$s : htmlspecialchars(%1$s, (%2$s[\'keepQuotes\'] ? ENT_NOQUOTES : ENT_QUOTES), %2$s[\'encoding\'], %2$s[\'doubleEncode\'])',
-            $valueVariableName,
-            $argumentsName,
-        );
     }
 }


### PR DESCRIPTION
In #1151, it was already clarified that the `HtmlspecialcharsViewHelper`
is in fact not used internally by Fluid. This means that we can also
get rid of the custom compilation logic, which makes maintainance
unnecessarily hard.