### PR TITLE
[TASK] Cache compilation in ArgumentDefinition

### DIFF
--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -250,15 +250,7 @@ class TemplateCompiler
             return '';
         }
         $argumentDefinitionsCode = array_map(
-            static fn(ArgumentDefinition $argumentDefinition): string => sprintf(
-                'new \\TYPO3Fluid\\Fluid\\Core\\ViewHelper\\ArgumentDefinition(%s, %s, %s, %s, %s, %s)',
-                var_export($argumentDefinition->getName(), true),
-                var_export($argumentDefinition->getType(), true),
-                var_export($argumentDefinition->getDescription(), true),
-                var_export($argumentDefinition->isRequired(), true),
-                var_export($argumentDefinition->getDefaultValue(), true),
-                var_export($argumentDefinition->getEscape(), true),
-            ),
+            static fn(ArgumentDefinition $argumentDefinition): string => $argumentDefinition->compile(),
             $argumentDefinitions,
         );
         return 'public function getArgumentDefinitions(): array {' . chr(10)

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -134,4 +134,20 @@ class ArgumentDefinition
     {
         return $this->getType() === 'bool' || $this->getType() === 'boolean';
     }
+
+    /**
+     * @internal Only to be used by TemplateCompiler
+     */
+    public function compile(): string
+    {
+        return sprintf(
+            'new ' . static::class . '(%s, %s, %s, %s, %s, %s)',
+            var_export($this->getName(), true),
+            var_export($this->getType(), true),
+            var_export($this->getDescription(), true),
+            var_export($this->isRequired(), true),
+            var_export($this->getDefaultValue(), true),
+            var_export($this->getEscape(), true),
+        );
+    }
 }


### PR DESCRIPTION
To make backports possible, compilation for Fluid cache file is now
handled within `ArgumentDefinition`. This matches the behavior of
Fluid 5, introduced in #1313.