### PR TITLE
[BUGFIX] Address inconsistencies in object comparisons (#1320)

### DIFF
--- a/src/Core/Parser/BooleanParser.php
+++ b/src/Core/Parser/BooleanParser.php
@@ -347,14 +347,6 @@ class BooleanParser
      */
     protected function evaluateCompare(mixed $x, mixed $y, string $comparator)
     {
-        // enfore strong comparison for comparing two objects
-        if ($comparator === '==' && is_object($x) && is_object($y)) {
-            $comparator = '===';
-        }
-        if ($comparator === '!=' && is_object($x) && is_object($y)) {
-            $comparator = '!==';
-        }
-
         if ($this->compileToCode === true) {
             return sprintf('(%s %s %s)', $x, $comparator, $y);
         }

--- a/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/IfThenElseViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use stdClass;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -432,6 +433,16 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
             ['verdict' => true],
             true,
         ];
+        yield 'object comparison ==' => [
+            '<f:if condition="{obj1} == {obj2}" />',
+            ['obj1' => new stdClass(), 'obj2' => new stdClass()],
+            true,
+        ];
+        yield 'object comparison ===' => [
+            '<f:if condition="{obj1} === {obj2}" />',
+            ['obj1' => new stdClass(), 'obj2' => new stdClass()],
+            false,
+        ];
 
         yield 'inline syntax, then argument, verdict true' => [
             '{f:if(condition:\'{verdict}\', then:\'thenArgument\')}',
@@ -595,12 +606,12 @@ final class IfThenElseViewHelperTest extends AbstractFunctionalTestCase
         $view->assignMultiple($variables);
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
-        self::assertSame($expected, $view->render());
+        self::assertSame($expected, $view->render(), 'uncached');
 
         $view = new TemplateView();
         $view->assignMultiple($variables);
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
-        self::assertSame($expected, $view->render());
+        self::assertSame($expected, $view->render(), 'cached');
     }
 }

--- a/tests/Unit/Core/Parser/BooleanParserTest.php
+++ b/tests/Unit/Core/Parser/BooleanParserTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use TYPO3Fluid\Fluid\Core\Parser\BooleanParser;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\BooleanNode;
@@ -104,6 +105,20 @@ final class BooleanParserTest extends TestCase
             ['{foo}', true, ['foo' => true]],
             ['{foo} == FALSE', true, ['foo' => false]],
             ['!{foo}', true, ['foo' => false]],
+
+            ['{obj1} == {obj2}', true, ['obj1' => new stdClass(), 'obj2' => new stdClass()]],
+            ['{obj1} != {obj2}', false, ['obj1' => new stdClass(), 'obj2' => new stdClass()]],
+            ['{obj1} === {obj2}', false, ['obj1' => new stdClass(), 'obj2' => new stdClass()]],
+            ['{obj1} !== {obj2}', true, ['obj1' => new stdClass(), 'obj2' => new stdClass()]],
+
+            ['{foo}', false, ['foo' => new UnsafeHTMLString('')]],
+            ["{foo} == ''", true, ['foo' => new UnsafeHTMLString('')]],
+            ['{foo}', true, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} == FALSE', false, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} == TRUE', true, ['foo' => new UnsafeHTMLString('test')]],
+            ["{foo} == 'test'", true, ['foo' => new UnsafeHTMLString('test')]],
+            ['{foo} === TRUE', false, ['foo' => new UnsafeHTMLString('0')]],
+            ['{foo} === \'0\'', false, ['foo' => new UnsafeHTMLString('0')]],
 
             /*
              * @todo This should work but doesn't at the moment. This is probably related to the boolean

--- a/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/BooleanNodeTest.php
@@ -481,7 +481,7 @@ final class BooleanNodeTest extends TestCase
     }
 
     #[Test]
-    public function objectsAreComparedStrictly(): void
+    public function objectsAreComparedLoosely(): void
     {
         $renderingContext = new RenderingContext();
         $renderingContext->getVariableProvider()->add('object1', new \stdClass());
@@ -493,11 +493,11 @@ final class BooleanNodeTest extends TestCase
         $rootNode->addChildNode(new ObjectAccessorNode('object2'));
 
         $booleanNode = new BooleanNode($rootNode);
-        self::assertFalse($booleanNode->evaluate($renderingContext));
+        self::assertTrue($booleanNode->evaluate($renderingContext));
     }
 
     #[Test]
-    public function objectsAreComparedStrictlyInUnequalComparison(): void
+    public function objectsAreComparedLooselyInUnequalComparison(): void
     {
         $renderingContext = new RenderingContext();
         $renderingContext->getVariableProvider()->add('object1', new \stdClass());
@@ -510,7 +510,7 @@ final class BooleanNodeTest extends TestCase
         $rootNode->addChildNode(new ObjectAccessorNode('object2'));
 
         $booleanNode = new BooleanNode($rootNode);
-        self::assertTrue($booleanNode->evaluate($renderingContext));
+        self::assertFalse($booleanNode->evaluate($renderingContext));
     }
 
     public static function getStandardInputTypes(): array


### PR DESCRIPTION
Fluid's `BooleanParser` attempts to cover a specific edge case: If
two objects should be compared, according to the code it should always
be a strict comparison. However, the condition that should have
accomplished this depends on the variable content during the first
run. If a template is compiled (which is almost always the case), the
comparison is still dependent on the variable content during initial
template compilation.

Above all, this special handling doesn't really make sense, since strict
comparison operators are available as well.

This patch adds test coverage for object comparisons on multiple levels.
Also, the special handling is removed from `BooleanParser` to get the
tests to pass. Without the adjustment, either uncached or cached
templates would be correct, but never both. The new version delivers
the same results as cached templates before this change, so it should
be in line with real-world projects.