### PR TITLE
[TASK] Use modern HTML syntax for boolean attributes

### DIFF
--- a/src/Core/ViewHelper/TagBuilder.php
+++ b/src/Core/ViewHelper/TagBuilder.php
@@ -43,8 +43,7 @@ class TagBuilder
 
     protected bool $ignoreEmptyAttributes = false;
     /**
-     * I'd prefer to set the default value to FALSE.
-     * Maybe we can leave it to AbstractTagBasedViewHelper in TYPO3
+     * Specifies whether a value is required for boolean attributes
      */
     protected bool $requireAttributeValues = true;
 
@@ -223,12 +222,6 @@ class TagBuilder
                 $this->addAttribute($attributeName . '-' . $name, $value, $escapeSpecialCharacters);
             }
         } else {
-            // Remove the attribute when it's NULL instead of FALSE, and keep the boolean values as they are
-            if ($attributeValue === null) {
-                $this->removeAttribute($attributeName);
-                return;
-            }
-
             if ($attributeValue instanceof \BackedEnum) {
                 $attributeValue = (string)$attributeValue->value;
             } elseif ($attributeValue instanceof \UnitEnum) {


### PR DESCRIPTION
Fluid used the XHTML syntax to represent boolean values. This change adjusts
the `TagBuilder` to use the modern syntax. This change is considered non-breaking
because it results in the same interpretation of the browser. However, it will
not be backported to Fluid v4 to be safe.

Before:

```xml
<my:tagBased required="{true}" />
Result: <input required="required" />
```

After:

```xml
<my:tagBased required="{true}" />
Result: <input required />
```