### PR TITLE
[TASK] Avoid PHP 8.5 deprecation \SplObjectStorage->attach()

### DIFF
--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -136,9 +136,9 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
 
         $value = new \SplObjectStorage();
         $object1 = new \stdClass();
-        $value->attach($object1);
+        $value->offsetSet($object1);
         $object2 = new \stdClass();
-        $value->attach($object2, 'foo');
+        $value->offsetSet($object2, 'foo');
         $object3 = new \stdClass();
         $value->offsetSet($object3, 'bar');
         yield 'keys are a numerical index with objects of type SplObjectStorage' => [


### PR DESCRIPTION
Use alias offsetSet() instead: "The SplObjectStorage::contains(), SplObjectStorage::attach(), and SplObjectStorage::detach() methods have been deprecated in favour of SplObjectStorage::offsetExists(), SplObjectStorage::offsetSet(), and SplObjectStorage::offsetUnset() respectively."

Releases: main, 4.5