### PR TITLE
[TASK] Option to get available templates without extension

### DIFF
--- a/src/View/TemplateFinder.php
+++ b/src/View/TemplateFinder.php
@@ -42,7 +42,7 @@ final readonly class TemplateFinder
      * @param string[] $paths
      * @return string[]
      */
-    public function findTemplatesByFileExtension(array $paths, string $fileExtension): array
+    public function findTemplatesByFileExtension(array $paths, string $fileExtension, bool $stripFileExtension = false): array
     {
         if ($paths === []) {
             return [];
@@ -51,7 +51,10 @@ final readonly class TemplateFinder
             $this->createFileIterator($paths),
             fn(SplFileInfo $file): bool => str_ends_with($file->getBasename(), '.' . $fileExtension),
         );
-        return array_keys(iterator_to_array($filterIterator));
+        $files = array_keys(iterator_to_array($filterIterator));
+        return $stripFileExtension
+            ? array_map(fn($file) => $this->stripFileExtension($file, $fileExtension), $files)
+            : $files;
     }
 
     /**
@@ -66,5 +69,16 @@ final readonly class TemplateFinder
             $appendIterator->append($recursiveIterator);
         }
         return $appendIterator;
+    }
+
+    private function stripFileExtension(string $path, string $fileExtension): string
+    {
+        $fileExtension = '.' . $fileExtension;
+        $fluidExtension = '.' . TemplatePaths::FLUID_EXTENSION;
+        $path = substr($path, 0, - strlen($fileExtension));
+        if (str_ends_with($path, $fluidExtension)) {
+            $path = substr($path, 0, - strlen($fluidExtension));
+        }
+        return $path;
     }
 }

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -240,32 +240,32 @@ class TemplatePaths
     /**
      * @return string[]
      */
-    public function resolveAvailableTemplateFiles(?string $controllerName, ?string $format = null): array
+    public function resolveAvailableTemplateFiles(?string $controllerName, ?string $format = null, bool $stripFileExtension = false): array
     {
         $paths = $this->getTemplateRootPaths();
         foreach ($paths as $index => $path) {
             $paths[$index] = rtrim($path . ($controllerName ?? ''), '/') . '/';
         }
         $scanner = new TemplateFinder();
-        return $scanner->findTemplatesByFileExtension($paths, $format ?: $this->getFormat());
+        return $scanner->findTemplatesByFileExtension($paths, $format ?: $this->getFormat(), $stripFileExtension);
     }
 
     /**
      * @return string[]
      */
-    public function resolveAvailablePartialFiles(?string $format = null): array
+    public function resolveAvailablePartialFiles(?string $format = null, bool $stripFileExtension = false): array
     {
         $scanner = new TemplateFinder();
-        return $scanner->findTemplatesByFileExtension($this->getPartialRootPaths(), $format ?: $this->getFormat());
+        return $scanner->findTemplatesByFileExtension($this->getPartialRootPaths(), $format ?: $this->getFormat(), $stripFileExtension);
     }
 
     /**
      * @return string[]
      */
-    public function resolveAvailableLayoutFiles(?string $format = null): array
+    public function resolveAvailableLayoutFiles(?string $format = null, bool $stripFileExtension = false): array
     {
         $scanner = new TemplateFinder();
-        return $scanner->findTemplatesByFileExtension($this->getLayoutRootPaths(), $format ?: $this->getFormat());
+        return $scanner->findTemplatesByFileExtension($this->getLayoutRootPaths(), $format ?: $this->getFormat(), $stripFileExtension);
     }
 
     /**

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -112,6 +112,13 @@ final class TemplatePathsTest extends TestCase
         );
         self::assertSame(
             [
+                $examplesPath . 'Resources/Private/Layouts/Default',
+                $examplesPath . 'Resources/Private/Layouts/Dynamic',
+            ],
+            $this->sortTemplatePaths($instance->resolveAvailableLayoutFiles(null, true)),
+        );
+        self::assertSame(
+            [
                 $examplesPath . 'Resources/Private/Templates/Default/Default.fluid.html',
                 $examplesPath . 'Resources/Private/Templates/Default/Nested/Default.fluid.html',
                 $examplesPath . 'Resources/Private/Templates/Other/Default.fluid.html',
@@ -121,12 +128,30 @@ final class TemplatePathsTest extends TestCase
         );
         self::assertSame(
             [
+                $examplesPath . 'Resources/Private/Templates/Default/Default',
+                $examplesPath . 'Resources/Private/Templates/Default/Nested/Default',
+                $examplesPath . 'Resources/Private/Templates/Other/Default',
+                $examplesPath . 'Resources/Private/Templates/Other/List',
+            ],
+            $this->sortTemplatePaths($instance->resolveAvailableTemplateFiles(null, null, true)),
+        );
+        self::assertSame(
+            [
                 $examplesPath . 'Resources/Private/Partials/EscapingModifierPartial.fluid.html',
                 $examplesPath . 'Resources/Private/Partials/FirstPartial.fluid.html',
                 $examplesPath . 'Resources/Private/Partials/SecondPartial.fluid.html',
                 $examplesPath . 'Resources/Private/Partials/Structures.fluid.html',
             ],
             $this->sortTemplatePaths($instance->resolveAvailablePartialFiles(null)),
+        );
+        self::assertSame(
+            [
+                $examplesPath . 'Resources/Private/Partials/EscapingModifierPartial',
+                $examplesPath . 'Resources/Private/Partials/FirstPartial',
+                $examplesPath . 'Resources/Private/Partials/SecondPartial',
+                $examplesPath . 'Resources/Private/Partials/Structures',
+            ],
+            $this->sortTemplatePaths($instance->resolveAvailablePartialFiles(null, true)),
         );
     }
 


### PR DESCRIPTION
An option is added to `TemplateFinder` and `TemplatePaths` to get all
available templates without their file extension. This enables easier
processing later, e. g. in the context of component collections.