### PR TITLE
[!!!][TASK] Accumulate validation code in ViewHelperInvoker

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -83,6 +83,9 @@ Changelog 5.x
   allow `null` as template identifier.
 * Breaking: Tag attributes that are set to `null` are now removed from the tag instead of being
   interpreted as empty string in :php:`TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder`.
+* Breaking: Method :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper::validateArguments()`
+  has been removed.
+* Breaking: Custom implementations of the `validateArguments()` methods in ViewHelpers are no longer called.
 * Deprecation: Class :php:`TYPO3Fluid\Fluid\Core\ViewHelper\LenientArgumentProcessor`
   is no longer being used by Fluid v5 and will be removed with Fluid v6.
 

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -209,16 +209,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      */
     public function initializeArgumentsAndRender()
     {
-        $this->validateArguments();
-        if ($this instanceof ViewHelperArgumentsValidatedEventInterface) {
-            $this::argumentsValidatedEvent(
-                $this->arguments,
-                $this->renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($this),
-                $this,
-            );
-        }
         $this->initialize();
-
         return $this->render();
     }
 
@@ -286,33 +277,6 @@ abstract class AbstractViewHelper implements ViewHelperInterface
             self::$argumentDefinitionCache[$thisClassName] = $this->argumentDefinitions;
         }
         return $this->argumentDefinitions;
-    }
-
-    /**
-     * Validate arguments, and throw exception if arguments do not validate.
-     *
-     * @throws \InvalidArgumentException
-     * @deprecated Will be removed in v5. Use the new ViewHelperArgumentsValidatedEventInterface to add custom validation logic
-     */
-    public function validateArguments()
-    {
-        // @todo move to ViewHelperInvoker with Fluid v5
-        $argumentProcessor = $this->renderingContext->getArgumentProcessor();
-        $argumentDefinitions = $this->renderingContext->getViewHelperResolver()->getArgumentDefinitionsForViewHelper($this);
-        foreach ($argumentDefinitions as $argumentName => $registeredArgument) {
-            // Note: This relies on the TemplateParser to check for missing required arguments
-            if ($this->hasArgument($argumentName)) {
-                $value = $this->arguments[$argumentName];
-                if (!$argumentProcessor->isValid($value, $registeredArgument)) {
-                    $givenType = is_object($value) ? get_class($value) : gettype($value);
-                    throw new \InvalidArgumentException(
-                        'The argument "' . $argumentName . '" was registered with type "' . $registeredArgument->getType() . '", but is of type "'
-                        . $givenType . '" in view helper "' . get_class($this) . '".',
-                        1256475113,
-                    );
-                }
-            }
-        }
     }
 
     /**

--- a/tests/Functional/Core/Component/ComponentRenderingTest.php
+++ b/tests/Functional/Core/Component/ComponentRenderingTest.php
@@ -82,31 +82,20 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
         self::assertSame($expected, $view->render(), 'cached');
     }
 
-    public static function basicComponentCollectionValidatesArgumentsDataProvider(): iterable
+    public static function basicComponentCollectionValidatesArgumentsCachedDataProvider(): iterable
     {
         return [
             'missing required argument' => ['<my:testComponent />', 1237823699],
             'additional argument not allowed' => ['<my:testComponent title="TITLE" foo="bar" />', 1748903732],
-            'invalid type' => ['<my:testComponent title="TITLE" tags="test" />', 1746637333],
+            'invalid type' => ['<my:testComponent title="TITLE" tags="test" />', 1746637333], // different exception code between uncached and cached
             'invalid component' => ['<my:nonexistentComponent />', 1407060572],
             'fragments nested in other viewhelpers' => ['<my:namedSlots><f:if condition="1 == 0"><f:fragment>foo</f:fragment></f:if></my:namedSlots>', 1750865702],
         ];
     }
 
-    public static function basicComponentCollectionValidatesArgumentsUncachedDataProvider(): iterable
-    {
-        return [
-            // Some detail validations can only be performed for uncached templates because
-            // the required information is no longer reproducible from the cache
-            'duplicate fragment' => ['<my:namedSlots><f:fragment name="test1">foo</f:fragment><f:fragment name="test1">bar</f:fragment></my:namedSlots>', 1750865701],
-            'duplicate default fragment' => ['<my:namedSlots><f:fragment>foo</f:fragment><f:fragment>bar</f:fragment></my:namedSlots>', 1750865701],
-        ];
-    }
-
     #[Test]
-    #[DataProvider('basicComponentCollectionValidatesArgumentsDataProvider')]
     #[DataProvider('basicComponentCollectionValidatesArgumentsUncachedDataProvider')]
-    public function basicComponentCollectionValidatesArguments(string $source, int $expectedExceptionCode): void
+    public function basicComponentCollectionValidatesArgumentsUncached(string $source, int $expectedExceptionCode): void
     {
         self::expectExceptionCode($expectedExceptionCode);
 
@@ -117,8 +106,23 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
         $view->render();
     }
 
+    public static function basicComponentCollectionValidatesArgumentsUncachedDataProvider(): iterable
+    {
+        return [
+            'missing required argument' => ['<my:testComponent />', 1237823699],
+            'additional argument not allowed' => ['<my:testComponent title="TITLE" foo="bar" />', 1748903732],
+            'invalid type' => ['<my:testComponent title="TITLE" tags="test" />', 1256475113], // different exception code between uncached and cached
+            'invalid component' => ['<my:nonexistentComponent />', 1407060572],
+            'fragments nested in other viewhelpers' => ['<my:namedSlots><f:if condition="1 == 0"><f:fragment>foo</f:fragment></f:if></my:namedSlots>', 1750865702],
+            // Some detail validations can only be performed for uncached templates because
+            // the required information is no longer reproducible from the cache
+            'duplicate fragment' => ['<my:namedSlots><f:fragment name="test1">foo</f:fragment><f:fragment name="test1">bar</f:fragment></my:namedSlots>', 1750865701],
+            'duplicate default fragment' => ['<my:namedSlots><f:fragment>foo</f:fragment><f:fragment>bar</f:fragment></my:namedSlots>', 1750865701],
+        ];
+    }
+
     #[Test]
-    #[DataProvider('basicComponentCollectionValidatesArgumentsDataProvider')]
+    #[DataProvider('basicComponentCollectionValidatesArgumentsCachedDataProvider')]
     public function basicComponentCollectionValidatesArgumentsCached(string $source, int $expectedExceptionCode): void
     {
         self::expectExceptionCode($expectedExceptionCode);


### PR DESCRIPTION
Because of deprecations and other prerequisites in v4, we are now
able to accumulate all ViewHelper-related validation code in
`ViewHelperInvoker`.