### PR TITLE
[TASK] Allow TemplateValidator to discover underscore variables

### DIFF
--- a/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/src/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\Variables\InvalidVariableIdentifierException;
 
 /**
  * A node which handles object access. This means it handles structures like {object.accessor.bla}
@@ -34,6 +35,12 @@ final class ObjectAccessorNode extends AbstractNode
      */
     public function __construct(string $objectPath)
     {
+        // TODO consider removing this exception in later Fluid versions. For now it allows the
+        //      TemplateValidator to find occurrances of variables starting with "_" in templates,
+        //      which are no longer allowed since Fluid 5.
+        if (str_starts_with($objectPath, '_') && $objectPath !== '_all') {
+            throw new InvalidVariableIdentifierException('Variable identifiers cannot start with a "_": ' . $objectPath, 1765900762);
+        }
         $this->objectPath = $objectPath;
     }
 

--- a/tests/Functional/Fixtures/Validation/AccessToInvalidVariableName.fluid.html
+++ b/tests/Functional/Fixtures/Validation/AccessToInvalidVariableName.fluid.html
@@ -1,0 +1,1 @@
+{_something.sub}

--- a/tests/Functional/Validation/TemplateValidatorTest.php
+++ b/tests/Functional/Validation/TemplateValidatorTest.php
@@ -26,6 +26,7 @@ final class TemplateValidatorTest extends AbstractFunctionalTestCase
             [$fixturePath . 'InvalidNamespace.fluid.html', 'Unknown Namespace: foo', 0],
             [$fixturePath . 'RequiredArgumentMissing.fluid.html', 'Required argument "each" was not supplied.', 1237823699],
             [$fixturePath . 'RedefinedComponentArgument.fluid.html', 'Template argument "foo" has been defined multiple times.', 1744908509],
+            [$fixturePath . 'AccessToInvalidVariableName.fluid.html', 'Variable identifiers cannot start with a "_": _something.sub', 1765900762],
         ];
     }
 


### PR DESCRIPTION
Fluid 5 disallows variable names that start with an underscore. While
this is already enforced in `StandardVariableProvider` for setting
such variables, this change now also triggers an exception if a
variable with an invalid name is accessed.

This is probably a temporary change to be removed with Fluid 6. For now,
it allows the `TemplateValidator`, which is used during template
warmup, to discover this issue during parse time, and to let users
know about affected templates.

Resolves: #1263