### PR TITLE
[TASK] Add file path to ViewHelper exception messages

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,6 +25,12 @@ parameters:
 			path: src/Core/Parser/TemplateParser.php
 
 		-
+			message: '#^Method TYPO3Fluid\\Fluid\\Core\\ErrorHandler\\ErrorHandlerInterface\:\:handleViewHelperError\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 3
+			path: src/Core/Parser/TemplateParser.php
+
+		-
 			message: '#^Method TYPO3Fluid\\Fluid\\Core\\Parser\\TemplateParser\:\:initializeViewHelperAndAddItToStack\(\) should return TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\ViewHelperNode\|null but returns TYPO3Fluid\\Fluid\\Core\\Parser\\SyntaxTree\\NodeInterface\.$#'
 			identifier: return.type
 			count: 1
@@ -35,6 +41,12 @@ parameters:
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/Core/Variables/JSONVariableProvider.php
+
+		-
+			message: '#^Method TYPO3Fluid\\Fluid\\Core\\ErrorHandler\\ErrorHandlerInterface\:\:handleViewHelperError\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Core/ViewHelper/ViewHelperInvoker.php
 
 		-
 			message: '#^Variable \$iterationData might not be defined\.$#'

--- a/src/Core/ErrorHandler/ErrorHandlerInterface.php
+++ b/src/Core/ErrorHandler/ErrorHandlerInterface.php
@@ -9,6 +9,11 @@ declare(strict_types=1);
 
 namespace TYPO3Fluid\Fluid\Core\ErrorHandler;
 
+/**
+ * @todo consider extending in Fluid 6 to provide additional context for exceptions,
+ *       such as the original template file. This is already provided for handleViewHelperError()
+ *       which currently leads to phpstan issues in the baseline.
+ */
 interface ErrorHandlerInterface
 {
     /**

--- a/src/Core/ErrorHandler/StandardErrorHandler.php
+++ b/src/Core/ErrorHandler/StandardErrorHandler.php
@@ -29,8 +29,18 @@ class StandardErrorHandler implements ErrorHandlerInterface
         throw $error;
     }
 
-    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error): string
+    public function handleViewHelperError(\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error, ?string $originalTemplatePath = null): string
     {
+        if ($originalTemplatePath !== null) {
+            throw new \TYPO3Fluid\Fluid\Core\ViewHelper\Exception(sprintf(
+                '%s in %s: %s (%s:%d)',
+                get_class($error),
+                $originalTemplatePath,
+                $error->getMessage(),
+                $error->getFile(),
+                $error->getLine(),
+            ), $error->getCode(), $error);
+        }
         throw $error;
     }
 

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -248,7 +248,7 @@ class TemplateParser
                 } catch (\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error) {
                     $this->textHandler(
                         $state,
-                        $this->renderingContext->getErrorHandler()->handleViewHelperError($error),
+                        $this->renderingContext->getErrorHandler()->handleViewHelperError($error, $state->getOriginalTemplatePath()),
                     );
                 } catch (Exception $error) {
                     $this->textHandler(
@@ -361,7 +361,7 @@ class TemplateParser
         } catch (\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error) {
             $this->textHandler(
                 $state,
-                $this->renderingContext->getErrorHandler()->handleViewHelperError($error),
+                $this->renderingContext->getErrorHandler()->handleViewHelperError($error, $state->getOriginalTemplatePath()),
             );
         } catch (Exception $error) {
             $this->textHandler(
@@ -689,7 +689,7 @@ class TemplateParser
                 } catch (\TYPO3Fluid\Fluid\Core\ViewHelper\Exception $error) {
                     $this->textHandler(
                         $state,
-                        $this->renderingContext->getErrorHandler()->handleViewHelperError($error),
+                        $this->renderingContext->getErrorHandler()->handleViewHelperError($error, $state->getOriginalTemplatePath()),
                     );
                 } catch (Exception $error) {
                     $this->textHandler(

--- a/src/Core/ViewHelper/ViewHelperInvoker.php
+++ b/src/Core/ViewHelper/ViewHelperInvoker.php
@@ -95,6 +95,9 @@ class ViewHelperInvoker
             }
             return $viewHelper->initializeArgumentsAndRender();
         } catch (Exception $error) {
+            if (method_exists($renderingContext, 'getOriginalTemplatePath')) {
+                return $renderingContext->getErrorHandler()->handleViewHelperError($error, $renderingContext->getOriginalTemplatePath());
+            }
             return $renderingContext->getErrorHandler()->handleViewHelperError($error);
         }
     }


### PR DESCRIPTION
If the path to the current template file is available, exceptions
from ViewHelpers now also contain this information to make debugging
easier. To achieve that, all ViewHelper exceptions are wrapped in
an outer exception which extends the original exception message. This
new behavior can be disabled by registering a custom error handler
in the rendering context.