### PR TITLE
[TASK] Address deprecations introduced by PHP 8.5 (#1236)

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -105,6 +105,8 @@ class TemplateParser
      */
     public function parse(string $templateString, ?string $templateIdentifier = null): ParsingState
     {
+        // @todo change method signature in Fluid v5 to only allow strings with empty string as default
+        $templateIdentifier ??= '';
         try {
             $this->reset();
 
@@ -119,6 +121,9 @@ class TemplateParser
         return $parsingState;
     }
 
+    /**
+     * @todo change method signature in Fluid v5 to only allow strings for templateIdentifier with empty string as default
+     */
     public function createParsingRelatedExceptionWithContext(\Exception $error, ?string $templateIdentifier): \Exception
     {
         list($line, $character, $templateCode) = $this->getCurrentParsingPointers();
@@ -622,7 +627,7 @@ class TemplateParser
         //       should be applied to the global state, while others should only
         //       affect the local state. Maybe it's also possible to get rid
         //       of the local state altogether.
-        $innerState = $this->buildObjectTree($this->createParsingState(null), $splitArgument, self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS);
+        $innerState = $this->buildObjectTree($this->createParsingState(''), $splitArgument, self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS);
         // This can be removed once the outer-inner-state issue is resolved
         $state->setAvailableSlots(array_unique(array_merge(
             $state->getAvailableSlots(),
@@ -836,12 +841,12 @@ class TemplateParser
         $state->getNodeFromStack()->addChildNode($node);
     }
 
-    protected function createParsingState(?string $templateIdentifier): ParsingState
+    protected function createParsingState(string $templateIdentifier): ParsingState
     {
         $rootNode = new RootNode();
         $variableProvider = $this->renderingContext->getVariableProvider();
         $state = new ParsingState();
-        $state->setIdentifier($templateIdentifier ?? '');
+        $state->setIdentifier($templateIdentifier);
         $state->setRootNode($rootNode);
         $state->pushNodeToStack($rootNode);
         $state->setVariableProvider($variableProvider->getScopeCopy($variableProvider->getAll()));

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -186,11 +186,11 @@ class StandardVariableProvider implements VariableProviderInterface
     /**
      * Clean up for serializing.
      *
-     * @return string[]
+     * @return array
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
-        return ['variables'];
+        return ['variables' => $this->variables];
     }
 
     /**

--- a/src/Core/ViewHelper/ViewHelperVariableContainer.php
+++ b/src/Core/ViewHelper/ViewHelperVariableContainer.php
@@ -154,8 +154,8 @@ class ViewHelperVariableContainer
      *
      * @return array
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
-        return ['objects'];
+        return ['objects' => $this->objects];
     }
 }

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -159,6 +159,8 @@ class GroupedForViewHelper extends AbstractViewHelper
                 $currentGroupIndex = $currentGroupIndex->format(\DateTime::RFC850);
             } elseif (is_object($currentGroupIndex)) {
                 $currentGroupIndex = spl_object_hash($currentGroupIndex);
+            } elseif ($currentGroupIndex === null) {
+                $currentGroupIndex = '';
             }
             $groups['keys'][$currentGroupIndex] = $currentGroupKeyValue;
             $groups['values'][$currentGroupIndex][$key] = $value;

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -149,11 +149,12 @@ final class StandardVariableProviderTest extends TestCase
     }
 
     #[Test]
-    public function sleepReturnsArrayWithVariableKey(): void
+    public function serializeContainsVariables(): void
     {
-        $subject = new StandardVariableProvider();
-        $properties = $subject->__sleep();
-        self::assertContains('variables', $properties);
+        $subject = new StandardVariableProvider(['foo' => 'bar']);
+        $serialized = serialize($subject);
+        $unserialized = unserialize($serialized);
+        self::assertSame(['foo' => 'bar'], $unserialized->getAll());
     }
 
     #[Test]

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Fixtures\TestViewHelper;
 use TYPO3Fluid\Fluid\View\ViewInterface;
+use TYPO3Fluid\Fluid\ViewHelpers\Format\TrimViewHelper;
 
 final class ViewHelperVariableContainerTest extends TestCase
 {
@@ -103,11 +104,13 @@ final class ViewHelperVariableContainerTest extends TestCase
     }
 
     #[Test]
-    public function sleepReturnsExpectedPropertyNames(): void
+    public function serializeContainsObjects(): void
     {
         $subject = new ViewHelperVariableContainer();
-        $properties = $subject->__sleep();
-        self::assertContains('objects', $properties);
+        $subject->add(TrimViewHelper::class, 'foo', 'bar');
+        $serialized = serialize($subject);
+        $unserialized = unserialize($serialized);
+        self::assertSame(['foo' => 'bar'], $unserialized->getAll(TrimViewHelper::class));
     }
 
     #[Test]


### PR DESCRIPTION
This patch addresses various deprecations that were introduced in
recent dev versions of PHP 8.5. All changes should be non-breaking
and thus can be backported to Fluid v4.

* `TemplateParser` now uses empty strings instead of `null` as array
  key for runtime cache. Public API will be adjusted in v5 only.
* `StandardVariableProvider` and `ViewHelperVariableContainer` use
  `__serialize()` instead of `__sleep()` for serialization.
* GroupedForViewHelper ensures to use an empty string instead of
  `null` for array key to avoid the deprecation and considered
  non-breaking because php converted null-index to `""` index
  anyway.