### PR TITLE
[DOCS] Fluid file extension

### DIFF
--- a/Documentation/Usage/Components.rst
+++ b/Documentation/Usage/Components.rst
@@ -106,15 +106,15 @@ architecture and enables easier refactoring.
     * :path:`path/to/Components/`
         * :path:`Atom`
             * :path:`Button`
-                * :file:`Button.html`
+                * :file:`Button.fluid.html`
 
 Check out :ref:`components-folder-structure` if you want to adjust this.
 
 The :xml:`<my:atom.button>` component thus would be defined in
-`path/to/Components/Atom/Button/Button.html` like this:
+`path/to/Components/Atom/Button/Button.fluid.html` like this:
 
 ..  code-block:: xml
-    :caption: Button.html (component definition)
+    :caption: Button.fluid.html (component definition)
 
     <f:argument name="variant" type="string" optional="{true}" default="primary" />
 
@@ -135,7 +135,7 @@ been created, it can be imported into any Fluid template and component tags
 can be used:
 
 ..  code-block:: xml
-    :caption: MyTemplate.html
+    :caption: MyTemplate.fluid.html
 
     <html
         xmlns:my="http://typo3.org/ns/Vendor/MyPackage/Components/ComponentCollection"
@@ -175,7 +175,7 @@ Combining Components
 Components can also be nested:
 
 ..  code-block:: xml
-    :caption: MyTemplate.html
+    :caption: MyTemplate.fluid.html
 
     <html
         xmlns:my="http://typo3.org/ns/Vendor/MyPackage/Components/ComponentCollection"
@@ -191,7 +191,7 @@ An alternative approach that prevents the need for nesting would be to call the 
 component from within the `atom.button` component and to extend its argument API accordingly:
 
 ..  code-block:: xml
-    :caption: MyTemplate.html
+    :caption: MyTemplate.fluid.html
 
     <html
         xmlns:my="http://typo3.org/ns/Vendor/MyPackage/Components/ComponentCollection"
@@ -205,7 +205,7 @@ component from within the `atom.button` component and to extend its argument API
 The extended `atom.button` component could look something like this:
 
 ..  code-block:: xml
-    :caption: Button.html (component definition)
+    :caption: Button.fluid.html (component definition)
 
     <html
         xmlns:my="http://typo3.org/ns/Vendor/MyPackage/Components/ComponentCollection"
@@ -265,7 +265,7 @@ which allows you to do just that:
 In your component templates you would then be able to access those tokens:
 
 ..  code-block:: xml
-    :caption: MyComponent.html (component definition)
+    :caption: MyComponent.fluid.html (component definition)
 
     <f:argument name="color" type="string" optional="{true}" default="brand" />
 
@@ -308,7 +308,7 @@ in the collection):
 The following call of the button component would then be valid:
 
 ..  code-block:: xml
-    :caption: MyTemplate.html
+    :caption: MyTemplate.fluid.html
 
     <html
         xmlns:my="http://typo3.org/ns/Vendor/MyPackage/Components/ComponentCollection"
@@ -327,7 +327,7 @@ Alternative Folder Structure
 ============================
 
 If you want to define an alternative folder structure to the default
-`{componentName}/{componentName}.html`, you can do so by providing a custom
+`{componentName}/{componentName}.fluid.html`, you can do so by providing a custom
 implementation of :php:`resolveTemplateName()` in your :php:`ComponentCollection`.
 The following example skips the additional folder per component:
 
@@ -349,10 +349,10 @@ The following example skips the additional folder per component:
         }
     }
 
-`<my:atom.button>` will then be resolved to `path/to/Components/Atom/Button.html`.
+`<my:atom.button>` will then be resolved to `path/to/Components/Atom/Button.fluid.html`.
 
 ..  directory-tree::
 
     * :path:`path/to/Components/`
         * :path:`Atom`
-            * :path:`Button.html`
+            * :path:`Button.fluid.html`

--- a/Documentation/Usage/GettingStarted.rst
+++ b/Documentation/Usage/GettingStarted.rst
@@ -30,7 +30,7 @@ you need to be aware of `TemplateView`, the `RenderingContext` and `TemplatePath
 *   `TemplatePaths`, which is usually a sub-object of the rendering context. It provides multiple
     ways to define the location(s) to your template files.
 
-To render a template file called `MyTemplate.html`, which is located in `/path/to/templates/`,
+To render a template file called `MyTemplate.fluid.html`, which is located in `/path/to/templates/`,
 you first create a `TemplateView` object:
 
 .. code-block:: php
@@ -50,15 +50,7 @@ Finally, you can render the desired template:
 
     $view->render('MyTemplate');
 
-By default, `.html` is used as file extension. If you want to change this, you can specify a different
-format in `TemplatePaths`:
-
-.. code-block:: php
-
-    $view->getRenderingContext()->getTemplatePaths()->setFormat('xml');
-    $view->render('MyTemplate');
-
-Which would then render `MyTemplate.xml`.
+By default, `.fluid.html` is used as file extension.
 
 .. _assign-variables:
 

--- a/Documentation/Usage/Structure.rst
+++ b/Documentation/Usage/Structure.rst
@@ -53,12 +53,45 @@ associated with your `RenderingContext`:
     $paths->setTemplateRootPaths(['/path/to/templates/']);
     $paths->setLayoutRootPaths(['/path/to/layouts/']);
     $paths->setPartialRootPaths(['/path/to/partials/']);
+    // Render specific template
+    $view->render('myTemplate');
 
 Note that paths are *always defined as arrays*. In the default `TemplatePaths`
 implementation, Fluid supports lookups in multiple template file locations -
 which is very useful if you are rendering template files from another package
 and wish to replace just a few template files. By adding your own template files
 path *last in the paths arrays*, Fluid will check those paths *first*.
+
+.. _template-resolving:
+
+Template Resolving
+------------------
+
+..  versionadded:: Fluid 5.0
+
+When a specific template is requested to be rendered, Fluid creates a list of
+file name alternatives based on the provided template name. This fallback
+chain is then used to determine which file should be rendered.
+
+In the example above, the following chain would be used (first existing file
+wins):
+
+1. /path/to/templates/myTemplate.fluid.html
+2. /path/to/templates/myTemplate.html
+3. /path/to/templates/myTemplate
+4. /path/to/templates/MyTemplate.fluid.html
+5. /path/to/templates/MyTemplate.html
+6. /path/to/templates/MyTemplate
+
+As you can see, this provides backwards compatibility for `.html` files, but
+prefers the `.fluid.html` extension. It also includes a fallback from lowercase
+to uppercase file names.
+
+Note that `html` is the default template format, which can be changed via `TemplatePaths`:
+
+.. code-block:: php
+
+    $paths->setFormat('xml');
 
 .. _templates:
 
@@ -99,9 +132,9 @@ rendering templates in an MVC context, some templates might use layouts and
 others might not. Whether or not you use layouts of course depends on the
 design you are trying to convey.
 
-* `An example Template without a Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Singles/LayoutLess.html>`__
-* `An example Template with a Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Templates/Default/Default.html>`__ and the
-  `Layout used by that Template <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Layouts/Default.html>`__
+* `An example Template without a Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Singles/LayoutLess.fluid.html>`__
+* `An example Template with a Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Templates/Default/Default.fluid.html>`__ and the
+  `Layout used by that Template <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Layouts/Default.fluid.html>`__
 
 .. _layouts:
 
@@ -119,8 +152,8 @@ layout renders with `<f:render>`. In application terms, the rendering engine
 switches to the layout when it detects one and renders it while preserving the
 template's context of controller name and action name.
 
-* `An example Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Layouts/Default.html>`__ and
-  `Template which uses it <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Templates/Default/Default.html>`__
+* `An example Layout <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Layouts/Default.fluid.html>`__ and
+  `Template which uses it <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Templates/Default/Default.fluid.html>`__
 
 .. _partials:
 
@@ -155,8 +188,8 @@ including inside the Partial itself, by `<f:render partial="NameOfPartial" secti
 Partials without sections can be rendered by just
 `<f:render partial="NameOfPartial" />` (with or without `arguments`).
 
-* `An example of a partial template without sections <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Partials/FirstPartial.html>`__
-* `An example of a partial template with sections <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Partials/Structures.html>`__
+* `An example of a partial template without sections <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Partials/FirstPartial.fluid.html>`__
+* `An example of a partial template with sections <https://github.com/TYPO3/Fluid/blob/main/examples/Resources/Private/Partials/Structures.fluid.html>`__
 
 .. _template-argument-definitions:
 


### PR DESCRIPTION
Documentation is added for the new `*.fluid.*` file extension and the
associated fallback chain. File references throughout the documentation
are adjusted to always use the new extension. Also, links to moved files
are fixed.

Resolves: #1289