### PR TITLE
[TASK] Add deprecation warning for CDATA section replacement in templates

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -29,6 +29,8 @@ Changelog 4.x
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::enterWarmupMode()`
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::isWarmupMode()`
 * Deprecation: The `<f:cache.warmup>` ViewHelper is deprecated and will be removed in Fluid v5.
+* Deprecation: Replacing `<![CDATA[]]>` sections by empty lines is deprecated and will be removed in Fluid v5.
+  Method :php:`TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor.php::replaceCdataSectionsByEmptyLines()` now emits a E_USER_DEPRECATED level error.
 
 4.4
 ---

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -51,9 +51,18 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      *
      * @todo It should be evaluated if this is really necessary. If it is, it should
      *       be moved to a separate TemplateProcessor (which would be a breaking change)
+     *
+     * @deprecated since Fluid v4.5, will be removed in Fluid v5.0.
      */
     public function replaceCdataSectionsByEmptyLines(string $templateSource): string
     {
+        if (str_contains($templateSource, '<![CDATA[')) {
+            trigger_error(
+                'Replacing cdata sections by empty lines is deprecated and will be removed in Fluid v5.0.',
+                E_USER_DEPRECATED,
+            );
+        }
+
         $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $balance = 0;

--- a/tests/Functional/Core/Parser/CDataTest.php
+++ b/tests/Functional/Core/Parser/CDataTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class CDataTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    #[IgnoreDeprecations]
+    public function cDataRemovedFromTemplate(): void
+    {
+        $source = 'some content <![CDATA[some content within cdata]]> more content';
+        $expected = 'some content  more content';
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($source);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+    }
+}

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\FluidExamples\Helper\ExampleHelper;
 
@@ -219,6 +220,7 @@ final class ExamplesTest extends AbstractFunctionalTestCase
 
     #[DataProvider('exampleScriptValuesDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function exampleScriptValues(string $script, array $expectedOutputs): void
     {
         $scriptFile = __DIR__ . '/../../examples/' . $script;

--- a/tests/Functional/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CommentViewHelperTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -46,6 +47,7 @@ final class CommentViewHelperTest extends AbstractFunctionalTestCase
 
     #[DataProvider('renderDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();


### PR DESCRIPTION
Adds a deprecation warning to `NamespaceDetectionTemplateProcessor::replaceCdataSectionsByEmptyLines()` when CDATA sections are found in templates.