### PR TITLE
[BUGFIX] Allow null value as input for f:replace (#1282)

### DIFF
--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -67,7 +67,7 @@ final class ReplaceViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         $search = $this->arguments['search'];
         $replace = $this->arguments['replace'];
-        if ($value === null || (!is_scalar($value) && !$value instanceof \Stringable)) {
+        if ($value !== null && !is_scalar($value) && !$value instanceof \Stringable) {
             throw new \InvalidArgumentException('A stringable value must be provided.', 1710441987);
         }
         if ($search === null) {

--- a/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
@@ -20,12 +20,6 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
 {
     public static function throwsExceptionForInvalidArgumentDataProvider(): iterable
     {
-        yield 'without value' => [
-            '<f:replace search="foo" replace="bar" />',
-            [],
-            1710441987,
-            'A stringable value must be provided.',
-        ];
         yield 'array as value' => [
             '{value -> f:replace(search: \'foo\', replace: \'bar\')}',
             ['value' => [1, 2, 3]],
@@ -130,6 +124,11 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
         yield 'search and replace in empty string' => [
             '<f:replace value="{value}" search="foo" replace="bar" />',
             ['value' => ''],
+            '',
+        ];
+        yield 'with null as value' => [
+            '<f:replace search="foo" replace="bar" value="{null}" />',
+            [],
             '',
         ];
     }


### PR DESCRIPTION
`null` can safely be converted to an empty string, so it's fine to
allow it as a base string for string replacement.

Resolves: #1279