### PR TITLE
[TASK] Backport ViewHelper exception classes

### DIFF
--- a/src/Core/ViewHelper/InvalidArgumentDefinitionException.php
+++ b/src/Core/ViewHelper/InvalidArgumentDefinitionException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentDefinitionException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/InvalidArgumentException.php
+++ b/src/Core/ViewHelper/InvalidArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentException extends Exception {}

--- a/src/Core/ViewHelper/InvalidArgumentValueException.php
+++ b/src/Core/ViewHelper/InvalidArgumentValueException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class InvalidArgumentValueException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/MissingArgumentException.php
+++ b/src/Core/ViewHelper/MissingArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class MissingArgumentException extends InvalidArgumentException {}

--- a/src/Core/ViewHelper/UndeclaredArgumentException.php
+++ b/src/Core/ViewHelper/UndeclaredArgumentException.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * This file belongs to the package "TYPO3 Fluid".
+ * See LICENSE.txt that was shipped with this package.
+ */
+
+namespace TYPO3Fluid\Fluid\Core\ViewHelper;
+
+/**
+ * @api
+ */
+class UndeclaredArgumentException extends InvalidArgumentException {}


### PR DESCRIPTION
This is a partial backport of #1344. Only the exception classes are
backported, which makes it possible to use them in projects that need
to support both Fluid 4 and 5.