### PR TITLE
[TASK] Extend enum test coverage

### DIFF
--- a/tests/Functional/Fixtures/Various/IntBackedEnumExample.php
+++ b/tests/Functional/Fixtures/Various/IntBackedEnumExample.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
+
+enum IntBackedEnumExample: int
+{
+    case BAR = 123;
+}

--- a/tests/Functional/Fixtures/Various/StringBackedEnumExample.php
+++ b/tests/Functional/Fixtures/Various/StringBackedEnumExample.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various;
 
-enum BackedEnumExample: string
+enum StringBackedEnumExample: string
 {
-    case BAR = 'bar';
+    case BAR = 'bar value';
 }

--- a/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
@@ -12,9 +12,10 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
-use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StringBackedEnumExample;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class ConstantViewHelperTest extends AbstractFunctionalTestCase
@@ -60,14 +61,24 @@ final class ConstantViewHelperTest extends AbstractFunctionalTestCase
             ClassConstantsExample::FOO,
         ];
 
-        yield 'Name is backed enum case w/out leading slash' => [
-            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample::BAR',
-            BackedEnumExample::BAR,
+        yield 'Name is string-backed enum case w/out leading slash' => [
+            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StringBackedEnumExample::BAR',
+            StringBackedEnumExample::BAR,
         ];
 
-        yield 'Name is backed enum case with leading slash' => [
-            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample::BAR',
-            BackedEnumExample::BAR,
+        yield 'Name is string-backed enum case with leading slash' => [
+            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StringBackedEnumExample::BAR',
+            StringBackedEnumExample::BAR,
+        ];
+
+        yield 'Name is int-backed enum case w/out leading slash' => [
+            'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample::BAR',
+            IntBackedEnumExample::BAR,
+        ];
+
+        yield 'Name is int-backed enum case with leading slash' => [
+            '\TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample::BAR',
+            IntBackedEnumExample::BAR,
         ];
 
         yield 'Name is enum case w/out leading slash' => [

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
-use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\BackedEnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StringBackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 
 final class StrictArgumentProcessorTest extends TestCase
@@ -515,14 +515,14 @@ final class StrictArgumentProcessorTest extends TestCase
         ];
         // Enums
         yield [
-            'type' => BackedEnumExample::class,
-            'value' => BackedEnumExample::BAR,
+            'type' => StringBackedEnumExample::class,
+            'value' => StringBackedEnumExample::BAR,
             'expectedValidity' => true,
-            'expectedProcessedValue' => BackedEnumExample::BAR,
+            'expectedProcessedValue' => StringBackedEnumExample::BAR,
             'expectedProcessedValidity' => true,
         ];
         yield [
-            'type' => BackedEnumExample::class,
+            'type' => StringBackedEnumExample::class,
             'value' => $stdClass,
             'expectedValidity' => false,
             'expectedProcessedValue' => $stdClass,


### PR DESCRIPTION
The existing `BackedEnumExample` is renamed to `StringBackedEnumExample`
to also cover int-backed enums with `IntBackedEnumExample`. The
existing tests for `<f:constant>` are extended to cover all enum
variants.