### PR TITLE
[BUGFIX] Don't remove path duplicates to allow reordering

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: src/Core/Variables/JSONVariableProvider.php
 
 		-
-			message: '#^Parameter \#1 \$array of function array_unique expects an array of values castable to string, array\<array\<string\>\|string\> given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/View/TemplatePaths.php
-
-		-
 			message: '#^Variable \$iterationData might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -272,17 +272,18 @@ class TemplatePaths
      * Sanitize a path, ensuring it is absolute and
      * if a directory, suffixed by a trailing slash.
      *
-     * @todo $path should really be string. Array handling should not be part of this method, and other types
-     *       (such as bool) should really not be passed to this method in the first place. Further refactoring
-     *       is necessary to guarantee this.
+     * @todo Change $path from "mixed" to "string" in Fluid 6. The method signature has only been changed to
+     *       accommodate for an override of this method in TYPO3, which is no longer present. Fluid itself
+     *       never passed anything else to this method other than strings.
      * @param mixed $path
      * @return string|string[]
      */
     protected function sanitizePath(mixed $path): string|array
     {
+        // @todo remove this in Fluid 6
         if (is_array($path)) {
             $paths = array_map([$this, 'sanitizePath'], $path);
-            return array_unique($paths);
+            return $paths;
         }
         if (($wrapper = parse_url((string)$path, PHP_URL_SCHEME)) && in_array($wrapper, stream_get_wrappers())) {
             return $path;
@@ -305,7 +306,7 @@ class TemplatePaths
      */
     protected function sanitizePaths(array $paths): array
     {
-        return array_unique(array_map([$this, 'sanitizePath'], $paths));
+        return array_map([$this, 'sanitizePath'], $paths);
     }
 
     /**

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -49,6 +49,8 @@ final class TemplatePathsTest extends TestCase
             [['/foo/bar/baz', 'C:\\foo\\bar\\baz'], ['/foo/bar/baz', 'C:/foo/bar/baz']],
             [[__FILE__, __DIR__], [strtr(__FILE__, '\\', '/'), strtr(__DIR__, '\\', '/') . '/']],
             [['', 'composer.json'], ['', strtr(getcwd(), '\\', '/') . '/composer.json']],
+            [['/path/to/original', '/path/to/override'], ['/path/to/original', '/path/to/override']],
+            [['/path/to/original', '/path/to/override', '/path/to/original'], ['/path/to/original', '/path/to/override', '/path/to/original']],
         ];
     }
 
@@ -270,6 +272,13 @@ final class TemplatePathsTest extends TestCase
                 '',
                 'InBoth',
                 __DIR__ . '/Fixtures/TemplateResolving/Templates2/InBoth.html',
+            ],
+            // Use case: "Moving" a template path by adding it twice to the chain
+            'reorder template path chain' => [
+                [__DIR__ . '/Fixtures/TemplateResolving/Templates1', __DIR__ . '/Fixtures/TemplateResolving/Templates2', __DIR__ . '/Fixtures/TemplateResolving/Templates1'],
+                '',
+                'InBoth',
+                __DIR__ . '/Fixtures/TemplateResolving/Templates1/InBoth.html',
             ],
             'non-existent path is skipped' => [
                 [__DIR__ . '/Fixtures/TemplateResolving/Templates1', __DIR__ . '/Fixtures/TemplateResolving/TemplatesFoo'],


### PR DESCRIPTION
Previously, duplicate template/partial/layout root paths were removed
from the array to avoid potential duplicate lookups. However, this
prevented reordering of those paths by adding one path multiple times
to the same array, which would ideally increase its priority over
other paths.

This patch removes the associated `array_unique()` call. To prevent
breaking projects where such a configuration is already in use
unintentionally, this patch is not backported to Fluid 4. However,
this is highly unlikely, which is why this is not considered a
breaking change in Fluid 5.

This patch also clarifies comments to be able to simplify code with
Fluid 6.