### PR TITLE
[TASK] Avoid mixed return in AbstractViewHelper->render()

### DIFF
--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -316,8 +316,10 @@ abstract class AbstractViewHelper implements ViewHelperInterface
     /**
      * Main render method of the ViewHelper. Every modern ViewHelper implementation
      * must implement this method.
+     *
+     * @return mixed
      */
-    abstract public function render(): mixed;
+    abstract public function render();
 
     /**
      * You only should override this method *when you absolutely know what you


### PR DESCRIPTION
Change AbstractViewHelper declaration

abstract public function render(): mixed;

back to

abstract public function render();

Too much fallout with too little benefit.

Related: #1219