### PR TITLE
[FEATURE] Support union types for ViewHelper and component API

### DIFF
--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -141,4 +141,9 @@ class ArgumentDefinition
     {
         return $this->getType() === 'bool' || $this->getType() === 'boolean';
     }
+
+    public function getUnionTypes(): array
+    {
+        return array_map('trim', explode('|', $this->type));
+    }
 }

--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -56,7 +56,12 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
         }
 
         // Perform type validation
-        return $this->isValidType($definition->getType(), $value);
+        foreach ($definition->getUnionTypes() as $type) {
+            if ($this->isValidType($type, $value)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/Functional/Core/Component/ComponentRenderingTest.php
+++ b/tests/Functional/Core/Component/ComponentRenderingTest.php
@@ -60,6 +60,8 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
             'recursive call of one component' => ['<f:format.trim><my:recursive counter="5" /></f:format.trim>', '54321'],
             'access to variables provided by delegate' => ['<my:additionalVariable />', "my additional value\nadditionalVariable\n"],
             'additional arguments can be provided if delegate allows' => ['<my:additionalArgumentsJson foo="bar" />', '{"foo":"bar","myAdditionalVariable":"my additional value","viewHelperName":"additionalArgumentsJson"}' . "\n"],
+            'union type, array provided' => ['<my:unionTypeArgument item="{property: \'foo\'}" />', "\nfoo\n"],
+            'union type, string provided' => ['<my:unionTypeArgument item="bar" />', "\nbar\n"],
         ];
     }
 
@@ -88,6 +90,7 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
             'missing required argument' => ['<my:testComponent />', 1237823699],
             'additional argument not allowed' => ['<my:testComponent title="TITLE" foo="bar" />', 1748903732],
             'invalid type' => ['<my:testComponent title="TITLE" tags="test" />', 1746637333],
+            'invalid union type' => ['<my:unionTypeArgument item="{true}" />', 1746637333],
             'invalid component' => ['<my:nonexistentComponent />', 1407060572],
             'fragments nested in other viewhelpers' => ['<my:namedSlots><f:if condition="1 == 0"><f:fragment>foo</f:fragment></f:if></my:namedSlots>', 1750865702],
         ];

--- a/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
@@ -158,4 +158,60 @@ final class ViewHelperArgumentTypesTest extends AbstractFunctionalTestCase
         $result = unserialize($view->render());
         self::assertSame($expectedValue, $result[$argumentName], 'cached');
     }
+
+    public static function unionTypesDataProvider(): array
+    {
+        return [
+            ['foo', 'string'],
+            [['foo'], 'array'],
+        ];
+    }
+
+    #[DataProvider('unionTypesDataProvider')]
+    #[Test]
+    public function unionTypes(mixed $argumentValue, string $expectedResult): void
+    {
+        $variables = ['argumentValue' => $argumentValue];
+        $source = '<test:unionType arg="{argumentValue}" />';
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expectedResult, $view->render(), 'uncached');
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        self::assertSame($expectedResult, $view->render(), 'cached');
+    }
+
+    public static function invalidUnionTypeThrowsExceptionDataProvider(): array
+    {
+        return [
+            [123, 1256475113],
+            [new \DateTime(), 1256475113],
+        ];
+    }
+
+    #[DataProvider('invalidUnionTypeThrowsExceptionDataProvider')]
+    #[Test]
+    public function invalidUnionTypeThrowsException(mixed $argumentValue, int $expectedExceptionCode): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionCode($expectedExceptionCode);
+
+        $variables = ['argumentValue' => $argumentValue];
+        $source = '<test:unionType arg="{argumentValue}" />';
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $view->render();
+    }
 }

--- a/tests/Functional/Fixtures/Components/UnionTypeArgument/UnionTypeArgument.html
+++ b/tests/Functional/Fixtures/Components/UnionTypeArgument/UnionTypeArgument.html
@@ -1,0 +1,2 @@
+<f:argument name="item" type="array|string" />
+{f:if(condition: item.property, then: item.property, else: item)}

--- a/tests/Functional/Fixtures/ViewHelpers/UnionTypeViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/UnionTypeViewHelper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class UnionTypeViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('arg', 'array|string', '', true);
+    }
+
+    public function render(): string
+    {
+        return gettype($this->arguments['arg']);
+    }
+}

--- a/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/LenientArgumentProcessorTest.php
@@ -128,6 +128,25 @@ final class LenientArgumentProcessorTest extends TestCase
             [new \ArrayIterator(['bar']), 'double', false],
             [new UserWithToString('foo'), 'double', false],
 
+            // Union types just get silently ignored, unless an object is supplied
+            [true, 'array|string', true],
+            [false, 'array|string', true],
+            [2, 'array|string', true],
+            [1, 'array|string', true],
+            [0, 'array|string', true],
+            [-1, 'array|string', true],
+            [1.5, 'array|string', true],
+            ['', 'array|string', true],
+            ['test', 'array|string', true],
+            [null, 'array|string', true],
+            [new stdClass(), 'array|string', false],
+            [new stdClass(), 'array|string', false],
+            [new \DateTime('now'), 'array|string', false],
+            [[], 'array|string', true],
+            [['test'], 'array|string', true],
+            [new \ArrayIterator(['bar']), 'array|string', false],
+            [new UserWithToString('foo'), 'array|string', false],
+
             [new \ArrayIterator(['bar']), 'DateTime', false],
             ['test', 'DateTime', false],
             [null, 'DateTime', true], // @todo this can lead to PHP warnings

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -734,6 +734,39 @@ final class StrictArgumentProcessorTest extends TestCase
             'expectedProcessedValue' => ['foo', 1, 2, 3],
             'expectedProcessedValidity' => true,
         ];
+
+        //
+        // Union types
+        //
+        yield [
+            'type' => 'array|string',
+            'value' => ['foo', 1, 2, 3],
+            'expectedValidity' => true,
+            'expectedProcessedValue' => ['foo', 1, 2, 3],
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => 'array|string',
+            'value' => 'foo',
+            'expectedValidity' => true,
+            'expectedProcessedValue' => 'foo',
+            'expectedProcessedValidity' => true,
+        ];
+        // No support for automatic type casting
+        yield [
+            'type' => 'array|string',
+            'value' => 123,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 123,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => 'array|string',
+            'value' => $dateTime,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $dateTime,
+            'expectedProcessedValidity' => false,
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
With the `LenientArgumentProcessor`, which was previously used for
ViewHelper arguments, it was already possible to specify multiple
types for an argument. However, that definition was silently ignored
during validation (see `ImageViewHelper` in TYPO3 Core).

With the introduction of the `StrictArgumentProcessor` and its usage
for ViewHelpers in Fluid 5, this behavior changed: If a union type
is specified for an argument and a value with one of the allowed types
is supplied, this currently results in an exception because the
argument processor doesn't know about union types.

This patch officially adds support for union types in Fluid. It is
now possible to define more than one allowed type for an argument,
both in ViewHelpers and in components:

ViewHelper example:

```php
$this->registerArgument('arg', 'array|string', '');
```

Component example:

```xml
<f:argument name="arg" type="array|string" />
```

Note that automatic type casting cannot happen for union types because
it's not possible to determine the desired type automatically. Thus,
if union types are used, all possible types need to be specified
explicitly and need to be dealt manually in the ViewHelper's
implementation.

Resolves: #1130