### PR TITLE
[FEATURE] Introduce <f:enum.tryFrom> ViewHelper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,12 @@ parameters:
 			path: src/View/TemplatePaths.php
 
 		-
+			message: '#^Call to an undefined static method UnitEnum\:\:tryFrom\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/ViewHelpers/Enum/TryFromViewHelper.php
+
+		-
 			message: '#^Variable \$iterationData might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/ViewHelpers/Enum/TryFromViewHelper.php
+++ b/src/ViewHelpers/Enum/TryFromViewHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\ViewHelpers\Enum;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * The ViewHelper returns an enum case for the passed backed enum and value.
+ *
+ * Examples
+ * ========
+ *
+ * ::
+ *     <f:enum.tryFrom
+ *         enum="\Vendor\Package\SomeEnum"
+ *         value="42"
+ *     />
+ *
+ * Returns::
+ *
+ *     \Vendor\Package\SomeEnum::TheAnswer
+ *
+ * If a value as argument is passed which is not defined as a case in the backed enum, null is returned.
+ *
+ * Using in combination with the VariableViewHelper
+ * ------------------------------------------------
+ *
+ * The ViewHelper is best used in combination with the VariableViewHelper:
+ *
+ * ::
+ *
+ *     <f:variable name="someEnumCase" value="{f:enum.tryFrom(enum: '\Vendor\Package\SomeEnum', value: '{someFieldValue}'}"/>
+ *
+ * The enum case can then be used, for example:
+ *
+ * Get the name of the case:
+ *
+ * ::
+ *
+ *     {someEnumCase.name}
+ *
+ * returns
+ *
+ * ::
+ *
+ *     TheAnswer
+ *
+ * Get the value of the case:
+ *
+ * ::
+ *
+ *    {someEnumCase.value}
+ *
+ * returns
+ *
+ * ::
+ *
+ *     42
+ *
+ * Retrieve the return value from function "getSomething()" defined in the given backed enum:
+ *
+ * ::
+ *
+ *     {someEnumCase.something}
+ */
+final class TryFromViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument(
+            'enum',
+            'string',
+            'Fully-qualified name of the backed enum',
+            true,
+        );
+
+        $this->registerArgument(
+            'value',
+            'mixed',
+            'The value to try from',
+            true,
+        );
+    }
+
+    public function render(): ?\BackedEnum
+    {
+        $enum = $this->arguments['enum'];
+        $value = $this->arguments['value'];
+        if (! \enum_exists($enum)) {
+            throw new ViewHelper\Exception('Enum does not exist!', 1757668148);
+        }
+
+        $reflection = new \ReflectionEnum($enum);
+        if (! $reflection->isBacked()) {
+            throw new ViewHelper\Exception('Given enum is not a backed enum!', 1757668149);
+        }
+
+        $backingType = $reflection->getBackingType()->getName();
+        $valueType = \get_debug_type($value);
+        if ($valueType !== 'int' && $valueType !== 'string') {
+            throw new ViewHelper\Exception('Value must be of type "int" or "string"', 1757668151);
+        }
+        if ($backingType !== $valueType) {
+            $value = $backingType === 'int' ? (int)$value : (string)$value;
+        }
+
+        return $enum::tryFrom($value);
+    }
+}

--- a/tests/Functional/Fixtures/Various/BackedEnumIntExample.php
+++ b/tests/Functional/Fixtures/Various/BackedEnumIntExample.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+enum BackedEnumIntExample: int
+{
+    case BAR = 42;
+}

--- a/tests/Functional/ViewHelpers/Enum/TryFromViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Enum/TryFromViewHelperTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Enum;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumIntExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class TryFromViewHelperTest extends AbstractFunctionalTestCase
+{
+    public static function renderDataProvider(): \Generator
+    {
+        yield 'backed enum with int and passing string as value and available case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumIntExample" value="42"/>',
+            [],
+            BackedEnumIntExample::BAR,
+        ];
+
+        yield 'backed enum with int and passing string as value and unavailable case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumIntExample" value="43"/>',
+            [],
+            null,
+        ];
+
+        yield 'backed enum with int and passing int as value and available case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumIntExample" value="{value}"/>',
+            ['value' => 42],
+            BackedEnumIntExample::BAR,
+        ];
+
+        yield 'backed enum with int and passing int as value and unavailable case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumIntExample" value="{value}"/>',
+            ['value' => 43],
+            null,
+        ];
+
+        yield 'backed enum with string and available case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample" value="bar"/>',
+            [],
+            BackedEnumExample::BAR,
+        ];
+
+        yield 'backed enum with string and unavailable case' => [
+            '<f:enum.tryFrom enum="\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample" value="foo"/>',
+            [],
+            null,
+        ];
+    }
+
+    #[DataProvider('renderDataProvider')]
+    #[Test]
+    public function render(string $template, array $variables, ?\BackedEnum $expected): void
+    {
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        self::assertSame($expected, $view->render());
+    }
+
+    public static function exceptionIsThrownOnInvalidArgumentsDataProvider(): \Generator
+    {
+        yield 'enum does not exist' => [
+            [
+                'enum' => '\Non\Existing\Enum',
+                'value' => 'foo',
+            ],
+            1757668148,
+        ];
+
+        yield 'enum is a class' => [
+            [
+                'enum' => ArrayAccessExample::class,
+                'value' => 'foo',
+            ],
+            1757668148,
+        ];
+
+        yield 'enum is not a backed enum' => [
+            [
+                'enum' => EnumExample::class,
+                'value' => 'foo',
+            ],
+            1757668149,
+        ];
+
+        yield 'enum is backed but passed an array as value' => [
+            [
+                'enum' => BackedEnumExample::class,
+                'value' => [],
+            ],
+            1757668151,
+        ];
+
+        yield 'enum is backed but passed an object as value' => [
+            [
+                'enum' => BackedEnumExample::class,
+                'value' => new \stdClass(),
+            ],
+            1757668151,
+        ];
+
+        yield 'enum is backed but passed a bool as value' => [
+            [
+                'enum' => BackedEnumExample::class,
+                'value' => true,
+            ],
+            1757668151,
+        ];
+
+        yield 'enum is backed but passed a float as value' => [
+            [
+                'enum' => BackedEnumExample::class,
+                'value' => 42.42,
+            ],
+            1757668151,
+        ];
+    }
+
+    #[DataProvider('exceptionIsThrownOnInvalidArgumentsDataProvider')]
+    #[Test]
+    public function exceptionIsThrownOnInvalidArguments(array $variables, int $expectedCode): void
+    {
+        $this->expectException(ViewHelper\Exception::class);
+        $this->expectExceptionCode($expectedCode);
+
+        $view = new TemplateView();
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource(
+            '<f:enum.tryFrom enum="{enum}" value="{value}"/>',
+        );
+        $view->render();
+    }
+}


### PR DESCRIPTION
A `<f:enum.tryFrom>` ViewHelper can be useful to map a given value to a backed enum case to unlock the potential of the backed enums also in Fluid. This way, not only the name and value of a backed enum can be retrieved, also arbitrary methods defined in the backed enum can be called.