### PR TITLE
[TASK] Make ViewHelperMetadata compatible with components

### DIFF
--- a/src/Schema/ViewHelperMetadata.php
+++ b/src/Schema/ViewHelperMetadata.php
@@ -21,9 +21,9 @@ final class ViewHelperMetadata
      * @param array<string, ArgumentDefinition> $argumentDefinitions
      */
     public function __construct(
-        public readonly string $className,
+        public readonly ?string $className,
         public readonly string $namespace,
-        public readonly string $name,
+        public readonly ?string $name,
         public readonly string $tagName,
         public readonly string $documentation,
         public readonly string $xmlNamespace,

--- a/src/Schema/ViewHelperMetadataFactory.php
+++ b/src/Schema/ViewHelperMetadataFactory.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Schema;
 
+use TYPO3Fluid\Fluid\Core\Component\ComponentDefinition;
 use TYPO3Fluid\Fluid\Core\Parser\Patterns;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
 
 /**
  * @internal
@@ -80,6 +82,25 @@ final class ViewHelperMetadataFactory
             docTags: $docTags,
             argumentDefinitions: (new \ReflectionClass($className))->newInstanceWithoutConstructor()->prepareArguments(),
             allowsArbitraryArguments: is_subclass_of($className, AbstractTagBasedViewHelper::class),
+        );
+    }
+
+    public function createFromComponentDefinition(
+        ViewHelperResolverDelegateInterface $componentCollection,
+        ComponentDefinition $componentDefinition,
+    ): ViewHelperMetadata {
+        return new ViewHelperMetadata(
+            className: null,
+            namespace: $componentCollection->getNamespace(),
+            name: null,
+            tagName: $componentDefinition->getName(),
+            documentation: ($componentDefinition->getAvailableSlots() !== [])
+                ? 'Available slots: ' . implode(', ', $componentDefinition->getAvailableSlots())
+                : '',
+            xmlNamespace: $this->generateXmlNamespace($componentCollection->getNamespace()),
+            docTags: [],
+            argumentDefinitions: $componentDefinition->getArgumentDefinitions(),
+            allowsArbitraryArguments: $componentDefinition->additionalArgumentsAllowed(),
         );
     }
 

--- a/tests/Unit/Schema/ViewHelperMetadataFactoryTest.php
+++ b/tests/Unit/Schema/ViewHelperMetadataFactoryTest.php
@@ -12,8 +12,11 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3Fluid\Fluid\Core\Component\ComponentDefinitionProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
 use TYPO3Fluid\Fluid\Schema\ViewHelperMetadataFactory;
+use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ComponentCollections\BasicComponentCollection;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\Sub\ArbitraryArgumentsViewHelper;
 use TYPO3Fluid\Fluid\Tests\Unit\Schema\Fixtures\ViewHelpers\Sub\DeprecatedViewHelper;
@@ -115,5 +118,58 @@ final class ViewHelperMetadataFactoryTest extends TestCase
     {
         self::expectException(\InvalidArgumentException::class);
         (new ViewHelperMetadataFactory())->createFromViewhelperClass($className);
+    }
+
+    public static function createFromComponentDefinitionDataProvider(): iterable
+    {
+        return [
+            [
+                new BasicComponentCollection(),
+                'nested.subComponent',
+                'nested.subComponent',
+                '',
+                'http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ComponentCollections/BasicComponentCollection',
+                [],
+                false,
+                ['identifier' => new ArgumentDefinition('identifier', 'string', '', false, 'sub')],
+            ],
+            [
+                new BasicComponentCollection(),
+                'namedSlots',
+                'namedSlots',
+                'Available slots: test1, test2, default',
+                'http://typo3.org/ns/TYPO3Fluid/Fluid/Tests/Functional/Fixtures/ComponentCollections/BasicComponentCollection',
+                [],
+                false,
+                [],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('createFromComponentDefinitionDataProvider')]
+    public function createFromComponentDefinition(
+        ViewHelperResolverDelegateInterface&ComponentDefinitionProviderInterface $componentCollection,
+        string $name,
+        string $expectedTagName,
+        string $expectedDocumentation,
+        string $expectedXmlNamespace,
+        array $expectedDocTags,
+        bool $expectedAllowsArbitraryArguments,
+        array $expectedArgumentDefinitions,
+    ): void {
+        $object = (new ViewHelperMetadataFactory())->createFromComponentDefinition(
+            $componentCollection,
+            $componentCollection->getComponentDefinition($name),
+        );
+        self::assertNull($object->className);
+        self::assertSame($componentCollection::class, $object->namespace);
+        self::assertNull($object->name);
+        self::assertSame($expectedTagName, $object->tagName);
+        self::assertSame($expectedDocumentation, $object->documentation);
+        self::assertSame($expectedXmlNamespace, $object->xmlNamespace);
+        self::assertSame($expectedDocTags, $object->docTags);
+        self::assertSame($expectedAllowsArbitraryArguments, $object->allowsArbitraryArguments);
+        self::assertEquals($expectedArgumentDefinitions, $object->argumentDefinitions);
     }
 }


### PR DESCRIPTION
The patch extends Fluid's own XSD schema generator classes to
be able to work with component definitions. This allows frameworks
that use Fluid components and are aware of all component collections
(e. g. via DI) to generate XSD schema files for components.