### PR TITLE
[TASK] Move around template file validation code

### DIFF
--- a/src/Core/Component/AbstractComponentCollection.php
+++ b/src/Core/Component/AbstractComponentCollection.php
@@ -14,6 +14,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TemplateStructureViewHelperResolver;
 use TYPO3Fluid\Fluid\Core\ViewHelper\UnresolvableViewHelperException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
+use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
 /**
  * Base class for a collection of components: Fluid templates that can be called with Fluid's
@@ -176,7 +177,9 @@ abstract class AbstractComponentCollection implements ViewHelperResolverDelegate
     final public function resolveViewHelperClassName(string $viewHelperName): string
     {
         $expectedTemplateName = $this->resolveTemplateName($viewHelperName);
-        if (!$this->getTemplatePaths()->resolveTemplateFileForControllerAndActionAndFormat('Default', $expectedTemplateName)) {
+        try {
+            $this->getTemplatePaths()->resolveTemplateFileForControllerAndActionAndFormat('Default', $expectedTemplateName, null, true);
+        } catch (InvalidTemplateResourceException) {
             throw new UnresolvableViewHelperException(sprintf(
                 'Based on your spelling, the system would load the component template "%s.%s" in "%s", however this file does not exist.',
                 $expectedTemplateName,

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -55,6 +55,7 @@ class TemplatePaths
      * Holds already resolved identifiers for template files
      *
      * @var array<string, string[]>
+     * @todo check why this is only used for partials and if it's really necessary
      */
     protected array $resolvedIdentifiers = [
         self::NAME_TEMPLATES => [],
@@ -63,7 +64,7 @@ class TemplatePaths
     ];
 
     /**
-     * Holds already resolved identifiers for template files
+     * Holds already resolved paths for template files
      *
      * @var array<string, string[]>
      */
@@ -192,19 +193,27 @@ class TemplatePaths
      * already be, given that it is the same way
      * TypoScript path configurations work).
      * @api
+     * @todo remove $throwOnError with Fluid 6 and always throw exception; change return type to "string"
      */
-    public function resolveTemplateFileForControllerAndActionAndFormat(string $controller, string $action, ?string $format = null): ?string
+    public function resolveTemplateFileForControllerAndActionAndFormat(string $controller, string $action, ?string $format = null, bool $throwOnError = false): ?string
     {
         if ($this->templatePathAndFilename !== null) {
+            // @todo always throw exception in Fluid 6
+            if ($throwOnError && $this->templatePathAndFilename !== 'php://stdin' && !file_exists($this->templatePathAndFilename)) {
+                throw new InvalidTemplateResourceException(
+                    'Specified template file "' . $this->templatePathAndFilename . '" does not exist.',
+                    1772556162,
+                );
+            }
             return $this->templatePathAndFilename;
         }
 
         // Generate runtime cache identifier to check if template has already been resolved
         $format = $format ?: $this->getFormat();
         $controller = trim(str_replace('\\', '/', $controller), '/');
-        $identifier = $controller . '/' . $action . '.' . $format;
-        if (array_key_exists($identifier, $this->resolvedFiles[self::NAME_TEMPLATES])) {
-            return $this->resolvedFiles[self::NAME_TEMPLATES][$identifier];
+        $cacheIdentifier = $controller . '/' . $action . '.' . $format;
+        if (array_key_exists($cacheIdentifier, $this->resolvedFiles[self::NAME_TEMPLATES])) {
+            return $this->resolvedFiles[self::NAME_TEMPLATES][$cacheIdentifier];
         }
 
         // Use controller name as path suffix if specified and resolve template
@@ -214,7 +223,7 @@ class TemplatePaths
                 $this->getTemplateRootPaths(),
             );
             try {
-                return $this->resolvedFiles[self::NAME_TEMPLATES][$identifier] = $this->resolveFileInPaths(
+                return $this->resolvedFiles[self::NAME_TEMPLATES][$cacheIdentifier] = $this->resolveFileInPaths(
                     $controllerTemplatePaths,
                     $action,
                     $format,
@@ -225,7 +234,7 @@ class TemplatePaths
 
         // Resolve template based on action name
         try {
-            return $this->resolvedFiles[self::NAME_TEMPLATES][$identifier] = $this->resolveFileInPaths(
+            return $this->resolvedFiles[self::NAME_TEMPLATES][$cacheIdentifier] = $this->resolveFileInPaths(
                 $this->getTemplateRootPaths(),
                 $action,
                 $format,
@@ -233,8 +242,22 @@ class TemplatePaths
         } catch (InvalidTemplateResourceException $error) {
         }
 
-        // No template found, still add to runtime cache
-        return $this->resolvedFiles[self::NAME_TEMPLATES][$identifier] = null;
+        // @todo always throw exception in Fluid 6
+        if ($throwOnError) {
+            throw new InvalidTemplateResourceException(
+                sprintf(
+                    'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths '
+                    . 'contained the expected template file (%s). %s',
+                    $controller,
+                    $action,
+                    $format,
+                    $controller . '/' . $action . '.' . $format,
+                    count($this->getTemplateRootPaths()) ? 'The following paths were checked: ' . implode(', ', $this->getTemplateRootPaths()) : 'No paths configured.',
+                ),
+                1257246929,
+            );
+        }
+        return null;
     }
 
     /**
@@ -357,6 +380,8 @@ class TemplatePaths
      * @param string $controller
      * @param string $action Name of the action. If null, will be taken from request.
      * @return string template identifier
+     * @todo check if there are valid use cases when templatePathAndFilename=null; Otherwise, throw
+     *       exception in Fluid 6 if invalid template is supplied
      */
     public function getTemplateIdentifier(?string $controller = 'Default', ?string $action = 'Default'): string
     {
@@ -401,22 +426,7 @@ class TemplatePaths
             rewind($this->templateSource);
             return $this->templateSource = stream_get_contents($this->templateSource);
         }
-        $templateReference = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action);
-        if (!file_exists((string)$templateReference) && $templateReference !== 'php://stdin') {
-            $format = $this->getFormat();
-            throw new InvalidTemplateResourceException(
-                sprintf(
-                    'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths '
-                    . 'contained the expected template file (%s). %s',
-                    $controller,
-                    $action,
-                    $format,
-                    $templateReference === null ? $controller . '/' . $action . '.' . $format : $templateReference,
-                    count($this->getTemplateRootPaths()) ? 'The following paths were checked: ' . implode(', ', $this->getTemplateRootPaths()) : 'No paths configured.',
-                ),
-                1257246929,
-            );
-        }
+        $templateReference = $this->resolveTemplateFileForControllerAndActionAndFormat($controller, $action, null, true);
         return file_get_contents($templateReference);
     }
 


### PR DESCRIPTION
Within `TemplatePaths`, a `InvalidTemplateResourceException` is thrown
if no suitable template can be found based on the provided paths,
controller and action. Previously, this has been part of
`getTemplateSource()`, right before the template file is read.

This patch moves the validation one level deeper into
`resolveTemplateFileForControllerAndActionAndFormat()`, which
allows us to give more context in the exception message. As a
consequence, if a non-existing template is requested multiple times,
the result (= template does not exist) is no longer cached. This would
require caching the exception, which doesn't really make sense. Since
this method previously didn't throw exceptions and returned `null`
on failure, a temporary method argument is introduced, which can be
removed with Fluid 6. Otherwise this change would have been breaking.

In a follow-up patch, this will be improved even further by providing
the user with a list of all possible template paths that have been
tried.