### PR TITLE
[BUGFIX] Cast stringable objects early for ViewHelper arguments

### DIFF
--- a/src/Core/ViewHelper/StrictArgumentProcessor.php
+++ b/src/Core/ViewHelper/StrictArgumentProcessor.php
@@ -35,7 +35,7 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
         // Boolean expressions are evaluated at the parser level, so we just make sure
         // that the input has the correct type
         return match ($definition->getType()) {
-            'string' => is_scalar($value) ? (string)$value : $value,
+            'string' => is_scalar($value) || $value instanceof Stringable ? (string)$value : $value,
             'int', 'integer' => is_scalar($value) ? (int)$value : $value,
             'float', 'double' => is_scalar($value) ? (float)$value : $value,
             'bool', 'boolean' => is_scalar($value) ? (bool)$value : $value,
@@ -67,13 +67,13 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
     /**
      * Check whether the defined type matches the value type
      */
-    private function isValidType(string $type, mixed $value): bool
+    private function isValidType(string $type, mixed $value, bool $allowStringableAsString = false): bool
     {
         if ($type === 'object') {
             return is_object($value);
         }
         if ($type === 'string') {
-            return is_string($value) || $value instanceof Stringable;
+            return is_string($value) || ($allowStringableAsString && $value instanceof Stringable);
         }
         if ($type === 'int' || $type === 'integer') {
             return is_int($value);
@@ -102,7 +102,7 @@ final readonly class StrictArgumentProcessor implements ArgumentProcessorInterfa
                 if ($firstElement === null) {
                     return true;
                 }
-                return $this->isValidType(substr($type, 0, -2), $firstElement);
+                return $this->isValidType(substr($type, 0, -2), $firstElement, true);
             }
             return true;
         }

--- a/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
+++ b/tests/Unit/Core/ViewHelper/StrictArgumentProcessorTest.php
@@ -212,8 +212,8 @@ final class StrictArgumentProcessorTest extends TestCase
         yield [
             'type' => 'string',
             'value' => $stringable,
-            'expectedValidity' => true,
-            'expectedProcessedValue' => $stringable,
+            'expectedValidity' => false,
+            'expectedProcessedValue' => 'foo',
             'expectedProcessedValidity' => true,
         ];
 
@@ -762,9 +762,9 @@ final class StrictArgumentProcessorTest extends TestCase
         yield [
             'type' => 'int|string',
             'value' => $stringable,
-            'expectedValidity' => true,
+            'expectedValidity' => false,
             'expectedProcessedValue' => $stringable,
-            'expectedProcessedValidity' => true,
+            'expectedProcessedValidity' => false,
         ];
         // No support for automatic type casting
         yield [


### PR DESCRIPTION
Since Fluid 5, ViewHelpers can assume that the types of their arguments
are properly enforced by Fluid: Either by automatic casting for simple
types or by throwing an exception. However, this is currently not the
case for `string`: Here, `StrictArgumentProcessor` still accepts
stringable objects as input (which is correct), but passes them along
to the ViewHelper as-is (= not casted). So if a ViewHelper requests an
argument to be of type `string`, it still might receive an object
which then needs to be cast by the ViewHelper implementation. This is
especially relevant for ViewHelpers that use strict types because it
might lead to unexpected type errors in the context of a template.

This patch ensures that stringable objects are cast to string early.
This has no negative effects on ViewHelpers that use `string` as type.
String collections (`string[]`) remain untouched because that would
require preprocessing of arrays, which we currently don't do.

However, if the recently introduced union types are used, ViewHelpers
might need to be adjusted if they should also work with stringable
objects:

Before:

```
$this->registerArgument('value', 'string|int|float', '');
```

After:

```
$this->registerArgument('value', 'string|int|float|Stringable', '');
```

Since one specified goal of Fluid 5 is type safety within ViewHelpers,
this is considered a bugfix.

Resolves: #1099