### PR TITLE
[FEATURE] Automatic enum conversion for arguments

### DIFF
--- a/tests/Functional/Core/Component/ComponentRenderingTest.php
+++ b/tests/Functional/Core/Component/ComponentRenderingTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Component;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class ComponentRenderingTest extends AbstractFunctionalTestCase
@@ -62,6 +63,9 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
             'additional arguments can be provided if delegate allows' => ['<my:additionalArgumentsJson foo="bar" />', '{"foo":"bar","myAdditionalVariable":"my additional value","viewHelperName":"additionalArgumentsJson"}' . "\n"],
             'union type, array provided' => ['<my:unionTypeArgument item="{property: \'foo\'}" />', "\nfoo\n"],
             'union type, string provided' => ['<my:unionTypeArgument item="bar" />', "\nbar\n"],
+            'enum type, enum object provided' => ['<my:enumTypeArgument value="{f:constant(name: \'' . IntBackedEnumExample::class . '::BAR\')}" />', "\nBAR => 123\n"],
+            'enum type, enum name provided' => ['<my:enumTypeArgument value="BAR" />', "\nBAR => 123\n"],
+            'enum type, enum value provided' => ['<my:enumTypeArgument value="123" />', "\nBAR => 123\n"],
         ];
     }
 

--- a/tests/Functional/Fixtures/Components/EnumTypeArgument/EnumTypeArgument.html
+++ b/tests/Functional/Fixtures/Components/EnumTypeArgument/EnumTypeArgument.html
@@ -1,0 +1,2 @@
+<f:argument name="value" type="TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample" />
+{value.name} => {value.value}

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -18,6 +18,8 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\StrictArgumentProcessor;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\StringBackedEnumExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 
@@ -513,7 +515,53 @@ final class StrictArgumentProcessorTest extends TestCase
             'expectedProcessedValue' => $stdClass,
             'expectedProcessedValidity' => false,
         ];
+
+        //
         // Enums
+        //
+        yield [
+            'type' => EnumExample::class,
+            'value' => EnumExample::FOO,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => EnumExample::FOO,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => EnumExample::class,
+            'value' => 'FOO',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => EnumExample::FOO,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => EnumExample::class,
+            'value' => 'INVALIDCASE',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'INVALIDCASE',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => EnumExample::class,
+            'value' => '',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => EnumExample::class,
+            'value' => $stdClass,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $stdClass,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => EnumExample::class,
+            'value' => [],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [],
+            'expectedProcessedValidity' => false,
+        ];
+        // string-backed enums
         yield [
             'type' => StringBackedEnumExample::class,
             'value' => StringBackedEnumExample::BAR,
@@ -523,9 +571,94 @@ final class StrictArgumentProcessorTest extends TestCase
         ];
         yield [
             'type' => StringBackedEnumExample::class,
+            'value' => 'BAR',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => StringBackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => StringBackedEnumExample::class,
+            'value' => 'INVALIDCASE',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'INVALIDCASE',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => StringBackedEnumExample::class,
+            'value' => 'bar value',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => StringBackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => StringBackedEnumExample::class,
+            'value' => '',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => '',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => StringBackedEnumExample::class,
             'value' => $stdClass,
             'expectedValidity' => false,
             'expectedProcessedValue' => $stdClass,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => StringBackedEnumExample::class,
+            'value' => [],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [],
+            'expectedProcessedValidity' => false,
+        ];
+        // int-backed enums
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => IntBackedEnumExample::BAR,
+            'expectedValidity' => true,
+            'expectedProcessedValue' => IntBackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => 'BAR',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => IntBackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => 'INVALIDCASE',
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'INVALIDCASE',
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => 123,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => IntBackedEnumExample::BAR,
+            'expectedProcessedValidity' => true,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => 0,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 0,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => $stdClass,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => $stdClass,
+            'expectedProcessedValidity' => false,
+        ];
+        yield [
+            'type' => IntBackedEnumExample::class,
+            'value' => [],
+            'expectedValidity' => false,
+            'expectedProcessedValue' => [],
             'expectedProcessedValidity' => false,
         ];
 


### PR DESCRIPTION
It is already possible to use PHP enums in Fluid templates: Both
ViewHelpers and components can define an enum as argument type by using
the full name of the enum. With the `<f:constant>` ViewHelper, it is
possible to access individual enum cases. And enum cases are just
special PHP objects, which is why their properties (such as "name" or
"value") can be accessed with Fluid's variable syntax.

This patch aims to make the usage of enums for ViewHelper and
components easier: If an argument type is a known enum, Fluid
automatically tries to convert the supplied value to the matching enum
case. This works both for basic and backed enums: For backed enums,
Fluid first tries to find the enum case by its backed value and falls
back to the enum name. For basic enums, only the name is considered.
If the supplied value cannot be converted, the value remains unchanged,
which leads to the normal validation exception for a non-matching
argument type.

Given the following enum and component:

```php
namespace Vendor\Package;

enum VariantEnum: int
{
    case BASIC = 123456;
}
```

```xml
<f:argument name="variant" type="Vendor\Package\VariantEnum" />

Selected variant: {variant.value}
```

Before this change, the `<f:constant>` ViewHelper needed to be used
if the value isn't already an enum:

```xml
<my:exampleComponent
    variant="{f:constant(name: 'Vendor\Package\VariantEnum::BASIC')}"
/>
```

With this change, the name of the enum case is sufficient:

```xml
<my:exampleComponent
    variant="BASIC"
/>
```

And because the enum is int-backed, this also works:

```xml
<my:exampleComponent
    variant="123456"
/>
```