### PR TITLE
[TASK] Have notice and deprecation free phpunit v13

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,9 +41,3 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: src/ViewHelpers/ForViewHelper.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php

--- a/tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/StaticCacheable/NotSharedStaticCompilableViewHelperTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\StaticCacheable;
 
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolver;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -22,16 +21,6 @@ final class NotSharedStaticCompilableViewHelperTest extends AbstractFunctionalTe
     #[Test]
     public function renderWithNotSharedCompilableViewHelper(): void
     {
-        // @todo If the test with the mocked ViewHelperResolver is executed standalone, it fails and shows the broken
-        //       state. As soon as it is run next to other tests, it succeeds - which is currently wrong. We need to
-        //       tackle this first, so we can have proper test coverage for this regression - and before covering or
-        //       fixing the regression. If the skip is removed, the other test is green (which should be red right now).
-        // Note: To investigate this, the method code in ViewHelperNode->updateViewHelperNodeInViewHelper() should be
-        //       commented out and full test suite run vs the single concrete testcase to see if the single-failure vs
-        //       succeed with full suite can be solved.
-        //       Single TestCase: tests/Functional/ViewHelpers/StaticCacheable/SharedStaticCompilableViewHelperTest.php
-        self::markTestSkipped('Interfering with StaticCompilableViewHelperTest::renderWithSharedCompilableViewHelper');
-
         $template = __DIR__ . '/Fixtures/Templates/Results.html';
         $expectedMarkup = trim(file_get_contents(__DIR__ . '/Fixtures/ExpectedOutput.html'));
 

--- a/tests/Unit/Core/Compiler/TemplateCompilerTest.php
+++ b/tests/Unit/Core/Compiler/TemplateCompilerTest.php
@@ -23,7 +23,7 @@ final class TemplateCompilerTest extends TestCase
     public function getRenderingContextReturnsPreviouslySetRenderingContext(): void
     {
         $subject = new TemplateCompiler();
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $subject->setRenderingContext($renderingContextMock);
         self::assertSame($renderingContextMock, $subject->getRenderingContext());
     }
@@ -87,7 +87,7 @@ final class TemplateCompilerTest extends TestCase
     #[Test]
     public function getRenderingContextGetsPreviouslySetRenderingContext(): void
     {
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $subject = new TemplateCompiler();
         $subject->setRenderingContext($renderingContextMock);
         self::assertSame($renderingContextMock, $subject->getRenderingContext());

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -13,20 +13,20 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Parser\Exception;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\NodeInterface;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\UserWithToString;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Fixtures\AbstractNodeTestFixture;
 
 final class AbstractNodeTest extends TestCase
 {
     #[Test]
     public function evaluateChildNodesPassesRenderingContextToChildNodes(): void
     {
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $childNode = $this->createMock(NodeInterface::class);
         $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock);
-        $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
+        $subject = new AbstractNodeTestFixture();
         $subject->addChildNode($childNode);
         $subject->evaluateChildNodes($renderingContextMock);
     }
@@ -34,8 +34,8 @@ final class AbstractNodeTest extends TestCase
     #[Test]
     public function evaluateChildNodesReturnsNullIfNoChildNodesExist(): void
     {
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
-        $subject = $this->createMock(AbstractNode::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
+        $subject = new AbstractNodeTestFixture();
         self::assertNull($subject->evaluateChildNodes($renderingContextMock));
     }
 
@@ -47,10 +47,10 @@ final class AbstractNodeTest extends TestCase
         $this->expectExceptionCode($exceptionCode);
         $this->expectExceptionMessage($exceptionMessage);
 
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $childNode = $this->createMock(NodeInterface::class);
         $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn($value);
-        $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
+        $subject = new AbstractNodeTestFixture();
         $subject->addChildNode($childNode);
         $method = new \ReflectionMethod($subject, 'evaluateChildNode');
         $method->invoke($subject, $childNode, $renderingContextMock, true);
@@ -67,11 +67,11 @@ final class AbstractNodeTest extends TestCase
     #[Test]
     public function evaluateChildNodeCanCastToString(): void
     {
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $childNode = $this->createMock(NodeInterface::class);
         $withToString = new UserWithToString('foobar');
         $childNode->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn($withToString);
-        $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
+        $subject = new AbstractNodeTestFixture();
         $subject->addChildNode($childNode);
         $method = new \ReflectionMethod($subject, 'evaluateChildNode');
         $result = $method->invoke($subject, $childNode, $renderingContextMock, true);
@@ -81,9 +81,9 @@ final class AbstractNodeTest extends TestCase
     #[Test]
     public function evaluateChildNodesConcatenatesOutputs(): void
     {
-        $renderingContextMock = $this->createMock(RenderingContextInterface::class);
+        $renderingContextMock = self::createStub(RenderingContextInterface::class);
         $childNode = $this->createMock(NodeInterface::class);
-        $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
+        $subject = new AbstractNodeTestFixture();
         $subject->addChildNode($childNode);
         $child2 = clone $childNode;
         $child2->expects(self::once())->method('evaluate')->with($renderingContextMock)->willReturn('bar');
@@ -97,8 +97,8 @@ final class AbstractNodeTest extends TestCase
     #[Test]
     public function childNodeCanBeReadOutAgain(): void
     {
-        $childNode = $this->createMock(NodeInterface::class);
-        $subject = $this->getMockBuilder(AbstractNode::class)->onlyMethods(['evaluate'])->getMock();
+        $childNode = self::createStub(NodeInterface::class);
+        $subject = new AbstractNodeTestFixture();
         $subject->addChildNode($childNode);
         self::assertSame($subject->getChildNodes(), [$childNode]);
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/Fixtures/AbstractNodeTestFixture.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/Fixtures/AbstractNodeTestFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\Parser\SyntaxTree\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+final class AbstractNodeTestFixture extends AbstractNode
+{
+    public function evaluate(RenderingContextInterface $renderingContext): mixed
+    {
+        return null;
+    }
+}

--- a/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ObjectAccessorNodeTest.php
@@ -34,17 +34,14 @@ final class ObjectAccessorNodeTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $expected
-     */
     #[DataProvider('getEvaluateTestValues')]
     #[Test]
-    public function testEvaluateGetsExpectedValue(array $variables, string $path, $expected): void
+    public function testEvaluateGetsExpectedValue(array $variables, string $path, mixed $expected): void
     {
         $node = new ObjectAccessorNode($path);
         $renderingContext = $this->createMock(RenderingContextInterface::class);
         $variableContainer = new StandardVariableProvider($variables);
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
+        $renderingContext->expects(self::once())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);
         self::assertSame($expected, $value);
     }
@@ -56,7 +53,7 @@ final class ObjectAccessorNodeTest extends TestCase
         $renderingContext = $this->createMock(RenderingContextInterface::class);
         $variableContainer = $this->createMock(StandardVariableProvider::class);
         $variableContainer->expects(self::once())->method('getByPath')->with('foo.bar')->willReturn('foo');
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableContainer);
+        $renderingContext->expects(self::once())->method('getVariableProvider')->willReturn($variableContainer);
         $value = $node->evaluate($renderingContext);
         self::assertEquals('foo', $value);
     }

--- a/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/ViewHelperNodeTest.php
@@ -26,10 +26,10 @@ final class ViewHelperNodeTest extends TestCase
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelperResolverMock = $this->createMock(ViewHelperResolver::class);
         $renderingContextMock->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolverMock);
-        $viewHelperResolverMock->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
-        $viewHelperResolverMock->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
-        $viewHelperResolverMock->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
-        $arguments = [$this->createMock(NodeInterface::class)];
+        $viewHelperResolverMock->expects(self::once())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+        $viewHelperResolverMock->expects(self::once())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+        $viewHelperResolverMock->expects(self::once())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
+        $arguments = [self::createStub(NodeInterface::class)];
         $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', $arguments);
         self::assertSame($arguments, $subject->getArguments());
     }
@@ -40,13 +40,13 @@ final class ViewHelperNodeTest extends TestCase
         $renderingContextMock = $this->createMock(RenderingContextInterface::class);
         $viewHelperResolverMock = $this->createMock(ViewHelperResolver::class);
         $renderingContextMock->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolverMock);
-        $viewHelperResolverMock->expects(self::any())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
-        $viewHelperResolverMock->expects(self::any())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
-        $viewHelperResolverMock->expects(self::any())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
+        $viewHelperResolverMock->expects(self::once())->method('resolveViewHelperClassName')->with('f', 'vh')->willReturn(TestViewHelper::class);
+        $viewHelperResolverMock->expects(self::once())->method('createViewHelperInstanceFromClassName')->with(TestViewHelper::class)->willReturn(new TestViewHelper());
+        $viewHelperResolverMock->expects(self::once())->method('getArgumentDefinitionsForViewHelper')->willReturn([]);
         $viewHelperInvokerMock = $this->createMock(ViewHelperInvoker::class);
         $renderingContextMock->expects(self::once())->method('getViewHelperInvoker')->willReturn($viewHelperInvokerMock);
         $viewHelperInvokerMock->expects(self::once())->method('invoke')->willReturn('test');
-        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', [$this->createMock(NodeInterface::class)]);
+        $subject = new ViewHelperNode($renderingContextMock, 'f', 'vh', [self::createStub(NodeInterface::class)]);
         $result = $subject->evaluate($renderingContextMock);
         self::assertSame('test', $result);
     }

--- a/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
+++ b/tests/Unit/Core/Parser/TemplateProcessor/EscapingModifierTemplateProcessorTest.php
@@ -73,10 +73,9 @@ final class EscapingModifierTemplateProcessorTest extends TestCase
     public function testThrowsExceptionOnMultipleDefinitions(string $templateSource): void
     {
         $this->expectException(Exception::class);
-        $subject = new EscapingModifierTemplateProcessor();
         $context = new RenderingContext();
-        $parser = $this->getMockBuilder(TemplateParser::class)->onlyMethods(['setEscapingEnabled'])->getMock();
-        $context->setTemplateParser($parser);
+        $context->setTemplateParser(new TemplateParser());
+        $subject = new EscapingModifierTemplateProcessor();
         $subject->setRenderingContext($context);
         $subject->preProcessSource($templateSource);
     }

--- a/tests/Unit/Core/Rendering/RenderingContextTest.php
+++ b/tests/Unit/Core/Rendering/RenderingContextTest.php
@@ -65,7 +65,7 @@ final class RenderingContextTest extends TestCase
     #[Test]
     public function gettersReturnPreviouslySetObjects(string $property, string $expected): void
     {
-        $expected = $this->createMock($expected);
+        $expected = self::createStub($expected);
         $subject = new RenderingContext();
         $setter = 'set' . ucfirst($property);
         $subject->$setter($expected);
@@ -76,7 +76,7 @@ final class RenderingContextTest extends TestCase
     #[Test]
     public function getTemplateProcessorsReturnsPreviouslySetTemplateProcessor(): void
     {
-        $processors = [$this->createMock(TemplateProcessorInterface::class), $this->createMock(TemplateProcessorInterface::class)];
+        $processors = [self::createStub(TemplateProcessorInterface::class), self::createStub(TemplateProcessorInterface::class)];
         $subject = new RenderingContext();
         $subject->setTemplateProcessors($processors);
         self::assertSame($processors, $subject->getTemplateProcessors());
@@ -93,7 +93,7 @@ final class RenderingContextTest extends TestCase
     public function isCacheEnabledReturnsTrueIfCacheIsEnabled(): void
     {
         $subject = new RenderingContext();
-        $subject->setCache($this->createMock(FluidCacheInterface::class));
+        $subject->setCache(self::createStub(FluidCacheInterface::class));
         self::assertTrue($subject->isCacheEnabled());
     }
 

--- a/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -11,8 +11,8 @@ namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
+use TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures\AbstractTagBasedViewHelperTestFixture;
 
 final class AbstractTagBasedViewHelperTest extends TestCase
 {
@@ -21,7 +21,7 @@ final class AbstractTagBasedViewHelperTest extends TestCase
     {
         $tagBuilder = $this->createMock(TagBuilder::class);
         $tagBuilder->expects(self::once())->method('render')->willReturn('foobar');
-        $subject = $this->getMockBuilder(AbstractTagBasedViewHelper::class)->onlyMethods([])->getMock();
+        $subject = new AbstractTagBasedViewHelperTestFixture();
         $subject->setTagBuilder($tagBuilder);
         self::assertEquals('foobar', $subject->render());
     }

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -43,8 +43,8 @@ final class AbstractViewHelperTest extends TestCase
     #[Test]
     public function setRenderingContextShouldSetInnerVariables(): void
     {
-        $templateVariableContainer = $this->createMock(VariableProviderInterface::class);
-        $viewHelperVariableContainer = $this->createMock(ViewHelperVariableContainer::class);
+        $templateVariableContainer = self::createStub(VariableProviderInterface::class);
+        $viewHelperVariableContainer = self::createStub(ViewHelperVariableContainer::class);
         $renderingContext = new RenderingContext();
         $renderingContext->setVariableProvider($templateVariableContainer);
         $renderingContext->setViewHelperVariableContainer($viewHelperVariableContainer);

--- a/tests/Unit/Core/ViewHelper/Fixtures/AbstractTagBasedViewHelperTestFixture.php
+++ b/tests/Unit/Core/ViewHelper/Fixtures/AbstractTagBasedViewHelperTestFixture.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Tests\Unit\Core\ViewHelper\Fixtures;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+class AbstractTagBasedViewHelperTestFixture extends AbstractTagBasedViewHelper {}

--- a/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
+++ b/tests/Unit/Core/ViewHelper/ViewHelperVariableContainerTest.php
@@ -82,7 +82,7 @@ final class ViewHelperVariableContainerTest extends TestCase
     public function getViewReturnsPreviouslySetView(): void
     {
         $subject = new ViewHelperVariableContainer();
-        $view = $this->createMock(ViewInterface::class);
+        $view = self::createStub(ViewInterface::class);
         $subject->setView($view);
         self::assertSame($view, $subject->getView());
     }

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -28,7 +28,7 @@ final class AbstractTemplateViewTest extends TestCase
     public function getRenderingContextReturnsPreviouslySetRenderingContext(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
         self::assertSame($renderingContext, $subject->getRenderingContext());
@@ -38,8 +38,8 @@ final class AbstractTemplateViewTest extends TestCase
     public function getViewHelperResolverReturnsViewHelperResolverFromRenderingContext(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
-        $viewHelperResolver = $this->createMock(ViewHelperResolver::class);
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
+        $viewHelperResolver = self::createStub(ViewHelperResolver::class);
         $renderingContext->expects(self::once())->method('getViewHelperResolver')->willReturn($viewHelperResolver);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
@@ -50,9 +50,9 @@ final class AbstractTemplateViewTest extends TestCase
     public function assignAddsValueToTemplateVariableContainer(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $variableProvider = $this->createMock(VariableProviderInterface::class);
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableProvider);
+        $renderingContext->expects(self::atLeastOnce())->method('getVariableProvider')->willReturn($variableProvider);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
         $series = [
@@ -71,9 +71,9 @@ final class AbstractTemplateViewTest extends TestCase
     public function assignCanOverridePreviouslyAssignedValues(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $variableProvider = $this->createMock(VariableProviderInterface::class);
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableProvider);
+        $renderingContext->expects(self::atLeastOnce())->method('getVariableProvider')->willReturn($variableProvider);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
         $series = [
@@ -92,9 +92,9 @@ final class AbstractTemplateViewTest extends TestCase
     public function assignMultipleAddsValuesToTemplateVariableContainer(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $variableProvider = $this->createMock(VariableProviderInterface::class);
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableProvider);
+        $renderingContext->expects(self::atLeastOnce())->method('getVariableProvider')->willReturn($variableProvider);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
         $series = [
@@ -114,9 +114,9 @@ final class AbstractTemplateViewTest extends TestCase
     public function assignMultipleCanOverridePreviouslyAssignedValues(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $variableProvider = $this->createMock(VariableProviderInterface::class);
-        $renderingContext->expects(self::any())->method('getVariableProvider')->willReturn($variableProvider);
+        $renderingContext->expects(self::atLeastOnce())->method('getVariableProvider')->willReturn($variableProvider);
         $subject = new AbstractTemplateViewTestFixture();
         $subject->setRenderingContext($renderingContext);
         $series = [
@@ -138,12 +138,11 @@ final class AbstractTemplateViewTest extends TestCase
         $this->expectException(InvalidSectionException::class);
 
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
-        $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
-        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(false);
-        $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
+        $parsedTemplate->expects(self::once())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();
         $subject->setRenderingContext($renderingContext);
         $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(3);
@@ -157,12 +156,10 @@ final class AbstractTemplateViewTest extends TestCase
         $this->expectException(InvalidSectionException::class);
 
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
-        $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
-        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
+        $renderingContext->expects(self::once())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(true);
-        $parsedTemplate->expects(self::any())->method('getVariableContainer')->willReturn(new StandardVariableProvider(['sections' => []]));
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();
         $subject->setRenderingContext($renderingContext);
         $subject->expects(self::once())->method('getCurrentRenderingType')->willReturn(3);
@@ -174,9 +171,7 @@ final class AbstractTemplateViewTest extends TestCase
     public function renderSectionOnCompiledTemplateDoesNotThrowExceptionWhenIgnoreUnknownIsTrue(): void
     {
         $renderingContext = $this->createMock(RenderingContextInterface::class);
-        $renderingContext->expects(self::any())->method('getViewHelperVariableContainer')->willReturn($this->createMock(ViewHelperVariableContainer::class));
-        $renderingContext->expects(self::any())->method('getErrorHandler')->willReturn(new StandardErrorHandler());
-        $renderingContext->expects(self::any())->method('getViewHelperResolver')->willReturn(new ViewHelperResolver());
+        $renderingContext->expects(self::once())->method('getViewHelperVariableContainer')->willReturn(self::createStub(ViewHelperVariableContainer::class));
         $parsedTemplate = $this->createMock(AbstractCompiledTemplate::class);
         $parsedTemplate->expects(self::once())->method('isCompiled')->willReturn(true);
         $subject = $this->getMockBuilder(AbstractTemplateView::class)->onlyMethods(['getCurrentParsedTemplate', 'getCurrentRenderingType'])->getMock();

--- a/tests/Unit/View/TemplatePathsTest.php
+++ b/tests/Unit/View/TemplatePathsTest.php
@@ -75,9 +75,9 @@ final class TemplatePathsTest extends TestCase
     public static function getGetterAndSetterTestValues(): array
     {
         return [
-            ['layoutRootPaths', ['foo' => 'bar']],
-            ['templateRootPaths', ['foo' => 'bar']],
-            ['partialRootPaths', ['foo' => 'bar']],
+            ['layoutRootPaths', ['foo' => '/bar']],
+            ['templateRootPaths', ['foo' => '/bar']],
+            ['partialRootPaths', ['foo' => '/bar']],
         ];
     }
 
@@ -87,8 +87,7 @@ final class TemplatePathsTest extends TestCase
     {
         $getter = 'get' . ucfirst($property);
         $setter = 'set' . ucfirst($property);
-        $subject = $this->getMockBuilder(TemplatePaths::class)->onlyMethods(['sanitizePath'])->getMock();
-        $subject->expects(self::any())->method('sanitizePath')->willReturnArgument(0);
+        $subject = new TemplatePaths();
         $subject->$setter($value);
         self::assertSame($value, $subject->$getter());
     }


### PR DESCRIPTION
* Enable a skipped test that seems to work fine now.
* $this->creatMock() vs. self::createStub(): Mocks that declare no expectations are stubs. phpunit is now more picky with this, which is good to clarify things. The change switches many cases to stubs. Places that mock system-under-test to test abstracts (which is arguably not a great idea anyways) now use fixture classes extending the abstract and new().
* expects(self::any()) is deprecated. We switch to once() and friends or remove some cases entirely since some of course turn out to be obsolete.