### PR TITLE
[BUGFIX] Allow constants and enum cases as argument default

### DIFF
--- a/src/Core/ViewHelper/TemplateStructureViewHelperResolver.php
+++ b/src/Core/ViewHelper/TemplateStructureViewHelperResolver.php
@@ -16,6 +16,7 @@ namespace TYPO3Fluid\Fluid\Core\ViewHelper;
  * 2. Are there any sections?
  * 3. Are there argument definitions?
  * 4. Are there any slots?
+ * 5. PHP constants and enum cases to be used as default values for arguments
  * This prevents the parser from resolving _any_ ViewHelpers (both first and third party).
  * Note that this ViewHelperResolver results in templates that are not feasible for rendering
  * and should thus not be compiled/cached or rendered.
@@ -30,6 +31,7 @@ final class TemplateStructureViewHelperResolver extends ViewHelperResolver
         'section',
         'argument',
         'slot',
+        'constant',
     ];
 
     public function isNamespaceValid(string $namespaceIdentifier): bool

--- a/tests/Functional/Core/Component/ComponentRenderingTest.php
+++ b/tests/Functional/Core/Component/ComponentRenderingTest.php
@@ -62,6 +62,7 @@ final class ComponentRenderingTest extends AbstractFunctionalTestCase
             'additional arguments can be provided if delegate allows' => ['<my:additionalArgumentsJson foo="bar" />', '{"foo":"bar","myAdditionalVariable":"my additional value","viewHelperName":"additionalArgumentsJson"}' . "\n"],
             'union type, array provided' => ['<my:unionTypeArgument item="{property: \'foo\'}" />', "\nfoo\n"],
             'union type, string provided' => ['<my:unionTypeArgument item="bar" />', "\nbar\n"],
+            'enum type with default' => ['<my:enumTypeArgumentWithDefault />', "\nBAR => 123\n"],
         ];
     }
 

--- a/tests/Functional/Fixtures/Components/EnumTypeArgumentWithDefault/EnumTypeArgumentWithDefault.html
+++ b/tests/Functional/Fixtures/Components/EnumTypeArgumentWithDefault/EnumTypeArgumentWithDefault.html
@@ -1,0 +1,2 @@
+<f:argument name="value" type="TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample" optional="{true}" default="{f:constant(name: 'TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IntBackedEnumExample::BAR')}" />
+{value.name} => {value.value}


### PR DESCRIPTION
Due to the way the structure of components is extracted from template
files, it was previously not possible to use a PHP constant or enum
case as default value for a component argument.

This patch adds the `<f:constant>` ViewHelper to the list of allowed
ViewHelpers for that pre-parsing step, which makes it now possible
to use `<f:constant>` from within `<f:argument>`.