### PR TITLE
[BUGFIX] Fix RoundViewHelper with symfony/polyfill-php84 (#1373)

### DIFF
--- a/src/ViewHelpers/RoundViewHelper.php
+++ b/src/ViewHelpers/RoundViewHelper.php
@@ -94,7 +94,7 @@ final class RoundViewHelper extends AbstractViewHelper
     {
         $value = $this->arguments['value'] ?? $this->renderChildren();
 
-        if (class_exists(\RoundingMode::class)) {
+        if (\PHP_VERSION_ID >= 80400) {
             $roundingMode = match ($this->arguments['roundingMode']) {
                 'HalfAwayFromZero'  => \RoundingMode::HalfAwayFromZero,
                 'HalfTowardsZero'   => \RoundingMode::HalfTowardsZero,
@@ -107,6 +107,7 @@ final class RoundViewHelper extends AbstractViewHelper
                 default             => \RoundingMode::HalfAwayFromZero,
             };
         } else {
+            // @todo: Remove when PHP < 8.4 is dropped
             $roundingMode = match ($this->arguments['roundingMode']) {
                 'HalfAwayFromZero'  => \PHP_ROUND_HALF_UP,
                 'HalfTowardsZero'   => \PHP_ROUND_HALF_DOWN,


### PR DESCRIPTION
symfony/polyfill-php84 1.33.0->1.34.0 adds RoundingMode stub [1].

round() in PHP < 8.4 allows int as third argument only, and has been extended with php 8.4 to allow int|RoundingMode.

The 'class_exists()' check in RoundViewHelper now suddenly returns true when latest symfony/polyfill-php84 is loaded, and then feeds \RoundingMode enum to round() in php < 8.4, which fails with type error. Yay.

The patch switches to a straight version check to trigger the PHP < 8.4 callback chain avoiding RoundingMode enum altogether, to avoid the symfony/polyfill-php84 influence.

[1] https://github.com/symfony/polyfill-php84/commit/e4e3f1cc81b8b84a7c596f8817c6d186678e2884