### PR TITLE
[FEATURE] Introduce ViewHelperArgumentsValidated event (#1200)

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -11,6 +11,11 @@ Changelog 4.x
 
 * Deprecation: Using the `xmlns` namespace syntax with a PHP namespace instead of an url is deprecated
   and will no longer work in Fluid v5.
+* Deprecation: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::validateArguments()`
+  has been marked as deprecated and will be removed in Fluid v5.
+* Deprecation: Custom implementations of the `validateArguments()` methods in ViewHelpers will no longer
+  be called in Fluid v5. Use :php:`TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperArgumentsValidatedEventInterface`
+  instead.
 * Deprecation: Classes, interfaces, methods and constants related to cache warmup are deprecated and will be removed in Fluid v5:
     * :php:`TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface::getCacheWarmer()`
     * :php: `TYPO3Fluid\Fluid\Core\Cache\SimpleFileCache::getCacheWarmer()`

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -210,6 +210,13 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     public function initializeArgumentsAndRender()
     {
         $this->validateArguments();
+        if ($this instanceof ViewHelperArgumentsValidatedEventInterface) {
+            $this::argumentsValidatedEvent(
+                $this->arguments,
+                $this->renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($this),
+                $this,
+            );
+        }
         $this->initialize();
 
         return $this->render();
@@ -285,6 +292,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * Validate arguments, and throw exception if arguments do not validate.
      *
      * @throws \InvalidArgumentException
+     * @deprecated Will be removed in v5. Use the new ViewHelperArgumentsValidatedEventInterface to add custom validation logic
      */
     public function validateArguments()
     {

--- a/src/Core/ViewHelper/ViewHelperArgumentsValidatedEventInterface.php
+++ b/src/Core/ViewHelper/ViewHelperArgumentsValidatedEventInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+interface ViewHelperArgumentsValidatedEventInterface
+{
+    /**
+     * Event method that is called after all ViewHelper argument validation has
+     * been performed (and no exception has been thrown by the built-in validation).
+     * This can be used to implement additional validation logic for ViewHelper
+     * arguments, such as "either arg1 needs to be specified or arg2 AND arg3"
+     * and to throw an InvalidArgumentException if that is not the case.
+     *
+     * @param array<string, mixed> $arguments
+     * @param ArgumentDefinition[] $argumentDefinitions
+     * @throws \InvalidArgumentException
+     */
+    public static function argumentsValidatedEvent(array $arguments, array $argumentDefinitions, ViewHelperInterface $viewHelper): void;
+}

--- a/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -27,5 +28,46 @@ final class ViewHelperEventsTest extends AbstractFunctionalTestCase
         $view->render();
 
         // No second execution here because event only triggers for uncached templates
+    }
+
+    public static function argumentsValidatedEventDataProvider(): array
+    {
+        return [
+            ['<test:customValidation arg1="foo" />', 'foo||'],
+            ['<test:customValidation arg2="foo" arg3="bar" />', '|foo|bar'],
+            ['<test:customValidation arg1="foo" arg2="bar" arg3="baz" />', 'foo|bar|baz'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('argumentsValidatedEventDataProvider')]
+    public function argumentsValidatedEvent(string $template, string $expectedOutput): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertEquals($expectedOutput, $view->render());
+    }
+
+    public static function argumentsValidatedEventThrowsExceptionDataProvider(): array
+    {
+        return [
+            ['<test:customValidation />'],
+            ['<test:customValidation arg2="foo" />'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('argumentsValidatedEventThrowsExceptionDataProvider')]
+    public function argumentsValidatedEventThrowsException(string $template): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionCode(1755274666);
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $view->render();
     }
 }

--- a/tests/Functional/Fixtures/ViewHelpers/CustomValidationViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CustomValidationViewHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperArgumentsValidatedEventInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+
+final class CustomValidationViewHelper extends AbstractViewHelper implements ViewHelperArgumentsValidatedEventInterface
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('arg1', 'string', '');
+        $this->registerArgument('arg2', 'string', '');
+        $this->registerArgument('arg3', 'string', '');
+    }
+
+    public function render(): string
+    {
+        return $this->arguments['arg1'] . '|' . $this->arguments['arg2'] . '|' . $this->arguments['arg3'];
+    }
+
+    public static function argumentsValidatedEvent(array $arguments, array $argumentDefinitions, ViewHelperInterface $viewHelper): void
+    {
+        if (!isset($arguments['arg1']) && (!isset($arguments['arg2']) || !isset($arguments['arg3']))) {
+            throw new \InvalidArgumentException('ViewHelper must either be called with arg1 or with both arg2 and arg3.', 1755274666);
+        }
+    }
+}


### PR DESCRIPTION
The current implementation of `AbstractViewHelper` includes Fluid's validation logic for ViewHelper arguments in the public method `validateArguments()`. This method is called internally by each ViewHelper in `initializeArgumentsAndRender()`, just before initialization and rendering of the ViewHelper. It is currently possible to overwrite this method to implement custom argument validation logic per ViewHelper implementation.

With Fluid v5, we want to centralize Fluid's internal validation logic in `ViewHelperInvoker`. Thus, the existing public method `validateArguments()` is now deprecated and will no longer be called in Fluid v5.

However, there are some valid use cases to extend the default validation per ViewHelper. This patch introduces a new interface that can be used to hook into Fluid's ViewHelper rendering process and to trigger custom validation steps after the internal validation has been completed successfully. This should allow users that previously overrode `validateArguments()` to move their custom logic to the new event.