### PR TITLE
[!!!][TASK] Add type declarations to ViewHelper classes

### DIFF
--- a/examples/src/ViewHelper/CustomViewHelper.php
+++ b/examples/src/ViewHelper/CustomViewHelper.php
@@ -34,15 +34,12 @@ class CustomViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('page', 'string', 'An arbitrary page identifier', true);
     }
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         return 'The following is a dump of the "page"' . PHP_EOL
             . 'Argument passed to CustomViewHelper:' . PHP_EOL

--- a/examples/src/ViewHelper/Nested/CustomViewHelper.php
+++ b/examples/src/ViewHelper/Nested/CustomViewHelper.php
@@ -34,15 +34,12 @@ class CustomViewHelper extends AbstractViewHelper
      */
     protected $escapeOutput = false;
 
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('page', 'string', 'An arbitrary page identifier', true);
     }
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         return 'The following is a dump of the "page"' . PHP_EOL
             . 'Argument passed to CustomViewHelper:' . PHP_EOL

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,24 +37,6 @@ parameters:
 			path: src/Core/Variables/JSONVariableProvider.php
 
 		-
-			message: '#^Call to TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) on a separate line has no effect\.$#'
-			identifier: staticMethod.resultUnused
-			count: 1
-			path: src/Core/ViewHelper/AbstractTagBasedViewHelper.php
-
-		-
-			message: '#^Call to TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:initialize\(\) on a separate line has no effect\.$#'
-			identifier: staticMethod.resultUnused
-			count: 1
-			path: src/Core/ViewHelper/AbstractTagBasedViewHelper.php
-
-		-
-			message: '#^Method TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) has TYPO3Fluid\\Fluid\\Core\\ViewHelper\\Exception in PHPDoc @throws tag but it''s not thrown\.$#'
-			identifier: throws.unusedType
-			count: 1
-			path: src/Core/ViewHelper/AbstractViewHelper.php
-
-		-
 			message: '#^Parameter \#1 \$array of function array_unique expects an array of values castable to string, array\<array\<string\>\|string\> given\.$#'
 			identifier: argument.type
 			count: 2
@@ -71,9 +53,3 @@ parameters:
 			identifier: deadCode.unreachable
 			count: 1
 			path: tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php
-
-		-
-			message: '#^Call to TYPO3Fluid\\Fluid\\Core\\ViewHelper\\AbstractViewHelper\:\:handleAdditionalArguments\(\) on a separate line has no effect\.$#'
-			identifier: staticMethod.resultUnused
-			count: 1
-			path: tests/Unit/Core/Fixtures/TestViewHelper.php

--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -29,7 +29,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * @see \TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper for a more detailed explanation and a simple usage example.
  *
  * @api
- * @todo add missing types with Fluid v5
  */
 abstract class AbstractConditionViewHelper extends AbstractViewHelper
 {
@@ -46,7 +45,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
     /**
      * Initializes the "then" and "else" arguments
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false, null, true);
         $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false, null, true);
@@ -55,10 +54,9 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
     /**
      * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
      *
-     * @return mixed
      * @api
      */
-    public function render()
+    public function render(): mixed
     {
         if (static::verdict($this->arguments, $this->renderingContext)) {
             return $this->renderThenChild();
@@ -72,10 +70,8 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * to override and implement.
      *
      * @param array<string, mixed> $arguments
-     * @param RenderingContextInterface $renderingContext
-     * @return bool
      */
-    public static function verdict(array $arguments, RenderingContextInterface $renderingContext)
+    public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
         return isset($arguments['condition']) && (bool)($arguments['condition']);
     }
@@ -88,7 +84,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * @return mixed rendered ThenViewHelper or contents of <f:if> if no ThenViewHelper was found
      * @api
      */
-    protected function renderThenChild()
+    protected function renderThenChild(): mixed
     {
         // In cached templates, a closure is defined if any variant of "then" has been specified
         if ($this->thenClosure !== null) {
@@ -151,7 +147,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * @return mixed rendered ElseViewHelper or null if no ThenViewHelper was found
      * @api
      */
-    protected function renderElseChild()
+    protected function renderElseChild(): mixed
     {
         // Closures are present if ViewHelper is called from a cached template
         if ($this->elseIfClosures !== []) {

--- a/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
+++ b/src/Core/ViewHelper/AbstractTagBasedViewHelper.php
@@ -13,7 +13,6 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  * convenience methods to register default attributes, ...
  *
  * @api
- * @todo add missing types with Fluid v5
  */
 abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
 {
@@ -27,10 +26,9 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     /**
      * Tag builder instance
      *
-     * @var TagBuilder
      * @api
      */
-    protected $tag;
+    protected TagBuilder $tag;
 
     /**
      * Name of the tag to be created by this view helper
@@ -44,9 +42,9 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      * Arguments which are valid but do not have an ArgumentDefinition, e.g.
      * data- prefixed arguments.
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    protected $additionalArguments = [];
+    protected array $additionalArguments = [];
 
     /**
      * Constructor
@@ -59,7 +57,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
     /**
      * @param TagBuilder $tag
      */
-    public function setTagBuilder(TagBuilder $tag)
+    public function setTagBuilder(TagBuilder $tag): void
     {
         $this->tag = $tag;
         $this->tag->setTagName($this->tagName);
@@ -70,7 +68,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      *
      * @api
      */
-    public function initializeArguments()
+    public function initializeArguments(): void
     {
         $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.');
         $this->registerArgument('data', 'array', 'Additional data-* attributes. They will each be added with a "data-" prefix.');
@@ -86,7 +84,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
      *
      * @api
      */
-    public function initialize()
+    public function initialize(): void
     {
         parent::initialize();
         $this->tag->reset();
@@ -118,7 +116,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
         }
     }
 
-    public function handleAdditionalArguments(array $arguments)
+    public function handleAdditionalArguments(array $arguments): void
     {
         $this->additionalArguments = $arguments;
         parent::handleAdditionalArguments($arguments);
@@ -129,10 +127,7 @@ abstract class AbstractTagBasedViewHelper extends AbstractViewHelper
         // Skip validation of additional arguments since we want to pass all arguments to the tag
     }
 
-    /**
-     * @return string
-     */
-    public function render()
+    public function render(): string
     {
         return $this->tag->render();
     }

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -8,7 +8,6 @@
 namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -24,35 +23,34 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *           in the AbstractViewHelper and maintained.
  *           We'll try to resolve this restriction midterm, but you should
  *           not fully implement ViewHelperInterface yourself for now.
- * @todo add missing types with Fluid v5
  */
 interface ViewHelperInterface
 {
     /**
      * @return ArgumentDefinition[]
      */
-    public function prepareArguments();
+    public function prepareArguments(): array;
 
     /**
      * @param array<string, mixed> $arguments
      */
-    public function setArguments(array $arguments);
+    public function setArguments(array $arguments): void;
 
     public function getContentArgumentName(): ?string;
 
-    public function setViewHelperNode(ViewHelperNode $node);
+    public function setViewHelperNode(ViewHelperNode $node): void;
 
     /**
      * @param RenderingContextInterface $renderingContext
      */
-    public function setRenderingContext(RenderingContextInterface $renderingContext);
+    public function setRenderingContext(RenderingContextInterface $renderingContext): void;
 
     /**
      * Initialize the arguments of the ViewHelper, and call the render() method of the ViewHelper.
      *
      * @return mixed the rendered ViewHelper.
      */
-    public function initializeArgumentsAndRender();
+    public function initializeArgumentsAndRender(): mixed;
 
     /**
      * Method which can be implemented in any ViewHelper if that ViewHelper desires
@@ -61,7 +59,7 @@ interface ViewHelperInterface
      *
      * @param array<string, mixed> $arguments
      */
-    public function handleAdditionalArguments(array $arguments);
+    public function handleAdditionalArguments(array $arguments): void;
 
     /**
      * Method which can be implemented in any ViewHelper if that ViewHelper desires
@@ -70,14 +68,12 @@ interface ViewHelperInterface
      *
      * @param array<string, mixed> $arguments
      */
-    public function validateAdditionalArguments(array $arguments);
+    public function validateAdditionalArguments(array $arguments): void;
 
     /**
      * Called when being inside a cached template.
-     *
-     * @param \Closure $renderChildrenClosure
      */
-    public function setRenderChildrenClosure(\Closure $renderChildrenClosure);
+    public function setRenderChildrenClosure(\Closure $renderChildrenClosure): void;
 
     /**
      * Main method called at compile time to turn this ViewHelper
@@ -104,13 +100,7 @@ interface ViewHelperInterface
      */
     public function convert(TemplateCompiler $templateCompiler): array;
 
-    /**
-     * @return bool
-     */
-    public function isChildrenEscapingEnabled();
+    public function isChildrenEscapingEnabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isOutputEscapingEnabled();
+    public function isOutputEscapingEnabled(): bool;
 }

--- a/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/MutableTestViewHelper.php
@@ -32,7 +32,7 @@ final class MutableTestViewHelper extends AbstractViewHelper
         $this->escapeOutput = $escapeOutput;
     }
 
-    public function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escaped = null): AbstractViewHelper
+    public function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escaped = null): static
     {
         return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escaped);
     }


### PR DESCRIPTION
Type declarations are added to all ViewHelper methods as well as
all properties that are considered internal and are most likely not
redefined directly by a ViewHelper implementation. Three properties
are left out intentionally, since they are currently part of the
ViewHelper API:

* `AbstractViewHelper::$escapeOutput`
* `AbstractViewHelper::$escapeChildren`
* `AbstractTagBasedViewHelper::$tagName`

Adding type declarations to those properties would make it impossible
to create ViewHelpers that are compatible with Fluid v4 and v5.