### PR TITLE
[FEATURE] API to generate component listings

### DIFF
--- a/src/Core/Component/ComponentListProviderInterface.php
+++ b/src/Core/Component/ComponentListProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\Component;
+
+/**
+ * @api
+ */
+interface ComponentListProviderInterface
+{
+    /**
+     * Returns a list of component names that are available in a
+     * component collection
+     * @return string[]
+     */
+    public function getAvailableComponents(): array;
+}


### PR DESCRIPTION
A new interface ComponentListProviderInterface is added to Fluid,
which allows component collections to not only resolve one specific
component, but also the reverse: When implemented,
getAvailableComponents() returns a list of all components that are
part of the collection. This can be useful for various developer tools,
such as styleguides, documentation generators as well as autocompletion.

This is a partial backport from Fluid 5, which only includes the
interface, but not the default implementation.