### PR TITLE
[TASK] Share resolver delegates in cached templates (#1319)

### DIFF
--- a/src/Core/Component/ComponentAdapter.php
+++ b/src/Core/Component/ComponentAdapter.php
@@ -187,7 +187,7 @@ final class ComponentAdapter implements ViewHelperInterface
         // cached templates
         $resolverDelegate = $this->getComponentDefinitionProvider();
         $convertedViewHelperExecutionCode = sprintf(
-            '$renderingContext->getViewHelperResolver()->createResolverDelegateInstanceFromClassName(%s)->getComponentRenderer()->renderComponent(%s, %s, %s, $renderingContext)',
+            '$renderingContext->getViewHelperResolver()->getResolverDelegate(%s)->getComponentRenderer()->renderComponent(%s, %s, %s, $renderingContext)',
             var_export($resolverDelegate->getNamespace(), true),
             var_export($this->viewHelperNode->getName(), true),
             $argumentsVariableName,

--- a/src/Core/ViewHelper/ViewHelperResolver.php
+++ b/src/Core/ViewHelper/ViewHelperResolver.php
@@ -451,10 +451,10 @@ class ViewHelperResolver
                 if ($namespace === null) {
                     continue;
                 }
-                $this->resolverDelegates[$namespace] ??= $this->createResolverDelegateInstanceFromClassName($namespace);
+                $delegate = $this->getResolverDelegate($namespace);
                 try {
-                    $this->resolverDelegates[$namespace]->resolveViewHelperClassName($methodIdentifier);
-                    return $this->resolverDelegates[$namespace];
+                    $delegate->resolveViewHelperClassName($methodIdentifier);
+                    return $delegate;
                 } catch (UnresolvableViewHelperException $e) {
                 }
             }
@@ -505,9 +505,23 @@ class ViewHelperResolver
     }
 
     /**
+     * Returns a resolver delegate instance. This should be preferred over
+     * createResolverDelegateInstanceFromClassName() because the internal
+     * runtime cache is used to fetch the shared delegate objects, which
+     * prevents duplicate object creation.
+     */
+    public function getResolverDelegate(string $delegateClassName): ViewHelperResolverDelegateInterface
+    {
+        $this->resolverDelegates[$delegateClassName] ??= $this->createResolverDelegateInstanceFromClassName($delegateClassName);
+        return $this->resolverDelegates[$delegateClassName];
+    }
+
+    /**
      * Creates a ViewHelperResolver delegate object based on a ViewHelper
      * namespace string. This can be overridden by frameworks to implement
      * dependency injection or custom fallback logic.
+     *
+     * @todo mark protected with Fluid 6
      */
     public function createResolverDelegateInstanceFromClassName(string $delegateClassName): ViewHelperResolverDelegateInterface
     {
@@ -548,9 +562,9 @@ class ViewHelperResolver
                 if ($namespace === null) {
                     continue;
                 }
-                $this->resolverDelegates[$namespace] ??= $this->createResolverDelegateInstanceFromClassName($namespace);
+                $delegate = $this->getResolverDelegate($namespace);
                 try {
-                    return $this->resolverDelegates[$namespace]->resolveViewHelperClassName($methodIdentifier);
+                    return $delegate->resolveViewHelperClassName($methodIdentifier);
                 } catch (UnresolvableViewHelperException $e) {
                     $lastException = $e;
                 }

--- a/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperResolverTest.php
@@ -256,6 +256,25 @@ final class ViewHelperResolverTest extends TestCase
         self::assertInstanceOf($expectedInstanceOf, $result);
     }
 
+    #[DataProvider('createResolverDelegateInstanceFromClassNameDataProvider')]
+    #[Test]
+    public function getResolverDelegateReturnsValidInstance(string $resolverClassName, string $expectedInstanceOf): void
+    {
+        $subject = new ViewHelperResolver();
+        $result = $subject->getResolverDelegate($resolverClassName);
+        self::assertInstanceOf($expectedInstanceOf, $result);
+    }
+
+    #[Test]
+    public function getResolverDelegateSharesInstances(): void
+    {
+        $subject = new ViewHelperResolver();
+        self::assertSame(
+            $subject->getResolverDelegate(TestViewHelperResolverDelegate::class),
+            $subject->getResolverDelegate(TestViewHelperResolverDelegate::class),
+        );
+    }
+
     public static function getResponsibleDelegateDataProvider(): iterable
     {
         return [


### PR DESCRIPTION
Due to an oversight, each component call from a template created its
own instance of the responsible ViewHelperResolverDelegate. This is
not necessary, since resolver delegates are meant to be sharable.

This patch introduces the new `getResolverDelegate()` method, which
centralizes the already existing runtime cache for resolver delegate
objects. All existing usages of
`createResolverDelegateInstanceFromClassName()` are migrated to the
new method.

Note that the performance impact wasn't relevant in TYPO3, since the
underlying DI implementation already shared the service objects.