### PR TITLE
[TASK] Deprecate CDATA removal from templates (#1231)

### DIFF
--- a/Documentation/Changelog/4.x.rst
+++ b/Documentation/Changelog/4.x.rst
@@ -32,6 +32,8 @@ Changelog 4.x
 * Deprecation: Fluid variable names can no longer start with an underscore character (`_`). Adding such a variable to a template
   now emits a E_USER_DEPRECATED level error and will result in an exception in Fluid v5. Note that this doesn't affect array
   keys or object property names, only the name of the variable itself.
+* Deprecation: Replacing `<![CDATA[]]>` sections by empty lines is deprecated and will be removed in Fluid v5.
+  Method :php:`TYPO3Fluid\Fluid\Core\Parser\TemplateProcessor\NamespaceDetectionTemplateProcessor.php::replaceCdataSectionsByEmptyLines()` now emits a E_USER_DEPRECATED level error.
 
 4.4
 ---

--- a/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/src/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -51,9 +51,18 @@ class NamespaceDetectionTemplateProcessor implements TemplateProcessorInterface
      *
      * @todo It should be evaluated if this is really necessary. If it is, it should
      *       be moved to a separate TemplateProcessor (which would be a breaking change)
+     *
+     * @deprecated since Fluid v4.5, will be removed in Fluid v5.0.
      */
     public function replaceCdataSectionsByEmptyLines(string $templateSource): string
     {
+        if (str_contains($templateSource, '<![CDATA[')) {
+            trigger_error(
+                'Replacing cdata sections by empty lines is deprecated and will be removed in Fluid v5.0.',
+                E_USER_DEPRECATED,
+            );
+        }
+
         $parts = preg_split('/(\<\!\[CDATA\[|\]\]\>)/', $templateSource, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         $balance = 0;

--- a/tests/Functional/Core/Parser/CDataTest.php
+++ b/tests/Functional/Core/Parser/CDataTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Cases\Parsing;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class CDataTest extends AbstractFunctionalTestCase
+{
+    public static function handleCdataInTemplateDataProvider(): array
+    {
+        return [
+            'simple string' => [
+                'some content <![CDATA[some content within cdata]]> more content',
+                [],
+                'some content  more content',
+            ],
+
+            'normal variable syntax' => [
+                'some content <![CDATA[some {content} within cdata]]> more content',
+                ['content' => 'foo'],
+                'some content  more content',
+            ],
+            'normal ViewHelper tag syntax' => [
+                'some content <![CDATA[<f:format.trim>  some content within cdata  </f:format.trim>]]> more content',
+                [],
+                'some content  more content',
+            ],
+            'normal ViewHelper inline syntax' => [
+                'some content <![CDATA[{f:format.trim(value: \'  some content within cdata  \')}]]> more content',
+                [],
+                'some content  more content',
+            ],
+            'normal math syntax' => [
+                'some content <![CDATA[{1 + 2}]]> more content',
+                [],
+                'some content  more content',
+            ],
+            'normal cast syntax' => [
+                'some content <![CDATA[{var as float}]]> more content',
+                ['var' => 1.0],
+                'some content  more content',
+            ],
+            'normal ternary syntax' => [
+                'some content <![CDATA[{var1 ? var2 : var3}]]> more content',
+                ['var1' => 'foo', 'var2' => 'bar', 'var3' => 'baz'],
+                'some content  more content',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('handleCdataInTemplateDataProvider')]
+    #[IgnoreDeprecations]
+    public function handleCdataInTemplate(string $template, array $variables, string $expected): void
+    {
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->assignMultiple($variables);
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        $output = $view->render();
+        self::assertSame($expected, $output);
+    }
+}

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\FluidExamples\Helper\ExampleHelper;
 
@@ -219,6 +220,7 @@ final class ExamplesTest extends AbstractFunctionalTestCase
 
     #[DataProvider('exampleScriptValuesDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function exampleScriptValues(string $script, array $expectedOutputs): void
     {
         $scriptFile = __DIR__ . '/../../examples/' . $script;

--- a/tests/Functional/ViewHelpers/CommentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CommentViewHelperTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -46,6 +47,7 @@ final class CommentViewHelperTest extends AbstractFunctionalTestCase
 
     #[DataProvider('renderDataProvider')]
     #[Test]
+    #[IgnoreDeprecations]
     public function render(string $template, $expected): void
     {
         $view = new TemplateView();


### PR DESCRIPTION
[TASK] Deprecate CDATA removal from templates (#1231)

Quite early in the development of Fluid, the decision has been made
to remove `<![CDATA[...]]>` sections from templates. The exact reason
remains unclear, as 978071f8f5484e01882d7c4c6d740064f22d51ef only
mentions that this has been added, but not why:

> - replace cdata sections with empty lines (including nested cdata)

As this modifies templates in an unnecessary way, this behavior is now
deprecated: From Fluid 5 onwards, CDATA sections will just remain in
Fluid templates untouched. Until then, a deprecation will be emitted
to let users know that this will change in the future.