### PR TITLE
[TASK] Provide current template path in renderingContext

### DIFF
--- a/src/Core/Compiler/AbstractCompiledTemplate.php
+++ b/src/Core/Compiler/AbstractCompiledTemplate.php
@@ -29,6 +29,11 @@ abstract class AbstractCompiledTemplate implements ParsedTemplateInterface
         return static::class;
     }
 
+    public function getOriginalTemplatePath(): ?string
+    {
+        return null;
+    }
+
     public function getVariableContainer(): VariableProviderInterface
     {
         return new StandardVariableProvider();

--- a/src/Core/Compiler/TemplateCompiler.php
+++ b/src/Core/Compiler/TemplateCompiler.php
@@ -107,7 +107,7 @@ class TemplateCompiler
         $this->currentlyProcessingState = null;
     }
 
-    public function store(string $identifier, ParsingState $parsingState): ?string
+    public function store(string $identifier, ParsingState $parsingState, ?string $originalTemplatePath = null): ?string
     {
         if ($this->isDisabled()) {
             $parsingState->setCompilable(false);
@@ -142,6 +142,9 @@ class TemplateCompiler
         $templateCode = sprintf(
             '<?php' . chr(10)
             . '%s {' . chr(10)
+            . '    public function getOriginalTemplatePath(): ?string {' . chr(10)
+                . '        return %s;' . chr(10)
+                . '    }' . chr(10)
             . '    public function getLayoutName(\\TYPO3Fluid\\Fluid\\Core\\Rendering\\RenderingContextInterface $renderingContext): ?string {' . chr(10)
             . '        %s;' . chr(10)
             . '    }' . chr(10)
@@ -156,6 +159,7 @@ class TemplateCompiler
             . '    %s' . chr(10)
             . '}' . chr(10),
             'class ' . $identifier . ' extends \TYPO3Fluid\Fluid\Core\Compiler\AbstractCompiledTemplate',
+            var_export($originalTemplatePath, true),
             $this->generateCodeForLayoutName($storedLayoutName),
             ($parsingState->hasLayout() ? 'true' : 'false'),
             var_export($this->renderingContext->getViewHelperResolver()->getLocalNamespaces(), true),

--- a/src/Core/Parser/ParsedTemplateInterface.php
+++ b/src/Core/Parser/ParsedTemplateInterface.php
@@ -25,6 +25,8 @@ interface ParsedTemplateInterface
 
     public function getIdentifier(): string;
 
+    public function getOriginalTemplatePath(): ?string;
+
     /**
      * @return ArgumentDefinition[]
      */

--- a/src/Core/Parser/ParsingState.php
+++ b/src/Core/Parser/ParsingState.php
@@ -26,6 +26,7 @@ use TYPO3Fluid\Fluid\View;
 class ParsingState implements ParsedTemplateInterface
 {
     protected string $identifier;
+    protected ?string $originalTemplatePath = null;
     protected string|NodeInterface|null $layoutName = null;
 
     /**
@@ -66,6 +67,16 @@ class ParsingState implements ParsedTemplateInterface
     public function getIdentifier(): string
     {
         return $this->identifier;
+    }
+
+    public function setOriginalTemplatePath(?string $originalTemplatePath): void
+    {
+        $this->originalTemplatePath = $originalTemplatePath;
+    }
+
+    public function getOriginalTemplatePath(): ?string
+    {
+        return $this->originalTemplatePath;
     }
 
     /**

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -111,7 +111,11 @@ class TemplateParser
             $templateString = $this->preProcessTemplateSource($templateString);
 
             $splitTemplate = $this->splitTemplateAtDynamicTags($templateString);
-            $parsingState = $this->buildObjectTree($this->createParsingState($templateIdentifier), $splitTemplate, self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS);
+            $parsingState = $this->buildObjectTree(
+                $this->createParsingState($templateIdentifier, $originalTemplatePath),
+                $splitTemplate,
+                self::CONTEXT_OUTSIDE_VIEWHELPER_ARGUMENTS,
+            );
         } catch (Exception $error) {
             throw $this->createParsingRelatedExceptionWithContext($error, $originalTemplatePath ?? $templateIdentifier);
         }
@@ -154,11 +158,11 @@ class TemplateParser
         } else {
             $parsedTemplate = $this->parseTemplateSource($templateIdentifier, $templateSourceClosure, $originalTemplatePath);
             try {
-                $compiler->store($templateIdentifier, $parsedTemplate);
+                $compiler->store($templateIdentifier, $parsedTemplate, $originalTemplatePath);
             } catch (StopCompilingException $stop) {
                 $this->renderingContext->getErrorHandler()->handleCompilerError($stop);
                 $parsedTemplate->setCompilable(false);
-                $compiler->store($templateIdentifier, $parsedTemplate);
+                $compiler->store($templateIdentifier, $parsedTemplate, $originalTemplatePath);
             }
         }
         return $parsedTemplate;
@@ -599,7 +603,11 @@ class TemplateParser
         //       should be applied to the global state, while others should only
         //       affect the local state. Maybe it's also possible to get rid
         //       of the local state altogether.
-        $innerState = $this->buildObjectTree($this->createParsingState(''), $splitArgument, self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS);
+        $innerState = $this->buildObjectTree(
+            $this->createParsingState('', $state->getOriginalTemplatePath()),
+            $splitArgument,
+            self::CONTEXT_INSIDE_VIEWHELPER_ARGUMENTS,
+        );
         // This can be removed once the outer-inner-state issue is resolved
         $state->setAvailableSlots(array_unique(array_merge(
             $state->getAvailableSlots(),
@@ -833,12 +841,13 @@ class TemplateParser
         $state->getNodeFromStack()->addChildNode($node);
     }
 
-    protected function createParsingState(string $templateIdentifier): ParsingState
+    protected function createParsingState(string $templateIdentifier, ?string $originalTemplatePath = null): ParsingState
     {
         $rootNode = new RootNode();
         $variableProvider = $this->renderingContext->getVariableProvider();
         $state = new ParsingState();
         $state->setIdentifier($templateIdentifier);
+        $state->setOriginalTemplatePath($originalTemplatePath);
         $state->setRootNode($rootNode);
         $state->pushNodeToStack($rootNode);
         $state->setVariableProvider($variableProvider->getScopeCopy($variableProvider->getAll()));

--- a/src/Core/Rendering/RenderingContext.php
+++ b/src/Core/Rendering/RenderingContext.php
@@ -83,6 +83,8 @@ class RenderingContext implements RenderingContextInterface
      */
     protected $controllerAction;
 
+    protected ?string $originalTemplatePath = null;
+
     /**
      * @var TemplateParser
      */
@@ -434,6 +436,16 @@ class RenderingContext implements RenderingContextInterface
     public function setControllerAction($action)
     {
         $this->controllerAction = $action;
+    }
+
+    public function setOriginalTemplatePath(?string $originalTemplatePath): void
+    {
+        $this->originalTemplatePath = $originalTemplatePath;
+    }
+
+    public function getOriginalTemplatePath(): ?string
+    {
+        return $this->originalTemplatePath;
     }
 
     public function __clone(): void

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -172,6 +172,12 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
                 return $error->getSource();
             }
             $this->startRendering(self::RENDERING_LAYOUT, $parsedTemplate, $layoutRenderingContext);
+            // Layout is a special case because the rendering stack contains the parsed template,
+            // not the parsed layout, so the wrong original template path would be set in layout files
+            // @todo decide if this method should be added to RenderingContextInterface in Fluid 6
+            if (method_exists($layoutRenderingContext, 'setOriginalTemplatePath')) {
+                $layoutRenderingContext->setOriginalTemplatePath($parsedLayout->getOriginalTemplatePath());
+            }
             try {
                 $this->processAndValidateTemplateVariables(
                     $parsedLayout,
@@ -336,6 +342,10 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
      */
     protected function startRendering($type, ParsedTemplateInterface $template, RenderingContextInterface $context)
     {
+        // @todo decide if this method should be added to RenderingContextInterface in Fluid 6
+        if (method_exists($context, 'setOriginalTemplatePath')) {
+            $context->setOriginalTemplatePath($template->getOriginalTemplatePath());
+        }
         $this->renderingStack[] = ['type' => $type, 'parsedTemplate' => $template, 'renderingContext' => $context];
     }
 

--- a/tests/Functional/Core/Rendering/RuntimeExceptionsTest.php
+++ b/tests/Functional/Core/Rendering/RuntimeExceptionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Core\Rendering;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+final class RuntimeExceptionsTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function originalTemplatePathIsConsistent(): void
+    {
+        $assertContains = [
+            '|Layout before: ' . __DIR__ . '/../../Fixtures/Layouts/OriginalTemplatePathLayout.html|',
+            '|Layout after: ' . __DIR__ . '/../../Fixtures/Layouts/OriginalTemplatePathLayout.html|',
+            '|Template before: ' . __DIR__ . '/../../Fixtures/Templates/OriginalTemplatePath.html|',
+            '|Template after: ' . __DIR__ . '/../../Fixtures/Templates/OriginalTemplatePath.html|',
+            '|Template inline: ' . __DIR__ . '/../../Fixtures/Templates/OriginalTemplatePath.html|',
+            '|Partial before: ' . __DIR__ . '/../../Fixtures/Partials/OriginalTemplatePathPartial.html|',
+            '|Partial after: ' . __DIR__ . '/../../Fixtures/Partials/OriginalTemplatePathPartial.html|',
+            '|Partial nested: ' . __DIR__ . '/../../Fixtures/Partials/OriginalTemplatePathPartialNested.html|',
+        ];
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateRootPaths([__DIR__ . '/../../Fixtures/Templates/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $result = $view->render('OriginalTemplatePath');
+        foreach ($assertContains as $contains) {
+            self::assertStringContainsString($contains, $result, 'uncached');
+        }
+
+        $view = new TemplateView();
+        $view->getRenderingContext()->setCache(self::$cache);
+        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');
+        $view->getRenderingContext()->getTemplatePaths()->setTemplateRootPaths([__DIR__ . '/../../Fixtures/Templates/']);
+        $view->getRenderingContext()->getTemplatePaths()->setPartialRootPaths([__DIR__ . '/../../Fixtures/Partials/']);
+        $view->getRenderingContext()->getTemplatePaths()->setLayoutRootPaths([__DIR__ . '/../../Fixtures/Layouts/']);
+        $result = $view->render('OriginalTemplatePath');
+        foreach ($assertContains as $contains) {
+            self::assertStringContainsString($contains, $result, 'cached');
+        }
+    }
+}

--- a/tests/Functional/Fixtures/Layouts/OriginalTemplatePathLayout.html
+++ b/tests/Functional/Fixtures/Layouts/OriginalTemplatePathLayout.html
@@ -1,0 +1,6 @@
+
+|Layout before: <test:originalTemplatePath />|
+<f:render section="main" />
+|Layout after: <test:originalTemplatePath />|
+
+

--- a/tests/Functional/Fixtures/Partials/OriginalTemplatePathPartial.html
+++ b/tests/Functional/Fixtures/Partials/OriginalTemplatePathPartial.html
@@ -1,0 +1,4 @@
+|Partial before: <test:originalTemplatePath />|
+<f:render partial="OriginalTemplatePathPartialNested" />
+|Partial after: <test:originalTemplatePath />|
+

--- a/tests/Functional/Fixtures/Partials/OriginalTemplatePathPartialNested.html
+++ b/tests/Functional/Fixtures/Partials/OriginalTemplatePathPartialNested.html
@@ -1,0 +1,1 @@
+|Partial nested: <test:originalTemplatePath />|

--- a/tests/Functional/Fixtures/Templates/OriginalTemplatePath.html
+++ b/tests/Functional/Fixtures/Templates/OriginalTemplatePath.html
@@ -1,0 +1,9 @@
+<f:layout name="OriginalTemplatePathLayout" />
+
+<f:section name="main">
+    |Template before: <test:originalTemplatePath />|
+    <f:render partial="OriginalTemplatePathPartial" />
+    |Template after: <test:originalTemplatePath />|
+    {f:if(condition: '{test:originalTemplatePath()}', then: '|Template inline: {test:originalTemplatePath()}|')}
+</f:section>
+

--- a/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
+++ b/tests/Functional/Fixtures/Various/ParsedTemplateImplementationFixture.php
@@ -26,6 +26,11 @@ final class ParsedTemplateImplementationFixture implements ParsedTemplateInterfa
         return 'myIdentifier';
     }
 
+    public function getOriginalTemplatePath(): string
+    {
+        return 'path/to/template.fluid.html';
+    }
+
     public function getArgumentDefinitions(): array
     {
         return [];

--- a/tests/Functional/Fixtures/ViewHelpers/OriginalTemplatePathViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/OriginalTemplatePathViewHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class OriginalTemplatePathViewHelper extends AbstractViewHelper
+{
+    public function render(): string
+    {
+        if (method_exists($this->renderingContext, 'getOriginalTemplatePath')) {
+            return $this->renderingContext->getOriginalTemplatePath();
+        }
+        return '';
+    }
+}


### PR DESCRIPTION
Previously, PHP code within the context of a template (most importantly
ViewHelpers, but also internal Fluid code) wasn't aware of the current
template context. This meant that exceptions couldn't refer to the
template file where the exception was actually triggered.

This change introduces the optional `originalTemplatePath` value both
in the parser/compilation and in the rendering layer. When filled, it
contains the full path to the template that is currently parsed or
rendered. Since the value is also persisted to the cache, this path
is even available for cached template files.

In follow-up patches, this path can be used to improve exception
messages within Fluid. It also allows users to access these values to
improve exception messages in their own implementations.