### PR TITLE
[!!!][FEATURE] Ability to replace argument processor

### DIFF
--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -24,6 +24,8 @@ use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\RemoveCommentsTemplateProcess
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentProcessorInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
@@ -63,6 +65,8 @@ class RenderingContext implements RenderingContextInterface
      * @var ViewHelperInvoker
      */
     protected $viewHelperInvoker;
+
+    protected ArgumentProcessorInterface $argumentProcessor;
 
     /**
      * @var TemplatePaths
@@ -146,6 +150,7 @@ class RenderingContext implements RenderingContextInterface
         );
         $this->setViewHelperResolver(new ViewHelperResolver());
         $this->setViewHelperInvoker(new ViewHelperInvoker());
+        $this->setArgumentProcessor(new StrictArgumentProcessor());
         $this->setViewHelperVariableContainer(new ViewHelperVariableContainer());
         $this->setVariableProvider(new StandardVariableProvider());
     }
@@ -217,6 +222,16 @@ class RenderingContext implements RenderingContextInterface
     public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker)
     {
         $this->viewHelperInvoker = $viewHelperInvoker;
+    }
+
+    public function getArgumentProcessor(): ArgumentProcessorInterface
+    {
+        return $this->argumentProcessor;
+    }
+
+    public function setArgumentProcessor(ArgumentProcessorInterface $argumentProcessor): void
+    {
+        $this->argumentProcessor = $argumentProcessor;
     }
 
     /**

--- a/src/Core/Rendering/RenderingContextInterface.php
+++ b/src/Core/Rendering/RenderingContextInterface.php
@@ -14,6 +14,7 @@ use TYPO3Fluid\Fluid\Core\Parser\Configuration;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateParser;
 use TYPO3Fluid\Fluid\Core\Parser\TemplateProcessorInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentProcessorInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInvoker;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
@@ -81,6 +82,10 @@ interface RenderingContextInterface
      * @param ViewHelperInvoker $viewHelperInvoker
      */
     public function setViewHelperInvoker(ViewHelperInvoker $viewHelperInvoker);
+
+    public function getArgumentProcessor(): ArgumentProcessorInterface;
+
+    public function setArgumentProcessor(ArgumentProcessorInterface $argumentProcessor): void;
 
     /**
      * Inject the Template Parser

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -296,8 +296,8 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      */
     public function validateArguments()
     {
-        // @todo move to ViewHelperInvoker and make configurable with Fluid v5
-        $argumentProcessor = new StrictArgumentProcessor();
+        // @todo move to ViewHelperInvoker with Fluid v5
+        $argumentProcessor = $this->renderingContext->getArgumentProcessor();
         $argumentDefinitions = $this->renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($this);
         foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
             // Note: This relies on the TemplateParser to check for missing required arguments

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -46,8 +46,6 @@ class ViewHelperInvoker
         }
         $argumentDefinitions = $viewHelperResolver->getArgumentDefinitionsForViewHelper($viewHelper);
 
-        // @todo make configurable with Fluid v5
-        $argumentProcessor = new StrictArgumentProcessor();
         try {
             // Convert nodes to actual values (in uncached context)
             $arguments = array_map(
@@ -60,7 +58,7 @@ class ViewHelperInvoker
             foreach ($argumentDefinitions as $argumentName => $argumentDefinition) {
                 // @todo also perform argument validation here with Fluid v5, including check for required arguments
                 $registeredArguments[$argumentName] = isset($arguments[$argumentName])
-                    ? $argumentProcessor->process($arguments[$argumentName], $argumentDefinition)
+                    ? $renderingContext->getArgumentProcessor()->process($arguments[$argumentName], $argumentDefinition)
                     : $argumentDefinition->getDefaultValue();
                 unset($arguments[$argumentName]);
             }

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -17,7 +17,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentProcessorInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
@@ -146,11 +145,10 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
         if (!$parsedTemplate->hasLayout()) {
             $this->startRendering(self::RENDERING_TEMPLATE, $parsedTemplate, $templateRenderingContext);
             try {
-                // @todo make argument processor configurable with Fluid v5
                 $this->processAndValidateTemplateVariables(
                     $parsedTemplate,
                     $templateRenderingContext->getVariableProvider(),
-                    new StrictArgumentProcessor(),
+                    $templateRenderingContext->getArgumentProcessor(),
                 );
             } catch (Exception $validationError) {
                 return $templateRenderingContext->getErrorHandler()->handleViewError($validationError);
@@ -175,11 +173,10 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
             }
             $this->startRendering(self::RENDERING_LAYOUT, $parsedTemplate, $layoutRenderingContext);
             try {
-                // @todo make argument processor configurable with Fluid v5
                 $this->processAndValidateTemplateVariables(
                     $parsedLayout,
                     $layoutRenderingContext->getVariableProvider(),
-                    new StrictArgumentProcessor(),
+                    $layoutRenderingContext->getArgumentProcessor(),
                 );
             } catch (Exception $validationError) {
                 return $layoutRenderingContext->getErrorHandler()->handleViewError($validationError);
@@ -317,11 +314,10 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
             $output = $this->renderSection($sectionName, $variables, $ignoreUnknown);
         } else {
             try {
-                // @todo make argument processor configurable with Fluid v5
                 $this->processAndValidateTemplateVariables(
                     $parsedPartial,
                     $renderingContext->getVariableProvider(),
-                    new StrictArgumentProcessor(),
+                    $renderingContext->getArgumentProcessor(),
                 );
             } catch (Exception $validationError) {
                 return $renderingContext->getErrorHandler()->handleViewError($validationError);


### PR DESCRIPTION
This patch introduces new API methods on the `RenderingContext` to
obtain and replace Fluid's argument processor implementation. By
default, the `StrictArgumentProcessor` is used, but the
`ArgumentProcessorInterface` exists to provide an alternative
implementation. However, it might be a good idea wrap custom
implementations around the `StrictArgumentProcessor` by using
the decorator design pattern to ensure valid input types
to ViewHelpers and components.

Resolves: #1105 