### PR TITLE
[FEATURE] API to generate component listings

### DIFF
--- a/src/Core/Component/AbstractComponentCollection.php
+++ b/src/Core/Component/AbstractComponentCollection.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Core\Component;
 
+use ReflectionMethod;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateStructureViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\UnresolvableViewHelperException;
@@ -21,7 +22,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
  *
  * @api
  */
-abstract class AbstractComponentCollection implements ViewHelperResolverDelegateInterface, ComponentDefinitionProviderInterface, ComponentTemplateResolverInterface
+abstract class AbstractComponentCollection implements ViewHelperResolverDelegateInterface, ComponentDefinitionProviderInterface, ComponentTemplateResolverInterface, ComponentListProviderInterface
 {
     /**
      * Runtime cache for component definitions. This mainly speeds up uncached templates since we
@@ -32,11 +33,13 @@ abstract class AbstractComponentCollection implements ViewHelperResolverDelegate
     private array $componentDefinitionsCache = [];
 
     /**
-     * Overwrite this method if you want to use a different folder structure for component templates
+     * Overwrite this method if you want to use a different folder structure for component templates.
+     * Note that getAvailableComponents() might need adjustment as well to get consistent results.
      *
      * @param string $viewHelperName  ViewHelper tag name from a template, e. g. atom.button
      * @return string                 Component template name to be used for this ViewHelper,
      *                                without format suffix, e. g. Atom/Button/Button
+     * @see getAvailableComponents()
      */
     public function resolveTemplateName(string $viewHelperName): string
     {
@@ -44,6 +47,51 @@ abstract class AbstractComponentCollection implements ViewHelperResolverDelegate
         $name = array_pop($fragments);
         $path = implode('/', $fragments);
         return ($path !== '' ? $path . '/' : '') . $name . '/' . $name;
+    }
+
+    /**
+     * Discovers all available components in the collection. Note that this default implementation
+     * assumes the same folder structure as the default implementation of resolveTemplateName().
+     *
+     * @return string[]
+     * @see resolveTemplateName()
+     */
+    public function getAvailableComponents(): array
+    {
+        /**
+         * To not return an inconsistent result for existing component collections that use a different
+         * folder structure by overriding resolveTemplateName(), we check if that method has been
+         * overridden and then default to an empty array. In those cases, a custom getAvailableComponents()
+         * needs to be implemented by the component collection.
+         *
+         * @todo remove this in Fluid 6 and add notice to changelog that getAvailableComponents()
+         *       and resolveTemplateName() must be implemented consistently.
+         */
+        if ((new ReflectionMethod($this, 'resolveTemplateName'))->getDeclaringClass()->getName() !== self::class) {
+            return [];
+        }
+        $availableTemplates = $this->getTemplatePaths()->resolveAvailableTemplateFiles(null, null, true);
+        $availableComponents = [];
+        foreach ($availableTemplates as $templatePath) {
+            // Remove template root path
+            foreach ($this->getTemplatePaths()->getTemplateRootPaths() as $rootPath) {
+                if (str_starts_with($templatePath, $rootPath)) {
+                    $templatePath = substr($templatePath, strlen($rootPath));
+                    break;
+                }
+            }
+            // Convert template name into ViewHelper name and validate directory structure
+            // (resolveTemplateName() in reverse)
+            $fragments = explode('/', $templatePath);
+            $name1 = array_pop($fragments);
+            $name2 = array_pop($fragments);
+            if ($name1 !== $name2) {
+                continue;
+            }
+            $fragments[] = $name2;
+            $availableComponents[] = implode('.', array_map(lcfirst(...), $fragments));
+        }
+        return $availableComponents;
     }
 
     /**

--- a/src/Core/Component/ComponentListProviderInterface.php
+++ b/src/Core/Component/ComponentListProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Component;
+
+/**
+ * @api
+ * @see AbstractComponentCollection
+ */
+interface ComponentListProviderInterface
+{
+    /**
+     * Returns a list of component names that are available in a
+     * component collection
+     * @return string[]
+     */
+    public function getAvailableComponents(): array;
+}

--- a/tests/Functional/Core/Component/AbstractComponentCollectionTest.php
+++ b/tests/Functional/Core/Component/AbstractComponentCollectionTest.php
@@ -14,10 +14,14 @@ use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Core\Component\AbstractComponentCollection;
 use TYPO3Fluid\Fluid\Core\Component\ComponentAdapter;
 use TYPO3Fluid\Fluid\Core\Component\ComponentDefinition;
+use TYPO3Fluid\Fluid\Core\Component\ComponentListProviderInterface;
 use TYPO3Fluid\Fluid\Core\Component\ComponentRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\UnresolvableViewHelperException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections\BasicComponentCollection;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections\CustomPathStructureComponentCollection;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections\CustomPathStructureWithListComponentCollection;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplatePaths;
 
@@ -222,5 +226,68 @@ final class AbstractComponentCollectionTest extends AbstractFunctionalTestCase
             }
         };
         self::assertSame(get_class($subject), $subject->getNamespace());
+    }
+
+    public static function getAvailableComponentsDataProvider(): array
+    {
+        return [
+            [
+                new BasicComponentCollection(),
+                [
+                    'additionalArguments',
+                    'additionalArgumentsJson',
+                    'additionalVariable',
+                    'booleanArgument',
+                    'enumTypeArgumentWithDefault',
+                    'globalNamespaceUsage',
+                    'localNamespaceImport',
+                    'namedSlots',
+                    'namespace.test',
+                    'nested.subComponent',
+                    'rawVariable',
+                    'recursive',
+                    'slotComponent',
+                    'testComponent',
+                    'unionTypeArgument',
+                    'unresolvableLocalNamespaceImport',
+                ],
+            ],
+            // @todo this will change with Fluid 6, see AbstractComponentCollection for details
+            [
+                new CustomPathStructureComponentCollection(),
+                [],
+            ],
+            [
+                new CustomPathStructureWithListComponentCollection(),
+                [
+                    'additionalArguments.additionalArguments',
+                    'additionalArgumentsJson.additionalArgumentsJson',
+                    'additionalVariable.additionalVariable',
+                    'booleanArgument.booleanArgument',
+                    'enumTypeArgumentWithDefault.enumTypeArgumentWithDefault',
+                    'globalNamespaceUsage.globalNamespaceUsage',
+                    'localNamespaceImport.localNamespaceImport',
+                    'namedSlots.namedSlots',
+                    'namespace.test.test',
+                    'nested.subComponent.subComponent',
+                    'rawVariable.rawVariable',
+                    'recursive.recursive',
+                    'slotComponent.slotComponent',
+                    'templateInvalidStructure',
+                    'testComponent.testComponent',
+                    'unionTypeArgument.unionTypeArgument',
+                    'unresolvableLocalNamespaceImport.unresolvableLocalNamespaceImport',
+                ],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('getAvailableComponentsDataProvider')]
+    public function getAvailableComponents(ComponentListProviderInterface $componentCollection, array $expectedComponents): void
+    {
+        $availableComponents = $componentCollection->getAvailableComponents();
+        sort($availableComponents);
+        self::assertSame($expectedComponents, $availableComponents);
     }
 }

--- a/tests/Functional/Fixtures/ComponentCollections/CustomPathStructureComponentCollection.php
+++ b/tests/Functional/Fixtures/ComponentCollections/CustomPathStructureComponentCollection.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections;
+
+use TYPO3Fluid\Fluid\Core\Component\AbstractComponentCollection;
+use TYPO3Fluid\Fluid\View\TemplatePaths;
+
+/**
+ * @todo remove with Fluid 6
+ */
+final class CustomPathStructureComponentCollection extends AbstractComponentCollection
+{
+    public function getTemplatePaths(): TemplatePaths
+    {
+        $templatePaths = new TemplatePaths();
+        $templatePaths->setTemplateRootPaths([
+            __DIR__ . '/../Components/',
+        ]);
+        return $templatePaths;
+    }
+
+    public function resolveTemplateName(string $viewHelperName): string
+    {
+        $fragments = array_map(ucfirst(...), explode('.', $viewHelperName));
+        $name = array_pop($fragments);
+        $path = implode('/', $fragments);
+        return ($path !== '' ? $path . '/' : '') . $name;
+    }
+}

--- a/tests/Functional/Fixtures/ComponentCollections/CustomPathStructureWithListComponentCollection.php
+++ b/tests/Functional/Fixtures/ComponentCollections/CustomPathStructureWithListComponentCollection.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections;
+
+use TYPO3Fluid\Fluid\Core\Component\AbstractComponentCollection;
+use TYPO3Fluid\Fluid\View\TemplatePaths;
+
+final class CustomPathStructureWithListComponentCollection extends AbstractComponentCollection
+{
+    public function getTemplatePaths(): TemplatePaths
+    {
+        $templatePaths = new TemplatePaths();
+        $templatePaths->setTemplateRootPaths([
+            __DIR__ . '/../Components/',
+        ]);
+        return $templatePaths;
+    }
+
+    public function resolveTemplateName(string $viewHelperName): string
+    {
+        $fragments = array_map(ucfirst(...), explode('.', $viewHelperName));
+        $name = array_pop($fragments);
+        $path = implode('/', $fragments);
+        return ($path !== '' ? $path . '/' : '') . $name;
+    }
+
+    public function getAvailableComponents(): array
+    {
+        $availableTemplates = $this->getTemplatePaths()->resolveAvailableTemplateFiles(null, null, true);
+        $availableComponents = [];
+        foreach ($availableTemplates as $templatePath) {
+            // Remove template root path
+            foreach ($this->getTemplatePaths()->getTemplateRootPaths() as $rootPath) {
+                if (str_starts_with($templatePath, $rootPath)) {
+                    $templatePath = substr($templatePath, strlen($rootPath));
+                    break;
+                }
+            }
+            // Convert template name into ViewHelper name and validate directory structure
+            // (resolveTemplateName() in reverse)
+            $fragments = explode('/', $templatePath);
+            $availableComponents[] = implode('.', array_map(lcfirst(...), $fragments));
+        }
+        return $availableComponents;
+    }
+}

--- a/tests/Functional/Fixtures/Components/TemplateInvalidStructure.html
+++ b/tests/Functional/Fixtures/Components/TemplateInvalidStructure.html
@@ -1,0 +1,1 @@
+This template shouldn't get picked up because it's not in the correct component directory structure.

--- a/tests/Unit/Schema/SchemaGeneratorTest.php
+++ b/tests/Unit/Schema/SchemaGeneratorTest.php
@@ -258,6 +258,31 @@ final class SchemaGeneratorTest extends TestCase
                 . '</xsd:element>'
                 . '</xsd:schema>' . "\n",
             ],
+            'component' => [
+                'http://typo3.org/ns/Vendor/Package/Components',
+                [
+                    new ViewHelperMetadata(
+                        null,
+                        'Vendor\\Package',
+                        null,
+                        'myComponent',
+                        'Available slots: default',
+                        'http://typo3.org/ns/Vendor/Package/Components',
+                        [],
+                        [],
+                        false,
+                    ),
+                ],
+                '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
+                . '<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://typo3.org/ns/Vendor/Package/Components">'
+                . '<xsd:element name="myComponent">'
+                . '<xsd:annotation><xsd:documentation><![CDATA[Available slots: default]]></xsd:documentation></xsd:annotation>'
+                . '<xsd:complexType mixed="true">'
+                . '<xsd:sequence><xsd:any minOccurs="0"/></xsd:sequence>'
+                . '</xsd:complexType>'
+                . '</xsd:element>'
+                . '</xsd:schema>' . "\n",
+            ],
         ];
     }
 


### PR DESCRIPTION
A new interface `ComponentListProviderInterface` is added to Fluid,
which allows component collections to not only resolve one specific
component, but also the reverse: When implemented,
`getAvailableComponents()` returns a list of all components that are
part of the collection. This can be useful for various developer tools,
such as styleguides, documentation generators as well as autocompletion.

This interface is now implemented by `AbstractComponentCollection`.
To avoid inconsistent results or a breaking change, one edge case
eeds to be avoided by using the reflection API: If a custom component
collection is based on `AbstractComponentCollection`, but uses a
different folder structure by overriding `resolveTemplateName()`, the
added default implementation would lead to inconsistent results.
Instead, an empty array is returned. Users that run into this edge case
need to provide a custom implementation for `getAvailableComponents()`
that matches their custom folder structure. This will change in Fluid 6,
where it will be assumed that users define both `resolveTemplateName()`
and `getAvailableComponents()` consistently if necessary.