### PR TITLE
[TASK] Loosen PHPDoc type for Fluid namespaces

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolverDelegateInterface.php
+++ b/src/Core/ViewHelper/ViewHelperResolverDelegateInterface.php
@@ -37,8 +37,6 @@ interface ViewHelperResolverDelegateInterface
      * Returns the PHP namespace this delegate has been registered for
      * This string representation will be used to restore the delegate
      * object from the cache in the future.
-     *
-     * @return class-string
      */
     public function getNamespace(): string;
 }


### PR DESCRIPTION
Since a Fluid namespace does not necesarily refer to an existing class
(e. g. "TYPO3Fluid\Fluid\ViewHelpers" is not a valid PHP class), the
PHPDoc annotation is removed from `getNamespace()`.

This enables comparing namespace strings with the result of
`getNamespace()` without phpstan issues (e. g. "[...] will always
evaluate to false").