### PR TITLE
[BUGFIX] Allow NULL for optional arguments with default

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -51,7 +51,7 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
         }
 
         // Always allow default value if argument is not required
-        if (!$definition->isRequired() && $value === $definition->getDefaultValue()) {
+        if (!$definition->isRequired() && ($value === null || $value === $definition->getDefaultValue())) {
             return true;
         }
 


### PR DESCRIPTION
If a component or ViewHelper argument is not required and is not
supplied in the ViewHelper call, Fluid takes care of filling in the
default value. But this also happens if the argument is supplied and
is set to `NULL`. This usually happens if an undefined variable is
provided to the ViewHelper. For ViewHelpers this is done by the
`ViewHelperInvoker`, for components in
`AbstractTemplateView::processAndValidateTemplateVariables()`.

The current implementation of `StrictArgumentProcessor` prevents the
fallback from happening if the argument is supplied, but with `NULL`
as value. This patch adjusts the `StrictArgumentProcessor` to also
pass `NULL` values through.