### PR TITLE
[TASK] Include template path in parser exceptions

### DIFF
--- a/src/Core/Component/AbstractComponentCollection.php
+++ b/src/Core/Component/AbstractComponentCollection.php
@@ -158,6 +158,7 @@ abstract class AbstractComponentCollection implements ViewHelperResolverDelegate
             $parsedTemplate = $renderingContext->getTemplateParser()->parse(
                 $this->getTemplatePaths()->getTemplateSource('Default', $templateName),
                 $this->getTemplatePaths()->getTemplateIdentifier('Default', $templateName),
+                $this->getTemplatePaths()->resolveTemplateFileForControllerAndActionAndFormat('Default', $templateName),
             );
             $this->componentDefinitionsCache[$viewHelperName] = new ComponentDefinition(
                 $viewHelperName,

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -103,7 +103,7 @@ class TemplateParser
      * @param string $templateIdentifier If the template has an identifying string it can be passed here to improve error reporting.
      * @throws Exception
      */
-    public function parse(string $templateString, string $templateIdentifier = ''): ParsingState
+    public function parse(string $templateString, string $templateIdentifier = '', ?string $originalTemplatePath = null): ParsingState
     {
         try {
             $this->reset();
@@ -113,20 +113,20 @@ class TemplateParser
             $splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
             $parsingState = $this->buildObjectTree($this->createParsingState($templateIdentifier), $splitTemplate, self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
         } catch (Exception $error) {
-            throw $this->createParsingRelatedExceptionWithContext($error, $templateIdentifier);
+            throw $this->createParsingRelatedExceptionWithContext($error, $originalTemplatePath ?? $templateIdentifier);
         }
         $this->parsedTemplates[$templateIdentifier] = $parsingState;
         return $parsingState;
     }
 
-    public function createParsingRelatedExceptionWithContext(\Exception $error, string $templateIdentifier): \Exception
+    public function createParsingRelatedExceptionWithContext(\Exception $error, string $templateIdentifierOrPath): \Exception
     {
         list($line, $character, $templateCode) = $this->getCurrentParsingPointers();
         $exceptionClass = get_class($error);
         return new $exceptionClass(
             sprintf(
                 'Fluid parse error in template %s, line %d at character %d. Error: %s (error code %d). Template source chunk: %s',
-                $templateIdentifier,
+                $templateIdentifierOrPath,
                 $line,
                 $character,
                 $error->getMessage(),
@@ -141,7 +141,7 @@ class TemplateParser
     /**
      * @param \Closure $templateSourceClosure Closure which returns the template source if needed
      */
-    public function getOrParseAndStoreTemplate(string $templateIdentifier, \Closure $templateSourceClosure): ParsedTemplateInterface
+    public function getOrParseAndStoreTemplate(string $templateIdentifier, \Closure $templateSourceClosure, ?string $originalTemplatePath = null): ParsedTemplateInterface
     {
         $compiler = $this->renderingContext->getTemplateCompiler();
         if (isset($this->parsedTemplates[$templateIdentifier])) {
@@ -149,10 +149,10 @@ class TemplateParser
         } elseif ($compiler->has($templateIdentifier)) {
             $parsedTemplate = $compiler->get($templateIdentifier);
             if ($parsedTemplate instanceof UncompilableTemplateInterface) {
-                $parsedTemplate = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure);
+                $parsedTemplate = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure, $originalTemplatePath);
             }
         } else {
-            $parsedTemplate = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure);
+            $parsedTemplate = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure, $originalTemplatePath);
             try {
                 $compiler->store($templateIdentifier, $parsedTemplate);
             } catch (StopCompilingException $stop) {
@@ -164,11 +164,12 @@ class TemplateParser
         return $parsedTemplate;
     }
 
-    protected function parseTemplateSource(string $templateIdentifier, \Closure $templateSourceClosure): ParsingState
+    protected function parseTemplateSource(string $templateIdentifier, \Closure $templateSourceClosure, ?string $originalTemplatePath): ParsingState
     {
         return $this->parse(
             $templateSourceClosure($this, $this->renderingContext->getTemplatePaths()),
             $templateIdentifier,
+            $originalTemplatePath,
         );
     }
 

--- a/src/Core/Variables/InvalidVariableIdentifierException.php
+++ b/src/Core/Variables/InvalidVariableIdentifierException.php
@@ -9,4 +9,6 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Core\Variables;
 
-class InvalidVariableIdentifierException extends \Exception {}
+use TYPO3Fluid\Fluid\Core\Parser\Exception;
+
+class InvalidVariableIdentifierException extends Exception {}

--- a/src/Validation/TemplateValidator.php
+++ b/src/Validation/TemplateValidator.php
@@ -48,6 +48,7 @@ final readonly class TemplateValidator
                 $parsedTemplate = $renderingContext->getTemplateParser()->parse(
                     $templatePaths->getTemplateSource(),
                     $templateIdentifier,
+                    $template,
                 );
             } catch (\Exception $e) {
                 $errors[] = $e;

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -166,6 +166,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
                     function ($parent, TemplatePaths $paths) use ($layoutName) {
                         return $paths->getLayoutSource($layoutName);
                     },
+                    $layoutRenderingContext->getTemplatePaths()->getLayoutPathAndFilename($layoutName),
                 );
             } catch (PassthroughSourceException $error) {
                 return $error->getSource();
@@ -291,6 +292,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
                 function ($parent, TemplatePaths $paths) use ($partialName) {
                     return $paths->getPartialSource($partialName);
                 },
+                $templatePaths->getPartialPathAndFilename($partialName),
             );
         } catch (PassthroughSourceException $error) {
             return $error->getSource();
@@ -380,6 +382,8 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
             function ($parent, TemplatePaths $paths) use ($controllerName, $actionName) {
                 return $paths->getTemplateSource($controllerName, $actionName);
             },
+            // @todo $controllerName and $actionName should never be null, see also TemplatePaths
+            $templatePaths->resolveTemplateFileForControllerAndActionAndFormat($controllerName ?? '', $actionName ?? ''),
         );
         if ($parsedTemplate->isCompiled()) {
             $parsedTemplate->addCompiledNamespaces($this->baseRenderingContext);


### PR DESCRIPTION
In an effort to ease debugging, exceptions thrown by the Fluid parser
now contain the full path to the original template file. Previously,
it could be quite hard to discover the affected template because of
the cryptic and internal templateIdentifier. Now, the full template
path is given as an additional input value to the parser and will be
used in exception messages if provided.

Note that this does not cover cached templates because that category
of exceptions only occur in uncached templates (because invalid syntax
cannot be cached). Also note that the performance impact is minimal
because all file lookups are runtime-cached and already needed to
be performed before this change.

`InvalidVariableIdentifierException` now uses the parser exception
as base class in order to profit from this change. That means that
users also get the added context information if an invalid variable
name is used in a template.

Fluid users that call the `TemplateParser` directly and not through
the high-level `TemplateView` class are encouraged to make use of the
new argument in `TemplateParser->parse()` and
`TemplateParse->getOrParseAndStoreTemplate()` to provide the full
path to the template.