### PR TITLE
[BUGFIX] Ensure valid name for cache classes

### DIFF
--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -422,7 +422,7 @@ class TemplatePaths
     /**
      * Returns a unique identifier for the given file in the format
      * <FileName>_<hash>
-     * The SH1 hash is a checksum that is based on the file path and last modification date
+     * The hash is a checksum that is based on the file path and last modification date
      */
     protected function createIdentifierForFile(?string $pathAndFilename): string
     {
@@ -432,7 +432,7 @@ class TemplatePaths
             $templateModifiedTimestamp = filemtime($pathAndFilename);
             $prefix = str_replace('.', '_', basename($pathAndFilename));
         }
-        return sprintf('%s_%s', $prefix, hash('xxh3', $pathAndFilename . '|' . $templateModifiedTimestamp));
+        return sprintf('template_%s_%s', $prefix, hash('xxh3', $pathAndFilename . '|' . $templateModifiedTimestamp));
     }
 
     /**

--- a/tests/Unit/View/Fixtures/123Template-foo$=bar.html
+++ b/tests/Unit/View/Fixtures/123Template-foo$=bar.html
@@ -1,0 +1,1 @@
+template name starting with non-alpha character and containing invalid characters

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -171,13 +171,19 @@ final class TemplatePathsTest extends TestCase
                 __DIR__ . '/Fixtures',
                 'ARandomController',
                 'TestTemplate',
-                'TestTemplate_html_',
+                'template_TestTemplate_html_',
             ],
             [
                 __DIR__ . '/Fixtures',
                 '',
                 'UnparsedTemplateFixture',
-                'UnparsedTemplateFixture_html_',
+                'template_UnparsedTemplateFixture_html_',
+            ],
+            [
+                __DIR__ . '/Fixtures',
+                '',
+                '123Template-foo$=bar',
+                'template_123Template-foo$=bar_', // Special characters are removed in template compiler
             ],
         ];
     }


### PR DESCRIPTION
Due to refactorings in the cache layer of Fluid, which were necessary
to make cache warmup feasible, the cache identifiers have changed
with Fluid 5. This currently leads to parse errors when a template
name starts with a number because the associated cache file and most
importantly the generated PHP class name also starts with that number,
which isn't allowed in PHP.

This patch addresses that issue by prepending "template_" to cache
identifiers. Other special characters are already dealt with in
`TemplateCompiler`, so we only need to ensure that the identifier
starts with an alpha-character.

Resolves: #1266