### PR TITLE
[FEATURE] Clarify exceptions for missing templates

### DIFF
--- a/src/Core/Component/AbstractComponentCollection.php
+++ b/src/Core/Component/AbstractComponentCollection.php
@@ -179,12 +179,12 @@ abstract class AbstractComponentCollection implements ViewHelperResolverDelegate
         $expectedTemplateName = $this->resolveTemplateName($viewHelperName);
         try {
             $this->getTemplatePaths()->resolveTemplateFileForControllerAndActionAndFormat('Default', $expectedTemplateName, null, true);
-        } catch (InvalidTemplateResourceException) {
+        } catch (InvalidTemplateResourceException $e) {
             throw new UnresolvableViewHelperException(sprintf(
-                'Based on your spelling, the system would load the component template "%s.%s" in "%s", however this file does not exist.',
+                'The component template "%s" in format ".%s" could not be found in the configured template paths. %s',
                 $expectedTemplateName,
                 $this->getTemplatePaths()->getFormat(),
-                implode(', ', $this->getTemplatePaths()->getTemplateRootPaths()),
+                $e->evaluatedTemplatePaths !== [] ? 'The following file paths were evaluated: "' . implode('", "', $e->evaluatedTemplatePaths) . '"' : 'No paths configured.',
             ), 1748511297);
         }
         return ComponentAdapter::class;

--- a/src/View/Exception/InvalidLayoutException.php
+++ b/src/View/Exception/InvalidLayoutException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\View\Exception;
+
+/**
+ * @api
+ */
+class InvalidLayoutException extends InvalidTemplateResourceException {}

--- a/src/View/Exception/InvalidPartialException.php
+++ b/src/View/Exception/InvalidPartialException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\View\Exception;
+
+/**
+ * @api
+ */
+class InvalidPartialException extends InvalidTemplateResourceException {}

--- a/src/View/Exception/InvalidTemplateResourceException.php
+++ b/src/View/Exception/InvalidTemplateResourceException.php
@@ -7,6 +7,7 @@
 
 namespace TYPO3Fluid\Fluid\View\Exception;
 
+use Throwable;
 use TYPO3Fluid\Fluid\View;
 
 /**
@@ -14,4 +15,16 @@ use TYPO3Fluid\Fluid\View;
  *
  * @api
  */
-class InvalidTemplateResourceException extends View\Exception {}
+class InvalidTemplateResourceException extends View\Exception
+{
+    public function __construct(
+        string $message,
+        int $code,
+        ?Throwable $previous = null,
+        public readonly string $templateName = '',
+        /** @var string[] */
+        public readonly array $evaluatedTemplatePaths = [],
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/View/TemplatePaths.php
+++ b/src/View/TemplatePaths.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\View;
 
+use TYPO3Fluid\Fluid\View\Exception\InvalidLayoutException;
+use TYPO3Fluid\Fluid\View\Exception\InvalidPartialException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 
 /**
@@ -201,8 +203,11 @@ class TemplatePaths
             // @todo always throw exception in Fluid 6
             if ($throwOnError && $this->templatePathAndFilename !== 'php://stdin' && !file_exists($this->templatePathAndFilename)) {
                 throw new InvalidTemplateResourceException(
-                    'Specified template file "' . $this->templatePathAndFilename . '" does not exist.',
+                    'The specified template file "' . $this->templatePathAndFilename . '" does not exist.',
                     1772556162,
+                    null,
+                    basename($this->templatePathAndFilename),
+                    [$this->templatePathAndFilename],
                 );
             }
             return $this->templatePathAndFilename;
@@ -215,6 +220,8 @@ class TemplatePaths
         if (array_key_exists($cacheIdentifier, $this->resolvedFiles[self::NAME_TEMPLATES])) {
             return $this->resolvedFiles[self::NAME_TEMPLATES][$cacheIdentifier];
         }
+
+        $evaluatedTemplatePaths = [];
 
         // Use controller name as path suffix if specified and resolve template
         if ($controller !== '') {
@@ -229,6 +236,7 @@ class TemplatePaths
                     $format,
                 );
             } catch (InvalidTemplateResourceException $error) {
+                $evaluatedTemplatePaths = $error->evaluatedTemplatePaths;
             }
         }
 
@@ -240,22 +248,18 @@ class TemplatePaths
                 $format,
             );
         } catch (InvalidTemplateResourceException $error) {
+            $evaluatedTemplatePaths = array_merge($evaluatedTemplatePaths, $error->evaluatedTemplatePaths);
         }
 
         // @todo always throw exception in Fluid 6
         if ($throwOnError) {
-            throw new InvalidTemplateResourceException(
-                sprintf(
-                    'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths '
-                    . 'contained the expected template file (%s). %s',
-                    $controller,
-                    $action,
-                    $format,
-                    $controller . '/' . $action . '.' . $format,
-                    count($this->getTemplateRootPaths()) ? 'The following paths were checked: ' . implode(', ', $this->getTemplateRootPaths()) : 'No paths configured.',
-                ),
-                1257246929,
-            );
+            throw new InvalidTemplateResourceException(sprintf(
+                'Tried resolving a template file for controller action "%s->%s" in format ".%s", but none of the paths contained a suitable candidate. %s',
+                $controller,
+                $action,
+                $format,
+                $evaluatedTemplatePaths !== [] ? 'The following file paths were evaluated: "' . implode('", "', $evaluatedTemplatePaths) . '"' : 'No paths configured.',
+            ), 1257246929, null, $controller . '/' . $action, $evaluatedTemplatePaths);
         }
         return null;
     }
@@ -365,7 +369,7 @@ class TemplatePaths
      *
      * @param string $layoutName Name of the layout to use. If none given, use "Default"
      * @return string Path and filename of layout file
-     * @throws InvalidTemplateResourceException
+     * @throws InvalidLayoutException
      */
     public function getLayoutSource(string $layoutName = 'Default'): string
     {
@@ -456,7 +460,7 @@ class TemplatePaths
      *
      * @param string $layoutName Name of the layout to use. If none given, use "Default"
      * @return string Path and filename of layout files
-     * @throws Exception\InvalidTemplateResourceException
+     * @throws InvalidLayoutException
      */
     public function getLayoutPathAndFilename(string $layoutName = 'Default'): string
     {
@@ -466,7 +470,16 @@ class TemplatePaths
         $layoutKey = $layoutName . '.' . $this->getFormat();
         if (!array_key_exists($layoutKey, $this->resolvedFiles[self::NAME_LAYOUTS])) {
             $paths = $this->getLayoutRootPaths();
-            $this->resolvedFiles[self::NAME_LAYOUTS][$layoutKey] = $this->resolveFileInPaths($paths, $layoutName, $this->getFormat());
+            try {
+                $this->resolvedFiles[self::NAME_LAYOUTS][$layoutKey] = $this->resolveFileInPaths($paths, $layoutName, $this->getFormat());
+            } catch (InvalidTemplateResourceException $e) {
+                throw new InvalidLayoutException(sprintf(
+                    'Tried resolving a template file for layout "%s" in format ".%s", but none of the paths contained a suitable candidate. %s',
+                    $layoutName,
+                    $this->getFormat(),
+                    $e->evaluatedTemplatePaths !== [] ? 'The following file paths were evaluated: "' . implode('", "', $e->evaluatedTemplatePaths) . '"' : 'No paths configured.',
+                ), 1772564027, null, $layoutName, $e->evaluatedTemplatePaths);
+            }
         }
         return $this->resolvedFiles[self::NAME_LAYOUTS][$layoutKey];
     }
@@ -493,7 +506,7 @@ class TemplatePaths
      *
      * @param string $partialName The name of the partial
      * @return string contents of the partial template
-     * @throws InvalidTemplateResourceException
+     * @throws InvalidPartialException
      */
     public function getPartialSource(string $partialName): string
     {
@@ -506,14 +519,23 @@ class TemplatePaths
      *
      * @param string $partialName The name of the partial
      * @return string the full path which should be used. The path definitely exists.
-     * @throws InvalidTemplateResourceException
+     * @throws InvalidPartialException
      */
     public function getPartialPathAndFilename(string $partialName): string
     {
         $partialKey = $partialName . '.' . $this->getFormat();
         if (!array_key_exists($partialKey, $this->resolvedFiles[self::NAME_PARTIALS])) {
             $paths = $this->getPartialRootPaths();
-            $this->resolvedFiles[self::NAME_PARTIALS][$partialKey] = $this->resolveFileInPaths($paths, $partialName, $this->getFormat());
+            try {
+                $this->resolvedFiles[self::NAME_PARTIALS][$partialKey] = $this->resolveFileInPaths($paths, $partialName, $this->getFormat());
+            } catch (InvalidTemplateResourceException $e) {
+                throw new InvalidPartialException(sprintf(
+                    'Tried resolving a template file for partial "%s" in format ".%s", but none of the paths contained a suitable candidate. %s',
+                    $partialName,
+                    $this->getFormat(),
+                    $e->evaluatedTemplatePaths !== [] ? 'The following file paths were evaluated: "' . implode('", "', $e->evaluatedTemplatePaths) . '"' : 'No paths configured.',
+                ), 1772564387, null, $partialName, $e->evaluatedTemplatePaths);
+            }
         }
         return $this->resolvedFiles[self::NAME_PARTIALS][$partialKey];
     }
@@ -522,7 +544,7 @@ class TemplatePaths
      * Selects the template file that best matches the input template name from the available paths.
      *
      * @param string[] $paths
-     * @throws \TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException
+     * @throws InvalidTemplateResourceException
      */
     protected function resolveFileInPaths(array $paths, string $fileName, string $format): string
     {
@@ -553,7 +575,7 @@ class TemplatePaths
             'The Fluid template file "%s" could not be loaded. Tried paths: "%s"',
             $fileName,
             implode('", "', $possibleTemplates),
-        ), 1225709595);
+        ), 1225709595, null, $fileName, $possibleTemplates);
     }
 
     protected function clearResolvedIdentifiersAndTemplates(?string $type = null): void

--- a/tests/Functional/ExamplesTest.php
+++ b/tests/Functional/ExamplesTest.php
@@ -202,7 +202,7 @@ final class ExamplesTest extends AbstractFunctionalTestCase
             'example_errorhandling.php' => [
                 'example_errorhandling.php',
                 [
-                    'View error: The Fluid template file',
+                    'Tried resolving a template file for partial',
                     'Section rendering error: Section "DoesNotExist" does not exist. Section rendering is mandatory; "optional" is false.',
                     'ViewHelper error: Undeclared arguments passed to ViewHelper TYPO3Fluid\Fluid\ViewHelpers\IfViewHelper: notregistered. Valid arguments are: then, else, condition - Offending code: <f:if notregistered="1" />',
                     'Parser error: The ViewHelper "<f:invalid>" could not be resolved.',

--- a/tests/Functional/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RenderViewHelperTest.php
@@ -12,8 +12,8 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\Exception\InvalidPartialException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
-use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
 final class RenderViewHelperTest extends AbstractFunctionalTestCase
@@ -43,8 +43,8 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function exceptionForMissingPartial(): void
     {
-        $this->expectException(InvalidTemplateResourceException::class);
-        $this->expectExceptionCode(1225709595);
+        $this->expectException(InvalidPartialException::class);
+        $this->expectExceptionCode(1772564387);
         $template = '<f:render partial="non-existent" />';
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -174,13 +174,60 @@ final class TemplatePathsTest extends TestCase
         fclose($stream);
     }
 
+    public static function resolveFileInPathsThrowsExceptionIfFileNotFoundDataProvider(): array
+    {
+        return [
+            [
+                'notfound',
+                [
+                    '/found/notfound.fluid.html',
+                    '/found/notfound.html',
+                    '/found/notfound',
+                    '/found/Notfound.fluid.html',
+                    '/found/Notfound.html',
+                    '/found/Notfound',
+                    '/not/notfound.fluid.html',
+                    '/not/notfound.html',
+                    '/not/notfound',
+                    '/not/Notfound.fluid.html',
+                    '/not/Notfound.html',
+                    '/not/Notfound',
+                ],
+            ],
+            [
+                'notfound.html',
+                [
+                    '/found/notfound.html.fluid.html',
+                    '/found/notfound.html.html',
+                    '/found/notfound.html',
+                    '/found/Notfound.html.fluid.html',
+                    '/found/Notfound.html.html',
+                    '/found/Notfound.html',
+                    '/not/notfound.html.fluid.html',
+                    '/not/notfound.html.html',
+                    '/not/notfound.html',
+                    '/not/Notfound.html.fluid.html',
+                    '/not/Notfound.html.html',
+                    '/not/Notfound.html',
+                ],
+            ],
+        ];
+    }
+
     #[Test]
-    public function testResolveFileInPathsThrowsExceptionIfFileNotFound(): void
+    #[DataProvider('resolveFileInPathsThrowsExceptionIfFileNotFoundDataProvider')]
+    public function testResolveFileInPathsThrowsExceptionIfFileNotFound(string $requestedTemplate, array $expectedEvaluatedTemplatePaths): void
     {
         $this->expectException(InvalidTemplateResourceException::class);
+        $this->expectExceptionCode(1225709595);
         $instance = new TemplatePaths();
         $method = new \ReflectionMethod($instance, 'resolveFileInPaths');
-        $method->invoke($instance, ['/not/', '/found/'], 'notfound.html', 'html');
+        try {
+            $method->invoke($instance, ['/not/', '/found/'], $requestedTemplate, 'html');
+        } catch (InvalidTemplateResourceException $e) {
+            self::assertEquals($expectedEvaluatedTemplatePaths, $e->evaluatedTemplatePaths);
+            throw $e;
+        }
     }
 
     #[Test]


### PR DESCRIPTION
This change aims to simplify debugging by providing improved exception
messages in cases where a template file cannot be resolved.

Previously, these exceptions lacked important context (e. g. which
type of template [template, partial, layout] is missing). Also,
the messages still suggested to the user that only one file path has
been checked, when in fact a whole fallback chain is evaluated
(e. g. with/without .fluid extension, upper/lowercase, ...).

To address this, the `InvalidTemplateResourceException` is extended
to contain the requested template name as well as a list of file paths
that have been evaluated. This information is passed through
`TemplatePaths` to enable frameworks to access that information to
create more suitable context-specific error messages.

Within Fluid itself, different exception classes and messages are now
used for templates, partials and layouts, which helps during debugging.
Also, the exception messages have been streamlined, which also extends
to components.