### PR TITLE
[FEATURE] Annotations API (#1314)

### DIFF
--- a/src/Core/Component/ComponentDefinition.php
+++ b/src/Core/Component/ComponentDefinition.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Core\Component;
 
+use TYPO3Fluid\Fluid\Core\Definition\Annotation\ViewHelperAnnotationInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 
 /**
@@ -16,15 +17,15 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
  */
 final readonly class ComponentDefinition
 {
-    /**
-     * @param array<string, ArgumentDefinition> $argumentDefinitions
-     * @param string[] $availableSlots
-     */
     public function __construct(
         private string $name,
+        /** @var array<string, ArgumentDefinition> */
         private array $argumentDefinitions,
         private bool $additionalArgumentsAllowed,
+        /** @var string[] */
         private array $availableSlots,
+        /** @var ViewHelperAnnotationInterface[] */
+        private array $annotations = [],
     ) {}
 
     public function getName(): string
@@ -51,5 +52,13 @@ final readonly class ComponentDefinition
     public function getAvailableSlots(): array
     {
         return $this->availableSlots;
+    }
+
+    /**
+     * @return ViewHelperAnnotationInterface[]
+     */
+    public function getAnnotations(): array
+    {
+        return $this->annotations;
     }
 }

--- a/src/Core/Definition/Annotation/Annotation.php
+++ b/src/Core/Definition/Annotation/Annotation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Definition\Annotation;
+
+/**
+ * Generic annotation implementation that works both for ViewHelpers/Components
+ * and their arguments. This can be used to add arbitrary information, such as
+ * a link to relevant documentation or flags like "internal" to ViewHelpers/Components
+ * and their arguments.
+ *
+ * For more advanced use cases, or when type safety is preferred, the relevant
+ * interfaces can be implemented by a custom annotation class (e. g. DeprecationAnnotation,
+ * DocumentationAnnotation, ...).
+ *
+ * @internal
+ */
+final readonly class Annotation implements ViewHelperAnnotationInterface, ArgumentAnnotationInterface
+{
+    public function __construct(public array $data) {}
+
+    public function compile(): string
+    {
+        return 'new ' . static::class . '(' . var_export($this->data, true) . ')';
+    }
+}

--- a/src/Core/Definition/Annotation/AnnotationInterface.php
+++ b/src/Core/Definition/Annotation/AnnotationInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Definition\Annotation;
+
+/**
+ * Annotations allow attaching arbitrary information to ViewHelper/Component
+ * or argument definitions.
+ *
+ * @internal
+ */
+interface AnnotationInterface
+{
+    /**
+     * Generates PHP code for the template cache that represents the
+     * Annotation object. Depending on the future of TemplateCompiler,
+     * this might no longer be necessary later.
+     */
+    public function compile(): string;
+}

--- a/src/Core/Definition/Annotation/ArgumentAnnotationInterface.php
+++ b/src/Core/Definition/Annotation/ArgumentAnnotationInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Definition\Annotation;
+
+/**
+ * Annotation that can only be applied to argument definitions
+ *
+ * @internal
+ */
+interface ArgumentAnnotationInterface extends AnnotationInterface {}

--- a/src/Core/Definition/Annotation/ViewHelperAnnotationInterface.php
+++ b/src/Core/Definition/Annotation/ViewHelperAnnotationInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Definition\Annotation;
+
+/**
+ * Annotation that can only be applied to ViewHelper/Component definitions
+ *
+ * @internal
+ */
+interface ViewHelperAnnotationInterface extends AnnotationInterface {}

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Core\ViewHelper;
 
+use TYPO3Fluid\Fluid\Core\Definition\Annotation\ArgumentAnnotationInterface;
+
 /**
  * Argument definition of each view helper argument
  */
@@ -52,6 +54,8 @@ class ArgumentDefinition
      */
     protected ?bool $escape;
 
+    protected array $annotations;
+
     /**
      * Constructor for this argument definition.
      *
@@ -61,8 +65,9 @@ class ArgumentDefinition
      * @param bool $required true if argument is required
      * @param mixed $defaultValue Default value
      * @param bool|null $escape Whether argument is escaped, or uses default escaping behavior (see class var comment)
+     * @param ArgumentAnnotationInterface[] $annotations
      */
-    public function __construct(string $name, string $type, string $description, bool $required, mixed $defaultValue = null, ?bool $escape = null)
+    public function __construct(string $name, string $type, string $description, bool $required, mixed $defaultValue = null, ?bool $escape = null, array $annotations = [])
     {
         $this->name = $name;
         $this->type = $type;
@@ -70,6 +75,7 @@ class ArgumentDefinition
         $this->required = $required;
         $this->defaultValue = $defaultValue;
         $this->escape = $escape;
+        $this->annotations = $annotations;
     }
 
     /**
@@ -136,18 +142,30 @@ class ArgumentDefinition
     }
 
     /**
+     * @return ArgumentAnnotationInterface[]
+     */
+    public function getAnnotations(): array
+    {
+        return $this->annotations;
+    }
+
+    /**
      * @internal Only to be used by TemplateCompiler
      */
     public function compile(): string
     {
         return sprintf(
-            'new ' . static::class . '(%s, %s, %s, %s, %s, %s)',
+            'new ' . static::class . '(%s, %s, %s, %s, %s, %s, [%s])',
             var_export($this->getName(), true),
             var_export($this->getType(), true),
             var_export($this->getDescription(), true),
             var_export($this->isRequired(), true),
             var_export($this->getDefaultValue(), true),
             var_export($this->getEscape(), true),
+            implode(',', array_map(
+                static fn(ArgumentAnnotationInterface $annotation): string => $annotation->compile(),
+                $this->getAnnotations(),
+            )),
         );
     }
 }

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3Fluid\Fluid\Core\Definition\Annotation\Annotation;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 
 final class ArgumentDefinitionTest extends TestCase
@@ -23,13 +24,14 @@ final class ArgumentDefinitionTest extends TestCase
         $description = 'Example desc';
         $type = 'string';
         $isRequired = true;
-        $isMethodParameter = true;
-        $argumentDefinition = new ArgumentDefinition($name, $type, $description, $isRequired, null);
+        $annotations = [new Annotation(['see' => 'https://example.com']), new Annotation(['deprecated' => 'since 2.0.0, will be removed in 2.0.0'])];
+        $argumentDefinition = new ArgumentDefinition($name, $type, $description, $isRequired, null, null, $annotations);
 
         self::assertEquals($argumentDefinition->getName(), $name, 'Name could not be retrieved correctly.');
         self::assertEquals($argumentDefinition->getDescription(), $description, 'Description could not be retrieved correctly.');
         self::assertEquals($argumentDefinition->getType(), $type, 'Type could not be retrieved correctly');
         self::assertEquals($argumentDefinition->isRequired(), $isRequired, 'Required flag could not be retrieved correctly.');
+        self::assertSame($argumentDefinition->getAnnotations(), $annotations);
     }
 
     public static function determinesBooleanCorrectlyDataProvider(): array
@@ -47,5 +49,21 @@ final class ArgumentDefinitionTest extends TestCase
     public function determinesBooleanCorrectly(ArgumentDefinition $argumentDefinition, bool $expected): void
     {
         self::assertSame($expected, $argumentDefinition->isBooleanType());
+    }
+
+    public static function compilationCreatesEqualObjectDataProvider(): array
+    {
+        return [
+            [new ArgumentDefinition('test', 'bool', 'description', false, 'default', null)],
+            [new ArgumentDefinition('test', 'bool', 'description', true, null, true, [new Annotation(['see' => 'https://example.com', 'something' => 'else'])])],
+            [new ArgumentDefinition('test', 'bool', 'description', false, 'default', false, [new Annotation(['see' => 'https://example.com']), new Annotation(['deprecated' => 'since 2.0.0, will be removed in 2.0.0'])])],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('compilationCreatesEqualObjectDataProvider')]
+    public function compilationCreatesEqualObject(ArgumentDefinition $argumentDefinition): void
+    {
+        self::assertEquals($argumentDefinition, eval('return ' . $argumentDefinition->compile() . ';'));
     }
 }


### PR DESCRIPTION
This patch introduces new data structures that represent annotations
for ViewHelpers/Components or their individual arguments. The purpose
is to be able to attach arbitrary information to definitions of
ViewHelpers/Components or arguments, either to pass them along as-is
or to react to them within Fluid. There are places within Fluid where
something like this already exists (e. g. XSD schema), and there are
multiple additional use cases for this, both by Fluid itself and by
third-party libraries that extend Fluid, for example:

* Marking ViewHelpers/Components or individual arguments as deprecated
* Collecting information for documentation from PhpDoc comments
* Attaching additional validations/constraints to component arguments

In this first step, only the low-level API is provided, which
consists of interfaces and a generic implementation. Since this concept
is new to Fluid, the API is still classified as internal and might
change with future revisions.

Since the `ArgumentDefinition` needs to be written to Fluid's template
cache files, each annotation needs to implement the `compile()`
method, which returns the PHP code that re-creates the annotation object
when a template is read from cache.