### PR TITLE
[TASK] Order tests by default by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Phpunit
         run: vendor/bin/phpunit
 
+      - name: Phpunit random order
+        run: vendor/bin/phpunit --order-by random
+
       - name: Documentation integrity
         run: |
           # Generate ViewHelper documentation

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
     cacheDirectory=".phpunit.cache"
     cacheResult="false"
     colors="true"
@@ -13,8 +13,6 @@
     failOnNotice="true"
     failOnRisky="true"
     failOnWarning="true"
-    executionOrder="random"
-    resolveDependencies="true"
 >
     <testsuites>
         <testsuite name="Unit">


### PR DESCRIPTION
Do not randomize test order in phpunit.xml since that is annoying when actively working with the test code base. Have a dedicated workflow job instead to add a randomized run.

Raise phpunit.xsd to oldest common denominator and remove resolveDependencies attribute which is identical to the default value.