### PR TITLE
[BUGFIX] Call proper API to obtain ViewHelper API

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -290,7 +290,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     {
         // @todo move to ViewHelperInvoker and make configurable with Fluid v5
         $argumentProcessor = new LenientArgumentProcessor();
-        $argumentDefinitions = $this->prepareArguments();
+        $argumentDefinitions = $this->renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($this);
         foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
             // Note: This relies on the TemplateParser to check for missing required arguments
             if ($this->hasArgument($argumentName)) {


### PR DESCRIPTION
Currently, the ViewHelper validation API calls the internal ViewHelper API to obtain its argument definitions for validation. However, the proper way is to use the `ViewHelperResolver`, since it is possible to redefine certain argument definitions there.

This is demonstrated and tested by the `CustomViewHelperResolver` in the examples. However, this example only worked until now because of the lenient validation implementation of ViewHelpers.