### PR TITLE
[TASK] Deprecate variables that start with a "_"

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -29,6 +29,9 @@ Changelog 4.x
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::enterWarmupMode()`
     * :php:`TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler::isWarmupMode()`
 * Deprecation: The `<f:cache.warmup>` ViewHelper is deprecated and will be removed in Fluid v5.
+* Deprecation: Fluid variable names can no longer start with an underscore character (`_`). Adding such a variable to a template
+  now emits a E_USER_DEPRECATED level error and will result in an exception in Fluid v5. Note that this doesn't affect array
+  keys or object property names, only the name of the variable itself.
 
 4.4
 ---

--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -82,6 +82,10 @@ class StandardVariableProvider implements VariableProviderInterface
         if (in_array(strtolower($identifier), $this->disallowedIdentifiers)) {
             throw new InvalidVariableIdentifierException('Invalid variable identifier: ' . $identifier, 1723131119);
         }
+        if (str_starts_with($identifier, '_')) {
+            // @todo replace with exception in Fluid 5
+            trigger_error('Variable identifiers cannot start with a "_": ' . $identifier . '. This will break with Fluid v5.', E_USER_DEPRECATED);
+        }
         $this->variables[$identifier] = $value;
     }
 

--- a/tests/Unit/Core/Variables/StandardVariableProviderTest.php
+++ b/tests/Unit/Core/Variables/StandardVariableProviderTest.php
@@ -501,12 +501,24 @@ final class StandardVariableProviderTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
+    public static function exceptionIsThrownForInvalidVariableIdentifierDataProvider(): array
+    {
+        return [
+            ['true', 1723131119],
+            ['TrUe', 1723131119],
+            ['false', 1723131119],
+            ['null', 1723131119],
+            ['_all', 1723131119],
+        ];
+    }
+
     #[Test]
-    public function exceptionIsThrownForInvalidVariableIdentifier(): void
+    #[DataProvider('exceptionIsThrownForInvalidVariableIdentifierDataProvider')]
+    public function exceptionIsThrownForInvalidVariableIdentifier(string $identifier, int $exceptionCode): void
     {
         self::expectException(InvalidVariableIdentifierException::class);
-        self::expectExceptionCode(1723131119);
+        self::expectExceptionCode($exceptionCode);
         $subject = new StandardVariableProvider();
-        $subject->add('TrUe', false);
+        $subject->add($identifier, false);
     }
 }


### PR DESCRIPTION
In preparation for the possible introduction of more internal
constants in Fluid, custom variable names that start with an
underscore will no longer be allowed.

For Fluid v4, a deprecation is emitted. In a follow-up for Fluid v5,
the deprecation will be replaced with an exception.

Related: #1166
Related: #1041