### PR TITLE
Add Infection

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,6 +78,16 @@ To perform static analysis, we use PHPStan. You can run it with the following co
 ./vendor/bin/phpstan analyse
 ```
 
+#### Mutation Testing (Infection)
+
+To check how well tests cover behavioral changes in Fluid internals, you can run Infection:
+
+```bash
+./vendor/bin/infection
+```
+
+For more details, see the official Infection documentation: https://infection.github.io/guide/
+
 #### Fluid Documentation Generator
 
 To generate the Fluid documentation, you can use the following commands.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 vendor
 examples/cache/
 /Documentation-GENERATED-temp/
+infection.html

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,16 @@
         "ext-mbstring": "*"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     },
     "require-dev": {
         "ext-json": "*",
         "ext-simplexml": "*",
         "friendsofphp/php-cs-fixer": "^3.94.2",
+        "infection/infection": "^0.32.6",
         "phpstan/phpstan": "^2.1.40",
         "phpstan/phpstan-phpunit": "^2.0.16",
         "phpunit/phpunit": "^11.5.55 || ^12.5.14 || ^13.0.5",

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,20 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "mutators": {
+        "@default": true,
+        // for now we disable these mutators as they cause too many false positives:
+        "PublicVisibility": false,
+        "ProtectedVisibility": false,
+        "MBString": false,
+    },
+    "threads": "max",
+    "initialTestsPhpOptions": "-d xdebug.mode=coverage",
+    "logs": {
+        "html": "infection.html"
+    }
+}


### PR DESCRIPTION
As discussed with @s2b we remove the minimum level and the run in CI.
And use it only as a tool for the developer.
TODO:
- [x] add Documentation how to use infection.
- [x] remove from CI
- [x] update to newest version