### PR TITLE
[FEATURE] UnsafeHTML interface to allow passing variables to template without being escaped (#1288)

### DIFF
--- a/examples/Resources/Private/Singles/Variables.html
+++ b/examples/Resources/Private/Singles/Variables.html
@@ -38,7 +38,8 @@ Direct access of numeric prefixed variable: {123numericprefix}
 		xyz: '{
 			foobar: \'Escaped sub-string\'
 		}'
-	}
+	},
+	unsafeHTML: unsafeHTML
 }"/>
 
 </f:section>
@@ -51,4 +52,7 @@ Received $array.printf with formatted string {array.printf -> f:format.printf(ar
 Received $array.baz with value {array.baz}
 Received $array.xyz.foobar with value {array.xyz.foobar}
 Received $myVariable with value {myVariable}
+Received $unsafeHTML with unescaped value {unsafeHTML}
+Received $unsafeHTML with format.raw {unsafeHTML -> f:format.raw()}
+Received $unsafeHTML with format.htmlspecialchars {unsafeHTML -> f:format.htmlspecialchars()}
 </f:section>

--- a/examples/example_variables.php
+++ b/examples/example_variables.php
@@ -13,6 +13,7 @@
  * how dynamic variable access works.
  */
 
+use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTMLString;
 use TYPO3Fluid\FluidExamples\Helper\ExampleHelper;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -56,6 +57,8 @@ $view->assignMultiple([
     '123numericprefix' => 'Numeric prefixed variable',
     // A variable whose value refers to another variable name
     'dynamicVariableName' => 'foobar',
+    // An UnsafeHTML variable that will not be escaped when rendered
+    'unsafeHTML' => new UnsafeHTMLString('<strong>Safe HTML String</strong>'),
 ]);
 
 // Assigning the template path and filename to be rendered. Doing this overrides

--- a/src/Core/Parser/SyntaxTree/BooleanNode.php
+++ b/src/Core/Parser/SyntaxTree/BooleanNode.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
+use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTML;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -127,6 +128,10 @@ class BooleanNode extends AbstractNode
         }
         if (is_numeric($value)) {
             return (bool)((float)$value);
+        }
+        if ($value instanceof UnsafeHTML) {
+            // unpack UnsafeHTML to string, as it may be empty
+            $value = (string)$value;
         }
         if (is_string($value)) {
             if (strlen($value) === 0) {

--- a/src/Core/Parser/SyntaxTree/EscapingNode.php
+++ b/src/Core/Parser/SyntaxTree/EscapingNode.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Core\Parser\SyntaxTree;
 
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTML;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -39,6 +40,9 @@ class EscapingNode extends AbstractNode
     public function evaluate(RenderingContextInterface $renderingContext): mixed
     {
         $evaluated = $this->node->evaluate($renderingContext);
+        if ($evaluated instanceof UnsafeHTML) {
+            return (string)$evaluated;
+        }
         if (is_string($evaluated) || (is_object($evaluated) && method_exists($evaluated, '__toString'))) {
             return htmlspecialchars((string)$evaluated, ENT_QUOTES);
         }
@@ -66,6 +70,7 @@ class EscapingNode extends AbstractNode
         if ($configuration['execution'] !== '\'\'') {
             $configuration['execution'] = sprintf(
                 'call_user_func_array( function ($var) { '
+                . 'if ($var instanceof ' . UnsafeHTML::class . ') { return (string)$var; }'
                 . 'return (is_string($var) || (is_object($var) && method_exists($var, \'__toString\')) '
                 . '? htmlspecialchars((string) $var, ENT_QUOTES) : $var); }, [%s])',
                 $configuration['execution'],

--- a/src/Core/Parser/UnsafeHTML.php
+++ b/src/Core/Parser/UnsafeHTML.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
+
+use Stringable;
+
+/**
+ * Interface for values that are considered safe HTML
+ * and will not be escaped by the Fluid rendering engine.
+ *
+ * Use with caution and ensure the HTML has already been sanitized, as it will not be escaped by the Fluid rendering engine.
+ *
+ * @method string __toString() returns HTML that has already been sanitized and will not be escaped by the Fluid rendering engine.
+ * @internal
+ */
+interface UnsafeHTML extends Stringable {}

--- a/src/Core/Parser/UnsafeHTMLString.php
+++ b/src/Core/Parser/UnsafeHTMLString.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Parser;
+
+use Stringable;
+
+/**
+ * value object for values that are considered safe HTML
+ * and will not be escaped by the Fluid rendering engine.
+ *
+ * Use with caution and ensure the HTML has already been sanitized, as it will not be escaped by the Fluid rendering engine.
+ *
+ * @internal
+ */
+final readonly class UnsafeHTMLString implements UnsafeHTML
+{
+    /**
+     * @param string|Stringable $html HTML that has already been sanitized and will not be escaped by the Fluid rendering engine.
+     */
+    public function __construct(private string|Stringable $html) {}
+
+    /**
+     * @inheritDoc
+     */
+    public function __toString(): string
+    {
+        return (string)$this->html;
+    }
+}

--- a/tests/Functional/Core/ViewHelper/ConditionViewHelperTest.php
+++ b/tests/Functional/Core/ViewHelper/ConditionViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTMLString;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -78,6 +79,7 @@ final class ConditionViewHelperTest extends AbstractFunctionalTestCase
             'foo' => 'bar',
         ];
         $emptyCountable = new \SplObjectStorage();
+        $htmlString = new UnsafeHTMLString('baz');
 
         return [
             // simple assignments
@@ -93,6 +95,12 @@ final class ConditionViewHelperTest extends AbstractFunctionalTestCase
             ['{test1} === {test2}', true, ['test1' => 'abc', 'test2' => 'abc']],
             ['{test1} === {test2}', false, ['test1' => 1, 'test2' => true]],
             ['{test1} == {test2}', true, ['test1' => 1, 'test2' => true]],
+
+            // conditions with UnsafeHTMLString
+            ['{test}', true, ['test' => $htmlString]],
+            ['{test} == \'baz\'', true, ['test' => $htmlString]],
+            ['{test1} === {test2}', false, ['test1' => 'baz', 'test2' => $htmlString]],
+            ['{test1} == {test2}', true, ['test1' => 'baz', 'test2' => $htmlString]],
 
             // conditions with objects
             ['{user1} == {user1}', true, ['user1' => $user1]],

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -167,6 +167,9 @@ final class ExamplesTest extends AbstractFunctionalTestCase
                     'Received $array.baz with value 42',
                     'Received $array.xyz.foobar with value Escaped sub-string',
                     'Received $myVariable with value Nice string',
+                    'Received $unsafeHTML with unescaped value <strong>Safe HTML String</strong>',
+                    'Received $unsafeHTML with format.raw <strong>Safe HTML String</strong>',
+                    'Received $unsafeHTML with format.htmlspecialchars &lt;strong&gt;Safe HTML String&lt;/strong&gt;',
                 ],
             ],
             'example_variableprovider.php' => [

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
+use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTMLString;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 
 final class BooleanParserTest extends TestCase
@@ -104,6 +105,15 @@ final class BooleanParserTest extends TestCase
             ['{foo}', true, ['foo' => true]],
             ['{foo} == FALSE', true, ['foo' => false]],
             ['!{foo}', true, ['foo' => false]],
+
+            ['{foo}', false, ['foo' => new UnsafeHTMLString('')]],
+            ["{foo} == ''", true, ['foo' => new UnsafeHTMLString('')]],
+            ['{foo}', true, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} == FALSE', false, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} == TRUE', true, ['foo' => new UnsafeHTMLString('test')]],
+            ["{foo} == 'test'", true, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} === TRUE', false, ['foo' => new UnsafeHTMLString('0')]],
+            ['{foo} === \'0\'', false, ['foo' => new UnsafeHTMLString('0')]],
 
             /*
              * @todo This should work but doesn't at the moment. This is probably related to the boolean


### PR DESCRIPTION
Fluid escapes variable output by default to prevent XSS. In some cases,
however, values originate from a trusted/sanitized source (e.g. HTML
generated from a sanitizer, CMS RTE output, a Markdown renderer with
a strict allow-list, …) and should be rendered as HTML without forcing
template authors to opt out of escaping via `f:format.raw` or similar.

This change introduces a marker interface
`TYPO3Fluid\Fluid\Core\Parser\UnsafeHTML` for values that should be
rendered unescaped. Any object implementing this interface will
bypass Fluid’s escaping and will be output as-is via `__toString()`.
For now, this interface is marked as `@internal` to be able to make
adjustments within the Fluid 5 branch, if necessary.

A small helper value object `UnsafeHTMLString` is included for convenience.

Example (PHP):
````php
use TYPO3Fluid\Fluid\Core\Parser\UnsafeHTMLString;

// $safeHtml must already be sanitized/escaped appropriately
$view->assign('content', new UnsafeHTMLString($safeHtml));
````
Template:
````html
{content}
````
Technical notes:

- `EscapingNode` now detects `UnsafeHTML` and returns the value unescaped.
- The compiled escaping closure generated by the `TemplateCompiler`
  includes the same check, so compiled templates behave identically.
- Boolean expression evaluation unwraps `UnsafeHTML` to a string first,
  so empty HTML values behave like empty strings in conditions
  (e.g. `{content}` is false when it’s `''`).

Tests/examples have been adjusted accordingly.