### PR TITLE
[!!!][FEATURE] Alternative Fluid syntax in CDATA

### DIFF
--- a/Documentation/Changelog/5.x.rst
+++ b/Documentation/Changelog/5.x.rst
@@ -90,4 +90,5 @@ Changelog 5.x
   results in an exception. Note that this doesn't affect array keys or object property names, only the name of the variable itself.
 * Deprecation: Class :php:`TYPO3Fluid\Fluid\Core\ViewHelper\LenientArgumentProcessor`
   is no longer being used by Fluid v5 and will be removed with Fluid v6.
-
+* Breaking: CDATA sections are no longer removed from Fluid templates. Use `<f:comment>` instead
+  if you want to comment out code in Fluid templates.

--- a/Documentation/Syntax/Escaping.rst
+++ b/Documentation/Syntax/Escaping.rst
@@ -51,19 +51,20 @@ one value:
 
     {myVariable -> f:format.case(mode: 'upper') -> f:format.trim()}
 
+.. _escaping-collisions:
 .. _escaping-workarounds:
 
-Workarounds for syntax collision with JS and CSS
-================================================
+Avoiding syntax collision with JS and CSS
+=========================================
 
 While it is generally advisable to avoid inline JavaScript and CSS code within
 Fluid templates, sometimes it may be unavoidable. This can lead to collisions
 between Fluid's inline or variable syntax and the curly braces :xml:`{}`
 syntax characters used in JavaScript and CSS.
 
-Currently, there is no clean way to solve this due to limitations of Fluid's parser.
-This would need a bigger rewrite, which is not yet feasible because of other more pressing
-issues. However, there are workarounds that might be applicable in your use case.
+There are two approaches how these collisions can be avoided:
+
+.. _escaping-collisions-json:
 
 f:format.json ViewHelper
 ------------------------
@@ -77,23 +78,49 @@ to generate valid JSON:
     <div data-value="{f:format.json(value: {foo: 'bar', bar: 'baz'})}">
 
 
-This can also be used directly in JavaScript code:
+This can also be used directly in JavaScript code that doesn't use any curly braces
+itself:
 
 ..  code-block:: xml
 
     <script>
     let data = {f:format.json(value: {foo: 'bar', bar: 'baz'}) -> f:format.raw()};
 
+.. _escaping-collisions-cdata:
 
-f:comment ViewHelper
---------------------
+CDATA sections
+--------------
 
-In some cases, you can use the :ref:`<f:comment> ViewHelper <typo3fluid-fluid-comment>`
-to trap the Fluid parser:
+..  versionadded:: Fluid 5.0
+    CDATA sections can be used to avoid syntax collisions. For Fluid 4 and below,
+    workarounds are documented in older versions of this documentation.
+
+CDATA sections can be used in Fluid templates to partially switch off the Fluid
+parser and to alter the syntax for variables, expressions and inline ViewHelpers.
+This makes it possible to mix CSS or JS with certain Fluid features.
+
+The following syntax rules apply to text wrapped with :xml:`<![CDATA[ ]]>` in
+Fluid templates:
+
+*   ViewHelper tag syntax is ignored: ViewHelper tags will not be interpreted and
+    will just remain as-is.
+*   ViewHelper inline syntax, variables and expressions are only interpreted if
+    they are using three curly braces `{{{ }}}` instead of just one `{ }`.
+*   The :xml:`<![CDATA[ ]]>` keyword will be removed. If you want the CDATA to remain
+    in the output, consider using the
+    :ref:`<f:format.cdata> ViewHelper <typo3fluid-fluid-format-cdata>`.
+
+Note that there might still be syntax overlaps if your CSS or JS uses three
+curly braces that shouldn't be interpreted by Fluid.
+
+Examples:
 
 ..  code-block:: xml
+    :caption: Avoiding collisions in HTML attribute
+    :emphasize-lines: 2, 11, 13
 
     <f:variable name="test" value="bar" />
+    <![CDATA[
     <div
         x-data="{
             test: null,
@@ -102,44 +129,37 @@ to trap the Fluid parser:
             }
         }"
     >
-        <f:comment>Only necessary to fix parser issue</f:comment>
-        {test}
+        {{{test}}}
     </div>
-
-
-f:format.raw ViewHelper
------------------------
-
-Within your JavaScript or CSS code, you can use the
-:ref:`<f:format.raw> ViewHelper <typo3fluid-fluid-format-raw>`
-on individual curly braces to trap the Fluid parser into ignoring that
-character:
+    ]]>
 
 ..  code-block:: xml
+    :caption: Avoiding collisions in inline CSS
+    :emphasize-lines: 3, 6, 9
 
     <f:variable name="color" value="red" />
     <style>
-        @media (min-width: 1000px) <f:format.raw>{</f:format.raw>
+    <![CDATA[
+        @media (min-width: 1000px) {
             p {
-                background-color: {color};
+                background-color: {{{color}}};
             }
         }
+    ]]>
     </style>
 
-
-Using variables for curly braces
---------------------------------
-
-You can define variables for curly braces to prevent parsing by the Fluid parser:
-
 ..  code-block:: xml
+    :caption: Avoiding collisions in inline JS
+    :emphasize-lines: 6, 8, 10
 
-    <f:alias map="{l: '{', r: '}'}">
-        var values = {};
-        <f:for each="{items}" as="item">
-            if (!values[{item.key}]) { values[{item.key}] = {}; }
-            values[{item.key}][values[{item.key}].length] = {l} label: "{item.description} ({item.short})", value: {item.id} {r};
-        </f:for>
-    </f:alias>
-
-Source: https://stackoverflow.com/a/51499855
+    <f:variable name="countries" value="{
+        0: {key: 'de', name: 'Germany', short: 'DE'},
+        1: {key: 'us', name: 'United States of America', short: 'US'},
+    }" />
+    <script>
+    <![CDATA[
+        const settings = {
+            countries: {{{countries -> f:format.json() -> f:format.raw()}}},
+        };
+    ]]>
+    </script>

--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -100,7 +100,7 @@ abstract class Patterns
      * This pattern detects CDATA sections and outputs the text between opening
      * and closing CDATA.
      */
-    public static string $SCAN_PATTERN_CDATA = '/^<!\[CDATA\[(.*?)\]\]>$/s';
+    public static string $SCAN_PATTERN_CDATA = '/^<!\[CDATA\[(?P<CDataContent>.*?)\]\]>$/s';
 
     /**
      * Pattern which splits the shorthand syntax into different tokens. The
@@ -118,6 +118,23 @@ abstract class Patterns
 				)+
 			}                                 # End of shorthand syntax
 		)/x';
+
+    /**
+     * Pattern which splits the shorthand syntax in CDATA sections into different tokens. The
+     * "shorthand syntax" is everything like {{{...}}}
+     */
+    public static string $SPLIT_PATTERN_SHORTHANDSYNTAX_IN_CDATA = '/
+    (
+        {{{                               # Start of shorthand syntax
+            (?:                           # Shorthand syntax is either composed of...
+                [a-zA-Z0-9\|\->_:=,.()*+\^\/\%] # Various characters including math operations
+                |"(?:\\\"|[^"])*"         # Double-quoted strings
+                |\'(?:\\\\\'|[^\'])*\'    # Single-quoted strings
+                |(?R)                     # Other shorthand syntaxes inside, albeit not in a quoted string
+                |\s+                      # Spaces
+            )+
+        }}}                               # End of shorthand syntax
+    )/x';
 
     /**
      * Pattern which detects the object accessor syntax:
@@ -215,6 +232,12 @@ abstract class Patterns
 				)                                                  # End array sub-match
 			}                                                      # Each array ends with }
 		)$/x';
+
+    /**
+     * Pattern to remove additional curly braces for variables, inline viewhelpers and expressions in
+     * CDATA sections. After removal, the normal SCAN patterns can be used to interpret the syntax.
+     */
+    public static string $SCAN_PATTERN_SHORTHANDSYNTAX_IN_CDATA = '/^{{(?P<ExpressionVariable>.*?)}}$/';
 
     /**
      * This pattern splits an array into its parts, each part consists of a key and a value.

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -17,7 +17,6 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * This template processor takes care of the following things:
  *
- *   - replace cdata sections with empty lines (including nested cdata)
  *   - register/ignore namespaces through xmlns and shorthand syntax
  *   - report any unregistered/unignored namespaces through exception
  */
@@ -39,46 +38,8 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      */
     public function preProcessSource(string $templateSource): string
     {
-        $templateSource = $this->replaceCdataSectionsByEmptyLines($templateSource);
         $templateSource = $this->registerNamespacesFromTemplateSource($templateSource);
         return $templateSource;
-    }
-
-    /**
-     * Replaces all cdata sections with empty lines to exclude it from further
-     * processing in the templateParser while maintaining the line-count
-     * of the template string for the exception handler to reference to.
-     *
-     * @todo It should be evaluated if this is really necessary. If it is, it should
-     *       be moved to a separate TemplateProcessor (which would be a breaking change)
-     *
-     * @deprecated since Fluid v4.5, will be removed in Fluid v5.0.
-     */
-    public function replaceCdataSectionsByEmptyLines(string $templateSource): string
-    {
-        if (str_contains($templateSource, '<![CDATA[')) {
-            trigger_error(
-                'Replacing cdata sections by empty lines is deprecated and will be removed in Fluid v5.0.',
-                E_USER_DEPRECATED,
-            );
-        }
-
-        $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
-
-        $balance = 0;
-        foreach ($parts as $index => $part) {
-            if ($part === '<![CDATA[') {
-                $balance++;
-            }
-            if ($balance > 0) {
-                $parts[$index] = str_repeat(PHP_EOL, substr_count($part, PHP_EOL));
-            }
-            if ($part === ']]>') {
-                $balance--;
-            }
-        }
-
-        return implode('', $parts);
     }
 
     /**

--- a/tests/Functional/Core/Parser/CDataTest.php
+++ b/tests/Functional/Core/Parser/CDataTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -23,45 +22,163 @@ final class CDataTest extends AbstractFunctionalTestCase
             'simple string' => [
                 'some content <![CDATA[some content within cdata]]> more content',
                 [],
-                'some content  more content',
+                'some content some content within cdata more content',
             ],
 
             'normal variable syntax' => [
                 'some content <![CDATA[some {content} within cdata]]> more content',
                 ['content' => 'foo'],
-                'some content  more content',
+                'some content some {content} within cdata more content',
             ],
             'normal ViewHelper tag syntax' => [
                 'some content <![CDATA[<f:format.trim>  some content within cdata  </f:format.trim>]]> more content',
                 [],
-                'some content  more content',
+                'some content <f:format.trim>  some content within cdata  </f:format.trim> more content',
             ],
             'normal ViewHelper inline syntax' => [
                 'some content <![CDATA[{f:format.trim(value: \'  some content within cdata  \')}]]> more content',
                 [],
-                'some content  more content',
+                'some content {f:format.trim(value: \'  some content within cdata  \')} more content',
             ],
             'normal math syntax' => [
                 'some content <![CDATA[{1 + 2}]]> more content',
                 [],
-                'some content  more content',
+                'some content {1 + 2} more content',
             ],
             'normal cast syntax' => [
                 'some content <![CDATA[{var as float}]]> more content',
                 ['var' => 1.0],
-                'some content  more content',
+                'some content {var as float} more content',
             ],
             'normal ternary syntax' => [
                 'some content <![CDATA[{var1 ? var2 : var3}]]> more content',
                 ['var1' => 'foo', 'var2' => 'bar', 'var3' => 'baz'],
+                'some content {var1 ? var2 : var3} more content',
+            ],
+
+            'CDATA variable syntax' => [
+                'some content <![CDATA[some {{{content}}} within cdata]]> more content',
+                ['content' => 'foo'],
+                'some content some foo within cdata more content',
+            ],
+            'CDATA ViewHelper inline syntax' => [
+                'some content <![CDATA[{{{f:format.trim(value: \'  some content within cdata  \')}}}]]> more content',
+                [],
+                'some content some content within cdata more content',
+            ],
+            'CDATA ViewHelper inline syntax with simple variable use' => [
+                'some content <![CDATA[{{{f:format.trim(value: content)}}}]]> more content',
+                ['content' => 'foo'],
+                'some content foo more content',
+            ],
+            'CDATA ViewHelper inline syntax with variable use' => [
+                'some content <![CDATA[{{{f:format.trim(value: \'{content}\')}}}]]> more content',
+                ['content' => 'foo'],
+                'some content foo more content',
+            ],
+            'CDATA ViewHelper inline syntax with CDATA variable use' => [
+                'some content <![CDATA[{{{f:format.trim(value: \'{{{content}}}\')}}}]]> more content',
+                ['content' => 'foo'],
                 'some content  more content',
+            ],
+            'CDATA math syntax' => [
+                'some content <![CDATA[{{{1 + 2}}}]]> more content',
+                [],
+                'some content 3 more content',
+            ],
+            'CDATA cast syntax' => [
+                'some content <![CDATA[{{{var as integer}}}]]> more content',
+                ['var' => 1.1],
+                'some content 1 more content',
+            ],
+            'CDATA ternary syntax' => [
+                'some content <![CDATA[{{{var1 ? var2 : var3}}}]]> more content',
+                ['var1' => 'foo', 'var2' => 'bar', 'var3' => 'baz'],
+                'some content bar more content',
+            ],
+
+            'html attribute example' => [
+                '
+<![CDATA[
+<div
+    x-data="{
+        test: null,
+        init() {
+            test = \'foo\';
+        }
+    }"
+>
+    {{{test}}}
+</div>
+]]>
+                ',
+                ['test' => 'bar'],
+                '
+
+<div
+    x-data="{
+        test: null,
+        init() {
+            test = \'foo\';
+        }
+    }"
+>
+    bar
+</div>
+
+                ',
+            ],
+            'inline css example' => [
+                '
+<style>
+<![CDATA[
+    @media (min-width: 1000px) {
+        p {
+            background-color: {{{color}}};
+        }
+    }
+]]>
+</style>
+                ',
+                ['color' => 'red'],
+                '
+<style>
+
+    @media (min-width: 1000px) {
+        p {
+            background-color: red;
+        }
+    }
+
+</style>
+                ',
+            ],
+            'inline js example' => [
+                '
+<script>
+<![CDATA[
+    const settings = {
+        countries: {{{countries -> f:format.json() -> f:format.raw()}}},
+    };
+]]>
+</script>
+                ',
+                ['countries' => [['key' => 'de', 'name' => 'Germany', 'short' => 'DE'], ['key' => 'us', 'name' => 'United States of America', 'short' => 'US']]],
+                '
+<script>
+
+    const settings = {
+        countries: [{"key":"de","name":"Germany","short":"DE"},{"key":"us","name":"United States of America","short":"US"}],
+    };
+
+</script>
+                ',
             ],
         ];
     }
 
     #[Test]
     #[DataProvider('handleCdataInTemplateDataProvider')]
-    #[IgnoreDeprecations]
     public function handleCdataInTemplate(string $template, array $variables, string $expected): void
     {
         $view = new TemplateView();


### PR DESCRIPTION
Fluid has so far removed any CDATA sections from templates. This has
been introduced with 978071f, without any clear indication why this
was done. This means that Fluid templates either expect CDATA sections
to be removed or avoid them altogether since they don't do anything.
This gives us the opportunity to not only re-add those sections to
Fluid templates (which is a breaking change), but to also introduce
new syntax within those section.

One common issue with the Fluid parser has always been that the
variable/inline syntax collides with both CSS and JS, which both use
curly braces quite extensively. In most cases, this leads to the
Fluid parser trapping over a curly brace that's not intended for Fluid
and then stops interpreting valid Fluid syntax after that.

This patch extends the Fluid parser to use alternative variable and
inline syntax within CDATA sections in the template. Both ViewHelper
tag syntax and the normal curly braces syntax no longer work there,
instead three curly braces `{{{ }}}` can be used to access Fluid
variables, call ViewHelpers and use expressions. The CDATA keyword
itself is removed from the output.

Resolves: #1012
Resolves: #808