### PR TITLE
[TASK] Improve return type annotation for VH creation

### DIFF
--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -360,6 +360,10 @@ class ViewHelperResolver
      * the final method called when creating ViewHelper classes -
      * overriding this method allows custom constructors, dependency
      * injections etc. to be performed on the ViewHelper instance.
+     *
+     * @template T of ViewHelperInterface
+     * @param class-string<T> $viewHelperClassName
+     * @return T
      */
     public function createViewHelperInstanceFromClassName(string $viewHelperClassName): ViewHelperInterface
     {


### PR DESCRIPTION
The return type for `ViewHelperResolver::createViewHelperInstance()` can be derived from the given parameter `$viewHelperClassName`. This enables better type handling when using static code analysis, especially in user-land code.