### PR TITLE
[BUGFIX] make ContentArgumentName non required argument

### DIFF
--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -543,7 +543,7 @@ class TemplateParser
                 $this->escapingEnabled = $escapingEnabledBackup;
             }
         }
-        $this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $argumentsObjectTree);
+        $this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $argumentsObjectTree, $viewHelperNode->getUninitializedViewHelper()->getContentArgumentName());
         $viewHelperNode->getUninitializedViewHelper()->validateAdditionalArguments($undeclaredArguments);
         return $argumentsObjectTree + $undeclaredArguments;
     }
@@ -816,7 +816,7 @@ class TemplateParser
             }
         }
         if ($viewHelperNode instanceof ViewHelperNode) {
-            $this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $arrayToBuild);
+            $this->abortIfRequiredArgumentsAreMissing($argumentDefinitions, $arrayToBuild, $viewHelperNode->getUninitializedViewHelper()->getContentArgumentName());
             $viewHelperNode->getUninitializedViewHelper()->validateAdditionalArguments($undeclaredArguments);
         }
         return $arrayToBuild + $undeclaredArguments;
@@ -851,10 +851,14 @@ class TemplateParser
      * @param NodeInterface[] $actualArguments Actual arguments
      * @throws Exception
      */
-    protected function abortIfRequiredArgumentsAreMissing(array $expectedArguments, array $actualArguments): void
+    protected function abortIfRequiredArgumentsAreMissing(array $expectedArguments, array $actualArguments, ?string $contentArgumentName): void
     {
         $actualArgumentNames = array_keys($actualArguments);
         foreach ($expectedArguments as $name => $expectedArgument) {
+            if ($name === $contentArgumentName) {
+                continue;
+            }
+
             if ($expectedArgument->isRequired() && !in_array($name, $actualArgumentNames)) {
                 throw new Exception('Required argument "' . $name . '" was not supplied.', 1237823699);
             }


### PR DESCRIPTION
if you have a ViewHelper that has a required argument like 'record'.
And you use 
````php
    public function getContentArgumentName(): string
    {
        return 'record';
    }
````

and then you want to use:

````html
{record -> my:vh()}
````

you currently get this error:
````
Fluid parse error in template template_..., line 19 at character 1. Error: Required argument "record" was not supplied. (error code 1237823699). Template source chunk: ...
````