### PR TITLE
[!!!][TASK] Disallow variables that start with a "_"

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -82,6 +82,9 @@ class StandardVariableProvider implements VariableProviderInterface
         if (in_array(strtolower($identifier), $this->disallowedIdentifiers)) {
             throw new InvalidVariableIdentifierException('Invalid variable identifier: ' . $identifier, 1723131119);
         }
+        if (str_starts_with($identifier, '_')) {
+            throw new InvalidVariableIdentifierException('Variable identifiers cannot start with a "_": ' . $identifier, 1756622558);
+        }
         $this->variables[$identifier] = $value;
     }
 

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -500,12 +500,25 @@ final class StandardVariableProviderTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
+    public static function exceptionIsThrownForInvalidVariableIdentifierDataProvider(): array
+    {
+        return [
+            ['true', 1723131119],
+            ['TrUe', 1723131119],
+            ['false', 1723131119],
+            ['null', 1723131119],
+            ['_all', 1723131119],
+            ['_somethingElse', 1756622558],
+        ];
+    }
+
     #[Test]
-    public function exceptionIsThrownForInvalidVariableIdentifier(): void
+    #[DataProvider('exceptionIsThrownForInvalidVariableIdentifierDataProvider')]
+    public function exceptionIsThrownForInvalidVariableIdentifier(string $identifier, int $exceptionCode): void
     {
         self::expectException(InvalidVariableIdentifierException::class);
-        self::expectExceptionCode(1723131119);
+        self::expectExceptionCode($exceptionCode);
         $subject = new StandardVariableProvider();
-        $subject->add('TrUe', false);
+        $subject->add($identifier, false);
     }
 }


### PR DESCRIPTION
[!!!][TASK] Disallow variables that start with a "_"

In preparation for the possible introduction of more internal
constants in Fluid, custom variable names that start with an
underscore are no longer allowed.

For Fluid 4, a deprecation will be introduced in a follow-up patch
to prepare template authors for the upcoming change.

Related: #1166
Related: #1041