### PR TITLE
[!!!][TASK] Don't allow null as template identifier in parser

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -78,5 +78,9 @@ Changelog 5.x
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::enterWarmupMode()`
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::isWarmupMode()`
 * Breaking: The `<f:cache.warmup>` ViewHelper has been removed.
+* Breaking: `TYPO3Fluid\Fluid\Core\Parser\TemplateParser::parse()` and
+  `TYPO3Fluid\Fluid\Core\Parser\TemplateParser::createParsingRelatedExceptionWithContext()` no longer
+  allow `null` as template identifier.
 * Deprecation: Class :php:`TYPO3Fluid\Fluid\Core\ViewHelper\LenientArgumentProcessor`
   is no longer being used by Fluid v5 and will be removed with Fluid v6.
+

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -99,13 +99,11 @@ class TemplateParser
      * TemplateParser directly.
      *
      * @param string $templateString The template to parse as a string
-     * @param string|null $templateIdentifier If the template has an identifying string it can be passed here to improve error reporting.
+     * @param string $templateIdentifier If the template has an identifying string it can be passed here to improve error reporting.
      * @throws Exception
      */
-    public function parse(string $templateString, ?string $templateIdentifier = null): ParsingState
+    public function parse(string $templateString, string $templateIdentifier = ''): ParsingState
     {
-        // @todo change method signature in Fluid v5 to only allow strings with empty string as default
-        $templateIdentifier ??= '';
         try {
             $this->reset();
 
@@ -120,17 +118,14 @@ class TemplateParser
         return $parsingState;
     }
 
-    /**
-     * @todo change method signature in Fluid v5 to only allow strings for templateIdentifier with empty string as default
-     */
-    public function createParsingRelatedExceptionWithContext(\Exception $error, ?string $templateIdentifier): \Exception
+    public function createParsingRelatedExceptionWithContext(\Exception $error, string $templateIdentifier): \Exception
     {
         list($line, $character, $templateCode) = $this->getCurrentParsingPointers();
         $exceptionClass = get_class($error);
         return new $exceptionClass(
             sprintf(
                 'Fluid parse error in template %s, line %d at character %d. Error: %s (error code %d). Template source chunk: %s',
-                (string)$templateIdentifier,
+                $templateIdentifier,
                 $line,
                 $character,
                 $error->getMessage(),


### PR DESCRIPTION
This is a follow-up from #1236. The internal changes are now reflected
in the public method signatures as well.