### PR TITLE
[FEATURE] Overhaul template path resolving

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -133,7 +133,6 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
     {
         $templateRenderingContext = $this->getCurrentRenderingContext();
         if ($actionName) {
-            $actionName = ucfirst($actionName);
             $templateRenderingContext->setControllerAction($actionName);
         }
         try {

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -198,7 +198,7 @@ final class ExamplesTest extends AbstractFunctionalTestCase
             'example_errorhandling.php' => [
                 'example_errorhandling.php',
                 [
-                    'View error: The Fluid template files',
+                    'View error: The Fluid template file',
                     'Section rendering error: Section "DoesNotExist" does not exist. Section rendering is mandatory; "optional" is false.',
                     'ViewHelper error: Undeclared arguments passed to ViewHelper TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper: notregistered. Valid arguments are: then, else, condition - Offending code: <f:if notregistered="1" />',
                     'Parser error: The ViewHelper "<f:invalid>" could not be resolved.',

--- a/tests/Unit/View/Fixtures/lowercaseTemplateFixture.html
+++ b/tests/Unit/View/Fixtures/lowercaseTemplateFixture.html
@@ -1,0 +1,1 @@
+Unparsed Template

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -155,7 +155,7 @@ final class TemplatePathsTest extends TestCase
         $this->expectException(InvalidTemplateResourceException::class);
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
-        $method->invoke($instance, ['/not/', '/found/'], 'notfound.html');
+        $method->invoke($instance, ['/not/', '/found/'], 'notfound.html', 'html');
     }
 
     #[Test]
@@ -216,8 +216,8 @@ final class TemplatePathsTest extends TestCase
             'lowercase action' => [
                 [__DIR__ . '/Fixtures'],
                 '',
-                'unparsedTemplateFixture',
-                __DIR__ . '/Fixtures/UnparsedTemplateFixture.html',
+                'lowercaseTemplateFixture',
+                __DIR__ . '/Fixtures/lowercaseTemplateFixture.html',
             ],
             'action includes format' => [
                 [__DIR__ . '/Fixtures'],


### PR DESCRIPTION
All path handling and resolving in Fluid is performed by the
`TemplatePaths` class, which is attached to the current rendering
context. While this class has already been simplified in the past,
the actual path resolving has largely stayed the same because it
includes edge cases that were moved over from TYPO3.

This patch attempts to make the path resolving code more understandable,
while also eliminating some shortcomings. Most importantly, it is no
longer required for template names to start with an uppercase character.
A fallback chain is introduced, which prefers the provided spelling
of the template name but tries its uppercase variant in case the
template cannot be found.

In a follow-up patch, this will also allow us to introduce a custom
file extension for Fluid templates, which will then also be part of that
fallback chain.

Resolves: #371
Related: #938