### PR TITLE
[TASK] Introduce dedicated exceptions for argument validation

### DIFF
--- a/src/Core/Component/ComponentAdapter.php
+++ b/src/Core/Component/ComponentAdapter.php
@@ -17,6 +17,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperResolverDelegateInterface;
 use TYPO3Fluid\Fluid\ViewHelpers\FragmentViewHelper;
@@ -97,7 +98,7 @@ final class ComponentAdapter implements ViewHelperInterface
             return;
         }
         if (!$this->getComponentDefinitionProvider()->getComponentDefinition($this->viewHelperNode->getName())->additionalArgumentsAllowed()) {
-            throw new Exception(sprintf(
+            throw new InvalidArgumentValueException(sprintf(
                 'Invalid arguments supplied to component <%s:%s>: %s',
                 $this->viewHelperNode->getNamespace(),
                 $this->viewHelperNode->getName(),

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -296,14 +296,13 @@ abstract class AbstractViewHelper implements ViewHelperInterface
      * overridden by any ViewHelper that desires this support and this inherited
      * method must not be called, obviously.
      *
-     * @throws Exception
      * @param array<string, mixed> $arguments
      */
     public function validateAdditionalArguments(array $arguments): void
     {
         if (!empty($arguments)) {
             if ($this->argumentDefinitions === []) {
-                throw new Exception(
+                throw new UndeclaredArgumentException(
                     sprintf(
                         'Undeclared arguments passed to ViewHelper %s: %s. No arguments are allowed.',
                         get_class($this),
@@ -311,7 +310,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface
                     ),
                 );
             }
-            throw new Exception(
+            throw new UndeclaredArgumentException(
                 sprintf(
                     'Undeclared arguments passed to ViewHelper %s: %s. Valid arguments are: %s',
                     get_class($this),

--- a/src/Core/ViewHelper/ArgumentDefinition.php
+++ b/src/Core/ViewHelper/ArgumentDefinition.php
@@ -37,7 +37,7 @@ class ArgumentDefinition
         protected array $annotations = [],
     ) {
         if ($required && $defaultValue !== null) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentDefinitionException(
                 sprintf('ArgumentDefinition "%s" cannot have a default value while also being required. Either remove the default or mark it as optional.', $name),
                 1754235900,
             );

--- a/src/Core/ViewHelper/InvalidArgumentDefinitionException.php
+++ b/src/Core/ViewHelper/InvalidArgumentDefinitionException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentDefinitionException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/InvalidArgumentException.php
+++ b/src/Core/ViewHelper/InvalidArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentException extends Exception {}

--- a/src/Core/ViewHelper/InvalidArgumentValueException.php
+++ b/src/Core/ViewHelper/InvalidArgumentValueException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentValueException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/MissingArgumentException.php
+++ b/src/Core/ViewHelper/MissingArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class MissingArgumentException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/UndeclaredArgumentException.php
+++ b/src/Core/ViewHelper/UndeclaredArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class UndeclaredArgumentException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/ViewHelperArgumentsValidatedEventInterface.php
+++ b/src/Core/ViewHelper/ViewHelperArgumentsValidatedEventInterface.php
@@ -14,11 +14,12 @@ interface ViewHelperArgumentsValidatedEventInterface
      * been performed (and no exception has been thrown by the built-in validation).
      * This can be used to implement additional validation logic for ViewHelper
      * arguments, such as "either arg1 needs to be specified or arg2 AND arg3"
-     * and to throw an InvalidArgumentException if that is not the case.
+     * and to throw an InvalidArgumentValueException if that is not the case.
      *
      * @param array<string, mixed> $arguments
      * @param ArgumentDefinition[] $argumentDefinitions
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException|InvalidArgumentValueException
+     * @todo remove \InvalidArgumentException in Fluid 6
      */
     public static function argumentsValidatedEvent(array $arguments, array $argumentDefinitions, ViewHelperInterface $viewHelper): void;
 }

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -61,7 +61,7 @@ class ViewHelperInvoker
                     $value = $renderingContext->getArgumentProcessor()->process($arguments[$argumentName], $argumentDefinition);
                     if (!$renderingContext->getArgumentProcessor()->isValid($value, $argumentDefinition)) {
                         $givenType = is_object($value) ? get_class($value) : gettype($value);
-                        throw new \InvalidArgumentException(sprintf(
+                        throw new InvalidArgumentValueException(sprintf(
                             'The argument "%s" was registered with type "%s", but is of type "%s" in view helper "%s".',
                             $argumentName,
                             $argumentDefinition->getType(),

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -17,6 +17,8 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentProcessorInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\MissingArgumentException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException;
 use TYPO3Fluid\Fluid\ViewHelpers\SectionViewHelper;
@@ -417,7 +419,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
             if ($variableProvider->exists($argumentName)) {
                 $processedValue = $argumentProcessor->process($variableProvider->get($argumentName), $argumentDefinition);
                 if (!$argumentProcessor->isValid($processedValue, $argumentDefinition)) {
-                    throw new Exception(sprintf(
+                    throw new InvalidArgumentValueException(sprintf(
                         'The argument "%s" for %s "%s" is registered with type "%s", but the provided value is of type "%s".',
                         $argumentName,
                         $renderingTypeLabel,
@@ -428,7 +430,7 @@ abstract class AbstractTemplateView extends AbstractView implements TemplateAwar
                 }
                 $variableProvider->add($argumentName, $processedValue);
             } elseif ($argumentDefinition->isRequired()) {
-                throw new Exception(sprintf(
+                throw new MissingArgumentException(sprintf(
                     'The argument "%s" for %s "%s" is required, but was not provided.',
                     $argumentName,
                     $renderingTypeLabel,

--- a/src/ViewHelpers/ContainsViewHelper.php
+++ b/src/ViewHelpers/ContainsViewHelper.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use Stringable;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The ContainsViewHelper checks if a provided string or array contains
@@ -88,7 +89,7 @@ final class ContainsViewHelper extends AbstractConditionViewHelper
     {
         if (!is_scalar($value) && !$value instanceof Stringable) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'If the argument "subject" is a string, then "value" must be scalar, but it is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1754978401,
@@ -101,7 +102,7 @@ final class ContainsViewHelper extends AbstractConditionViewHelper
     {
         if (!is_iterable($subject)) {
             $givenType = get_debug_type($subject);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "subject" must be either a scalar value or an array/iterator, but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1754978402,

--- a/src/ViewHelpers/CountViewHelper.php
+++ b/src/ViewHelpers/CountViewHelper.php
@@ -7,8 +7,8 @@
 
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
-use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * This ViewHelper counts elements of the specified array or countable object.
@@ -64,7 +64,7 @@ class CountViewHelper extends AbstractViewHelper
             return 0;
         }
         if (!$countable instanceof \Countable && !is_array($countable)) {
-            throw new ViewHelper\Exception(
+            throw new InvalidArgumentValueException(
                 sprintf(
                     'Subject given to f:count() is not countable (type: %s)',
                     is_object($countable) ? get_class($countable) : gettype($countable),

--- a/src/ViewHelpers/CycleViewHelper.php
+++ b/src/ViewHelpers/CycleViewHelper.php
@@ -11,6 +11,7 @@ use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * This ViewHelper cycles through the specified values.
@@ -112,7 +113,7 @@ class CycleViewHelper extends AbstractViewHelper
             return iterator_to_array($values, false);
         }
 
-        throw new ViewHelper\Exception('CycleViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
+        throw new InvalidArgumentValueException('CycleViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
     }
 
     protected static function initializeIndex(string $as, ViewHelper\ViewHelperVariableContainer $viewHelperVariableContainer): int

--- a/src/ViewHelpers/FirstViewHelper.php
+++ b/src/ViewHelpers/FirstViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The FirstViewHelper returns the first item of an array.
@@ -37,7 +38,7 @@ final class FirstViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1712220569,

--- a/src/ViewHelpers/FlattenViewHelper.php
+++ b/src/ViewHelpers/FlattenViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The FlattenViewHelper flattens a multi-dimensional array into a
@@ -42,7 +43,7 @@ final class FlattenViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1750878602,

--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -9,8 +9,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * Loop ViewHelper which can be used to iterate over arrays.
@@ -90,16 +90,13 @@ class ForViewHelper extends AbstractViewHelper
         $this->registerArgument('iteration', 'string', 'The name of the variable to store iteration information (index, cycle, total, isFirst, isLast, isEven, isOdd)');
     }
 
-    /**
-     * @throws ViewHelper\Exception
-     */
     public function render(): string
     {
         if (!isset($this->arguments['each'])) {
             return '';
         }
         if (is_object($this->arguments['each']) && !$this->arguments['each'] instanceof \Traversable) {
-            throw new ViewHelper\Exception('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
+            throw new InvalidArgumentValueException('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
         }
         if ($this->arguments['reverse'] === true) {
             $this->arguments['each'] = array_reverse(iterator_to_array($this->arguments['each']), true);

--- a/src/ViewHelpers/Format/CaseViewHelper.php
+++ b/src/ViewHelpers/Format/CaseViewHelper.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * Modifies the case of an input string to upper- or lowercase or capitalization.
@@ -110,7 +110,6 @@ final class CaseViewHelper extends AbstractViewHelper
 
     /**
      * Changes the case of the input string
-     * @throws Exception
      */
     public function render(): string
     {
@@ -142,7 +141,7 @@ final class CaseViewHelper extends AbstractViewHelper
                 $output = mb_convert_case($value, MB_CASE_TITLE, 'utf-8');
                 break;
             default:
-                throw new Exception('The case mode "' . $mode . '" supplied to Fluid\'s format.case ViewHelper is not supported.', 1358349150);
+                throw new InvalidArgumentValueException('The case mode "' . $mode . '" supplied to Fluid\'s format.case ViewHelper is not supported.', 1358349150);
         }
         return $output;
     }

--- a/src/ViewHelpers/Format/StripTagsViewHelper.php
+++ b/src/ViewHelpers/Format/StripTagsViewHelper.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use Stringable;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * Removes tags from the given string (applying PHPs :php:`strip_tags()` function)
@@ -95,10 +96,10 @@ final class StripTagsViewHelper extends AbstractViewHelper
         $value = $this->renderChildren();
         $allowedTags = $this->arguments['allowedTags'];
         if (is_array($value)) {
-            throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700819707);
+            throw new InvalidArgumentValueException('Specified array cannot be converted to string.', 1700819707);
         }
         if (is_object($value) && !($value instanceof Stringable)) {
-            throw new \InvalidArgumentException('Specified object cannot be converted to string.', 1700819706);
+            throw new InvalidArgumentValueException('Specified object cannot be converted to string.', 1700819706);
         }
         return strip_tags((string)$value, $allowedTags);
     }

--- a/src/ViewHelpers/Format/TrimViewHelper.php
+++ b/src/ViewHelpers/Format/TrimViewHelper.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * This ViewHelper strips whitespace (or other characters) from the beginning and end of a string.
@@ -115,7 +115,7 @@ final class TrimViewHelper extends AbstractViewHelper
             self::SIDE_BOTH => trim($value, $characters),
             self::SIDE_LEFT, self::SIDE_START => ltrim($value, $characters),
             self::SIDE_RIGHT, self::SIDE_END => rtrim($value, $characters),
-            default => throw new Exception(
+            default => throw new InvalidArgumentValueException(
                 'The side "' . $side . '" supplied to Fluid\'s format.trim ViewHelper is not supported.',
                 1669191560,
             ),

--- a/src/ViewHelpers/Format/UrlencodeViewHelper.php
+++ b/src/ViewHelpers/Format/UrlencodeViewHelper.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\ViewHelpers\Format;
 
 use Stringable;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * Encodes the given string according to http://www.faqs.org/rfcs/rfc3986.html
@@ -65,10 +66,10 @@ final class UrlencodeViewHelper extends AbstractViewHelper
     {
         $value = $this->renderChildren();
         if (is_array($value)) {
-            throw new \InvalidArgumentException('Specified array cannot be converted to string.', 1700821579);
+            throw new InvalidArgumentValueException('Specified array cannot be converted to string.', 1700821579);
         }
         if (is_object($value) && !($value instanceof Stringable)) {
-            throw new \InvalidArgumentException('Specified object cannot be converted to string.', 1700821578);
+            throw new InvalidArgumentValueException('Specified object cannot be converted to string.', 1700821578);
         }
         return rawurlencode((string)$value);
     }

--- a/src/ViewHelpers/GroupedForViewHelper.php
+++ b/src/ViewHelpers/GroupedForViewHelper.php
@@ -9,8 +9,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Variables\ScopedVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
-use TYPO3Fluid\Fluid\Core\ViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * Grouped loop ViewHelper.
@@ -112,7 +112,7 @@ class GroupedForViewHelper extends AbstractViewHelper
         }
         if (is_object($each)) {
             if (!$each instanceof \Traversable) {
-                throw new ViewHelper\Exception('GroupedForViewHelper only supports arrays and objects implementing \Traversable interface', 1253108907);
+                throw new InvalidArgumentValueException('GroupedForViewHelper only supports arrays and objects implementing \Traversable interface', 1253108907);
             }
             $each = iterator_to_array($each);
         }
@@ -138,7 +138,6 @@ class GroupedForViewHelper extends AbstractViewHelper
      * @param array $elements The array / traversable object to be grouped
      * @param string $groupBy Group by this property
      * @return array The grouped array in the form array('keys' => array('key1' => [key1value], 'key2' => [key2value], ...), 'values' => array('key1' => array([key1value] => [element1]), ...), ...)
-     * @throws ViewHelper\Exception
      */
     protected static function groupElements(array $elements, string $groupBy): array
     {
@@ -149,7 +148,7 @@ class GroupedForViewHelper extends AbstractViewHelper
                 $extractor->setSource($value);
                 $currentGroupIndex = $extractor->getByPath($groupBy);
             } else {
-                throw new ViewHelper\Exception('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
+                throw new InvalidArgumentValueException('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
             }
             $currentGroupKeyValue = $currentGroupIndex;
             if ($currentGroupIndex instanceof \DateTime) {

--- a/src/ViewHelpers/JoinViewHelper.php
+++ b/src/ViewHelpers/JoinViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The JoinViewHelper combines elements from an array into a single string.
@@ -73,7 +74,7 @@ final class JoinViewHelper extends AbstractViewHelper
         $separatorLast = $this->arguments['separatorLast'] ?? null;
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1256475113,

--- a/src/ViewHelpers/LastViewHelper.php
+++ b/src/ViewHelpers/LastViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The LastViewHelper returns the last item of an array.
@@ -37,7 +38,7 @@ final class LastViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1712221620,

--- a/src/ViewHelpers/LengthViewHelper.php
+++ b/src/ViewHelpers/LengthViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The LengthViewHelper returns the length of a given string.
@@ -73,7 +74,7 @@ final class LengthViewHelper extends AbstractViewHelper
 
         if (!is_scalar($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "string", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1754637887,

--- a/src/ViewHelpers/MaxViewHelper.php
+++ b/src/ViewHelpers/MaxViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The MaxViewHelper returns the maximum element from an array
@@ -40,7 +41,7 @@ final class MaxViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1756178710,

--- a/src/ViewHelpers/MergeViewHelper.php
+++ b/src/ViewHelpers/MergeViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The MergeViewHelper merges two arrays into one, optionally recursively.
@@ -72,7 +73,7 @@ final class MergeViewHelper extends AbstractViewHelper
         $array = $this->arguments['array'] ?? $this->renderChildren();
         if (!is_iterable($array)) {
             $givenType = get_debug_type($array);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "array" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1755316529,
@@ -83,7 +84,7 @@ final class MergeViewHelper extends AbstractViewHelper
         $with = $this->arguments['with'] ?? [];
         if (!is_iterable($with)) {
             $givenType = get_debug_type($with);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "with" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1755316530,

--- a/src/ViewHelpers/MinViewHelper.php
+++ b/src/ViewHelpers/MinViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The MinViewHelper returns the minimum element from an array.
@@ -40,7 +41,7 @@ final class MinViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1756016877,

--- a/src/ViewHelpers/RangeViewHelper.php
+++ b/src/ViewHelpers/RangeViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The RangeViewHelper returns an array containing a range of integers.
@@ -93,7 +94,7 @@ final class RangeViewHelper extends AbstractViewHelper
     {
         $step = $this->arguments['step'];
         if ($step === 0) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "step" cannot be 0 in view helper "' . static::class . '".',
                 1754596304,
             );

--- a/src/ViewHelpers/RenderViewHelper.php
+++ b/src/ViewHelpers/RenderViewHelper.php
@@ -10,6 +10,8 @@ namespace TYPO3Fluid\Fluid\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Parser\ParsedTemplateInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\MissingArgumentException;
 
 /**
  * A ViewHelper to render a section, a partial, a specified section in a partial
@@ -146,7 +148,7 @@ class RenderViewHelper extends AbstractViewHelper
         $content = '';
         if ($delegate !== null) {
             if (!is_a($delegate, ParsedTemplateInterface::class, true)) {
-                throw new \InvalidArgumentException(sprintf('Cannot render %s - must implement ParsedTemplateInterface!', $delegate));
+                throw new InvalidArgumentValueException(sprintf('Cannot render %s - must implement ParsedTemplateInterface!', $delegate));
             }
             $this->renderingContext = clone $this->renderingContext;
             $this->renderingContext->getVariableProvider()->setSource($variables);
@@ -156,7 +158,7 @@ class RenderViewHelper extends AbstractViewHelper
         } elseif ($section !== null) {
             $content = $view->renderSection($section, $variables, $optional);
         } elseif (!$optional) {
-            throw new \InvalidArgumentException('ViewHelper f:render called without either argument section, partial or delegate and optional flag is false');
+            throw new MissingArgumentException('ViewHelper f:render called without either argument section, partial or delegate and optional flag is false');
         }
         // Replace empty content with default value. If default is
         // not set, null is returned and cast to a new, empty string

--- a/src/ViewHelpers/ReplaceViewHelper.php
+++ b/src/ViewHelpers/ReplaceViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The ReplaceViewHelper replaces one or multiple strings with other
@@ -68,11 +69,11 @@ final class ReplaceViewHelper extends AbstractViewHelper
         $search = $this->arguments['search'];
         $replace = $this->arguments['replace'];
         if ($value !== null && !is_scalar($value) && !$value instanceof \Stringable) {
-            throw new \InvalidArgumentException('A stringable value must be provided.', 1710441987);
+            throw new InvalidArgumentValueException('A stringable value must be provided.', 1710441987);
         }
         if ($search === null) {
             if (!is_iterable($replace)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentValueException(sprintf(
                     'Argument "replace" must be iterable to be used without "search" argument, "%s" given instead.',
                     get_debug_type($replace),
                 ), 1710441988);
@@ -84,13 +85,13 @@ final class ReplaceViewHelper extends AbstractViewHelper
             $replace = array_values($replace);
         } else {
             if (!is_iterable($search) && !is_scalar($search)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentValueException(sprintf(
                     'Argument "search" must be either iterable or scalar, "%s" given instead.',
                     get_debug_type($search),
                 ), 1710441989);
             }
             if (!is_iterable($replace) && !is_scalar($replace)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentValueException(sprintf(
                     'Argument "replace" must be either iterable or scalar, "%s" given instead.',
                     get_debug_type($replace),
                 ), 1710441990);
@@ -100,7 +101,7 @@ final class ReplaceViewHelper extends AbstractViewHelper
             $replace = is_iterable($replace) ? iterator_to_array($replace) : [$replace];
 
             if (\count($search) !== \count($replace)) {
-                throw new \InvalidArgumentException('Count of "search" and "replace" arguments must be the same.', 1710441991);
+                throw new InvalidArgumentValueException('Count of "search" and "replace" arguments must be the same.', 1710441991);
             }
         }
         return str_replace($search, $replace, (string)$value);

--- a/src/ViewHelpers/ShuffleViewHelper.php
+++ b/src/ViewHelpers/ShuffleViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The ShuffleViewHelper shuffles elements from an array.
@@ -41,7 +42,7 @@ final class ShuffleViewHelper extends AbstractViewHelper
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if ($value === null || !is_iterable($value)) {
             $givenType = get_debug_type($value);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentValueException(
                 'The argument "value" was registered with type "array", but is of type "'
                 . $givenType . '" in view helper "' . static::class . '".',
                 1750881571,

--- a/src/ViewHelpers/SplitViewHelper.php
+++ b/src/ViewHelpers/SplitViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 
 /**
  * The SplitViewHelper splits a string by the specified separator, which
@@ -77,7 +78,7 @@ final class SplitViewHelper extends AbstractViewHelper
     {
         $value = $this->arguments['value'] ?? $this->renderChildren();
         if (!is_string($value)) {
-            throw new \InvalidArgumentException('Value to be split must be a string: ' . $value, 1705250408);
+            throw new InvalidArgumentValueException('Value to be split must be a string: ' . $value, 1705250408);
         }
         return explode($this->arguments['separator'], $value, $this->arguments['limit']);
     }

--- a/tests/Functional/Core/ViewHelper/TagBasedViewHelperTest.php
+++ b/tests/Functional/Core/ViewHelper/TagBasedViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\UserRoleBackedEnum;
 use TYPO3Fluid\Fluid\Tests\Unit\Core\Variables\Fixtures\UserRoleEnum;
@@ -325,7 +326,7 @@ final class TagBasedViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function throwsErrorForInvalidArgumentTypes(string $source): void
     {
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentValueException::class);
 
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperArgumentTypesTest.php
@@ -12,6 +12,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use stdClass;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\Objects\WithCamelCaseGetter;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\Objects\WithProperties;
@@ -204,7 +205,7 @@ final class ViewHelperArgumentTypesTest extends AbstractFunctionalTestCase
     #[Test]
     public function invalidUnionTypeThrowsException(string $source, array $variables, int $expectedExceptionCode): void
     {
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentValueException::class);
         self::expectExceptionCode($expectedExceptionCode);
 
         $view = new TemplateView();

--- a/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
+++ b/tests/Functional/Core/ViewHelper/ViewHelperEventsTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\Core\ViewHelper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -62,7 +63,7 @@ final class ViewHelperEventsTest extends AbstractFunctionalTestCase
     #[DataProvider('argumentsValidatedEventThrowsExceptionDataProvider')]
     public function argumentsValidatedEventThrowsException(string $template): void
     {
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentValueException::class);
         self::expectExceptionCode(1755274666);
         $view = new TemplateView();
         $view->getRenderingContext()->getViewHelperResolver()->addNamespace('test', 'TYPO3Fluid\\Fluid\\Tests\\Functional\\Fixtures\\ViewHelpers');

--- a/tests/Functional/Fixtures/ViewHelpers/CustomValidationViewHelper.php
+++ b/tests/Functional/Fixtures/ViewHelpers/CustomValidationViewHelper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace TYPO3Fluid\Fluid\Tests\Functional\Fixtures\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperArgumentsValidatedEventInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperInterface;
 
@@ -30,7 +31,7 @@ final class CustomValidationViewHelper extends AbstractViewHelper implements Vie
     public static function argumentsValidatedEvent(array $arguments, array $argumentDefinitions, ViewHelperInterface $viewHelper): void
     {
         if (!isset($arguments['arg1']) && (!isset($arguments['arg2']) || !isset($arguments['arg3']))) {
-            throw new \InvalidArgumentException('ViewHelper must either be called with arg1 or with both arg2 and arg3.', 1755274666);
+            throw new InvalidArgumentValueException('ViewHelper must either be called with arg1 or with both arg2 and arg3.', 1755274666);
         }
     }
 }

--- a/tests/Functional/ViewHelpers/ArgumentViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ArgumentViewHelperTest.php
@@ -11,6 +11,8 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\MissingArgumentException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -107,10 +109,12 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
         return [
             'required argument not provided' => [
                 [],
+                MissingArgumentException::class,
                 1746637334,
             ],
             'invalid type provided' => [
                 ['title' => 'My title', 'user' => ['firstName' => 'Jane', 'lastName' => 'Doe']],
+                InvalidArgumentValueException::class,
                 1746637333,
             ],
         ];
@@ -118,9 +122,9 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
 
     #[Test]
     #[DataProvider('templateWithInvalidArgumentsDataProvider')]
-    public function templateWithInvalidArguments(array $variables, int $expectedExceptionCode): void
+    public function templateWithInvalidArguments(array $variables, string $expectedException, int $expectedExceptionCode): void
     {
-        self::expectException(\TYPO3Fluid\Fluid\View\Exception::class);
+        self::expectException($expectedException);
         self::expectExceptionCode($expectedExceptionCode);
         $templatePath = __DIR__ . '/../Fixtures/Templates/TemplateWithArgumentDefinitions.html';
         $view = new TemplateView();
@@ -132,9 +136,9 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
 
     #[Test]
     #[DataProvider('templateWithInvalidArgumentsDataProvider')]
-    public function partialWithInvalidArguments(array $variables, int $expectedExceptionCode): void
+    public function partialWithInvalidArguments(array $variables, string $expectedException, int $expectedExceptionCode): void
     {
-        self::expectException(\TYPO3Fluid\Fluid\View\Exception::class);
+        self::expectException($expectedException);
         self::expectExceptionCode($expectedExceptionCode);
         $templateSource = '<f:render partial="PartialWithArgumentDefinitions" arguments="{_all}" />';
         $partialRootPath = __DIR__ . '/../Fixtures/Partials/';
@@ -166,9 +170,9 @@ final class ArgumentViewHelperTest extends AbstractFunctionalTestCase
 
     #[Test]
     #[DataProvider('templateWithInvalidArgumentsDataProvider')]
-    public function layoutWithInvalidArguments(array $variables, int $expectedExceptionCode): void
+    public function layoutWithInvalidArguments(array $variables, string $expectedException, int $expectedExceptionCode): void
     {
-        self::expectException(\TYPO3Fluid\Fluid\View\Exception::class);
+        self::expectException($expectedException);
         self::expectExceptionCode($expectedExceptionCode);
         $templateSource = '<f:layout name="LayoutWithArgumentDefinitions" />';
         $layoutRootPath = __DIR__ . '/../Fixtures/Layouts/';

--- a/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ConstantViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ClassConstantsExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\EnumExample;
@@ -23,7 +24,7 @@ final class ConstantViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionOnNonStringValue(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $name = new \stdClass();
         $view = new TemplateView();
         $view->assignMultiple(['name' => $name]);

--- a/tests/Functional/ViewHelpers/ContainsViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ContainsViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -185,7 +186,7 @@ final class ContainsViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalidArguments(array $arguments, string $src, int $expectedExceptionCode): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode($expectedExceptionCode);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/CountViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/CountViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -19,7 +20,7 @@ final class CountViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionIfSubjectIsNotCountable(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $value = new \stdClass();
         $view = new TemplateView();
         $view->assignMultiple(['value' => $value]);

--- a/tests/Functional/ViewHelpers/FirstViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/FirstViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -99,7 +100,7 @@ final class FirstViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1712220569);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/FlattenViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/FlattenViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -164,7 +165,7 @@ final class FlattenViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src, int $exceptionCode): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode($exceptionCode);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -19,7 +20,7 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionIfSubjectIsNotTraversable(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1256475113);
         $view = new TemplateView();
         $view->assignMultiple(['value' => new \stdClass()]);
@@ -31,7 +32,7 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionIfSubjectIsInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1256475113);
         $view = new TemplateView();
         $view->assignMultiple(['value' => new \stdClass()]);

--- a/tests/Functional/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/CaseViewHelperTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -85,7 +85,7 @@ final class CaseViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function viewHelperThrowsExceptionIfIncorrectModeIsGiven(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1358349150);
         $view = new TemplateView();
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource('<f:format.case value="foo" mode="invalid" />');

--- a/tests/Functional/ViewHelpers/Format/TrimViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/Format/TrimViewHelperTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers\Format;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -107,7 +107,7 @@ final class TrimViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function viewHelperThrowsExceptionIfIncorrectModeIsGiven(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1669191560);
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/GroupedForViewHelperTest.php
@@ -11,7 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\View\TemplateView;
@@ -21,7 +21,7 @@ final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionWhenEachIsNotTraversable(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1253108907);
         $source = '<f:groupedFor each="{items}" as="group" groupBy="by"></f:groupedFor>';
 
@@ -35,7 +35,7 @@ final class GroupedForViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderThrowsExceptionWhenEachIsOneDimensionalArray(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1253120365);
         $source = '<f:groupedFor each="{items}" as="group" groupBy="by"></f:groupedFor>';
 

--- a/tests/Functional/ViewHelpers/JoinViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/JoinViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -168,7 +169,7 @@ final class JoinViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1256475113);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/LastViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/LastViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -99,7 +100,7 @@ final class LastViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1712221620);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/LengthViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/LengthViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -101,7 +102,7 @@ final class LengthViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1754637887);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/MaxViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/MaxViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -107,7 +108,7 @@ final class MaxViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1756178710);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/MergeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/MergeViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -123,7 +124,7 @@ final class MergeViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src, int $expectedExceptionCode): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode($expectedExceptionCode);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/MinViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/MinViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -107,7 +108,7 @@ final class MinViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1756016877);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/RangeViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RangeViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\CMS\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\TemplateView;
 
@@ -111,7 +112,7 @@ final class RangeViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode(1754596304);
 
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/RenderViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/RenderViewHelperTest.php
@@ -11,6 +11,8 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
+use TYPO3Fluid\Fluid\Core\ViewHelper\MissingArgumentException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\View\Exception\InvalidPartialException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
@@ -21,7 +23,7 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function exceptionForOptionalSetToFalseAndNoTargetGiven(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(MissingArgumentException::class);
         $template = '<f:render optional="false"/>';
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);
@@ -32,7 +34,7 @@ final class RenderViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function exceptionForInvalidDelegate(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $template = '<f:render delegate="TYPO3Fluid\Fluid\Tests\Unit\Core\Rendering\RenderingContextFixture"/>';
         $view = new TemplateView();
         $view->getRenderingContext()->setCache(self::$cache);

--- a/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ReplaceViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -70,7 +71,7 @@ final class ReplaceViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function throwsExceptionForInvalidArgument(string $template, array $variables, int $exceptionCode, string $exceptionMessage): void
     {
-        self::expectException(\InvalidArgumentException::class);
+        self::expectException(InvalidArgumentValueException::class);
         self::expectExceptionCode($exceptionCode);
         self::expectExceptionMessage($exceptionMessage);
         $view = new TemplateView();

--- a/tests/Functional/ViewHelpers/ShuffleViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ShuffleViewHelperTest.php
@@ -11,6 +11,7 @@ namespace TYPO3Fluid\Fluid\Tests\Functional\ViewHelpers;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentValueException;
 use TYPO3Fluid\Fluid\Tests\Functional\AbstractFunctionalTestCase;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\ArrayAccessExample;
 use TYPO3Fluid\Fluid\Tests\Functional\Fixtures\Various\IterableExample;
@@ -184,7 +185,7 @@ final class ShuffleViewHelperTest extends AbstractFunctionalTestCase
     #[Test]
     public function renderInvalid(array $arguments, string $src, int $exceptionCode): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentValueException::class);
         $this->expectExceptionCode($exceptionCode);
 
         $view = new TemplateView();

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContext;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
-use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
+use TYPO3Fluid\Fluid\Core\ViewHelper\UndeclaredArgumentException;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 
 final class AbstractViewHelperTest extends TestCase
@@ -80,7 +80,7 @@ final class AbstractViewHelperTest extends TestCase
     #[Test]
     public function validateAdditionalArgumentsThrowsExceptionIfNotEmpty(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(UndeclaredArgumentException::class);
         $subject = new class () extends AbstractViewHelper {
             public function render(): string
             {

--- a/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
+++ b/tests/Unit/Core/ViewHelper/ArgumentDefinitionTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3Fluid\Fluid\Core\Definition\Annotation\Annotation;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\InvalidArgumentDefinitionException;
 
 final class ArgumentDefinitionTest extends TestCase
 {
@@ -54,7 +55,7 @@ final class ArgumentDefinitionTest extends TestCase
     #[Test]
     public function constructorThrowsExceptionWhenRequiredWithDefaultValue(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentDefinitionException::class);
         $this->expectExceptionCode(1754235900);
         $this->expectExceptionMessage('ArgumentDefinition "test" cannot have a default value while also being required. Either remove the default or mark it as optional.');
 


### PR DESCRIPTION
Several custom exceptions are introduced to indicate invalid ViewHelper
arguments. Their base class `InvalidArgumentException` extends from
`ViewHelper\Exception`, which makes it possible to catch them via
Fluid's error handlers. Previously, a lot of ViewHelpers used the
global `\InvalidArgumentException`, which bubbled through the custom
exception handler.

`InvalidArgumentDefinitionException` is thrown for invalid
argument definitions for ViewHelpers or components.

`MissingArgumentException` is thrown if a required argument is not
supplied.

`UndeclaredArgumentException` is thrown if an undeclared argument
is supplied to a ViewHelper.

`InvalidArgumentValueException` is used both by Fluid itself and by
individual ViewHelpers if a supplied argument value cannot be processed
by the ViewHelper. We recommend that custom ViewHelpers also use this
exception if they receive an invalid value.