### PR TITLE
[BUGFIX] Handle generators and traversables correctly in ForViewHelper

### DIFF
--- a/src/ViewHelpers/ForViewHelper.php
+++ b/src/ViewHelpers/ForViewHelper.php
@@ -99,8 +99,18 @@ class ForViewHelper extends AbstractViewHelper
         if (is_object($this->arguments['each']) && !$this->arguments['each'] instanceof \Traversable) {
             throw new InvalidArgumentValueException('ForViewHelper only supports arrays and objects implementing \Traversable interface', 1248728393);
         }
+        $isKeyValuePair = false;
+        if ($this->arguments['reverse'] === true || (isset($this->arguments['iteration'])) && !is_countable($this->arguments['each'])) {
+            $isKeyValuePair = true;
+            $traversable = $this->arguments['each'];
+            $this->arguments['each'] = [];
+            foreach ($traversable as $key => $singleElement) {
+                // unpack the traversable, but keep duplicate keys.
+                $this->arguments['each'][] = [$key, $singleElement];
+            }
+        }
         if ($this->arguments['reverse'] === true) {
-            $this->arguments['each'] = array_reverse(iterator_to_array($this->arguments['each']), true);
+            $this->arguments['each'] = array_reverse($this->arguments['each'], true);
         }
         if (isset($this->arguments['iteration'])) {
             $iterationData = [
@@ -114,6 +124,9 @@ class ForViewHelper extends AbstractViewHelper
         $this->renderingContext->setVariableProvider(new ScopedVariableProvider($globalVariableProvider, $localVariableProvider));
         $output = '';
         foreach ($this->arguments['each'] as $keyValue => $singleElement) {
+            if ($isKeyValuePair === true) {
+                [$keyValue, $singleElement] = $singleElement;
+            }
             $localVariableProvider->add($this->arguments['as'], $singleElement);
             if (isset($this->arguments['key'])) {
                 $localVariableProvider->add($this->arguments['key'], $keyValue);

--- a/tests/Functional/ViewHelpers/ForViewHelperTest.php
+++ b/tests/Functional/ViewHelpers/ForViewHelperTest.php
@@ -107,6 +107,147 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
             . '</ul>',
         ];
 
+        $value = new class () implements \IteratorAggregate {
+            public function getIterator(): \Traversable
+            {
+                return new \ArrayIterator([
+                    'first' => 'foo',
+                    'second' => 'bar',
+                ]);
+            }
+        };
+        yield 'iterator total works for non countable traversable' => [
+            '<f:for each="{value}" as="item" iteration="iterator">{item}: {iterator.total}, </f:for>',
+            ['value' => $value],
+            'foo: 2, bar: 2, ',
+        ];
+
+        yield 'generator gets traversed' => [
+            '<f:for each="{value}" as="item">{item} </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'first' => 'foo';
+                    yield 'second' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'foo bar ',
+        ];
+
+        yield 'iterator total works for generator' => [
+            '<f:for each="{value}" as="item" iteration="iterator">{item}: {iterator.total}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'first' => 'foo';
+                    yield 'second' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'foo: 2, bar: 2, ',
+        ];
+
+        yield 'iterator last works for generator' => [
+            '<f:for each="{value}" as="item" iteration="iterator">{item}{f:if(condition: iterator.isLast, then: \'!\', else: \', \')}</f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'Lucas';
+                    yield 'Helene';
+                    yield 'Thomas';
+                })();
+                return ['value' => $value];
+            },
+            'Lucas, Helene, Thomas!',
+        ];
+
+        yield 'generator preserves duplicate keys without key argument' => [
+            '<f:for each="{value}" as="item">{item} </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'duplicate' => 'foo';
+                    yield 'duplicate' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'foo bar ',
+        ];
+
+        yield 'iterator preserves duplicate keys from generator' => [
+            '<f:for each="{value}" as="item" key="key" iteration="iterator">{key}: {item} / {iterator.total}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'duplicate' => 'foo';
+                    yield 'duplicate' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'duplicate: foo / 2, duplicate: bar / 2, ',
+        ];
+
+        yield 'empty generator with iteration returns empty string' => [
+            '<f:for each="{value}" as="item" iteration="iterator">{item}: {iterator.total}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield from [];
+                })();
+                return ['value' => $value];
+            },
+            '',
+        ];
+
+        yield 'empty generator with reverse returns empty string' => [
+            '<f:for each="{value}" as="item" reverse="true">{item} </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield from [];
+                })();
+                return ['value' => $value];
+            },
+            '',
+        ];
+
+        yield 'reverse preserves duplicate keys from generator' => [
+            '<f:for each="{value}" as="item" key="key" reverse="true">{key}: {item}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'duplicate' => 'foo';
+                    yield 'duplicate' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'duplicate: bar, duplicate: foo, ',
+        ];
+
+        yield 'reverse and iteration work for generator' => [
+            '<f:for each="{value}" as="item" reverse="true" iteration="iterator">{item}: {iterator.total} / {iterator.isFirst} / {iterator.isLast}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'first' => 'foo';
+                    yield 'second' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'bar: 2 / 1 / , foo: 2 /  / 1, ',
+        ];
+
+        yield 'reverse and iteration preserve duplicate keys from generator' => [
+            '<f:for each="{value}" as="item" key="key" reverse="true" iteration="iterator">{key}: {item} / {iterator.total}, </f:for>',
+            static function () {
+                $value = (static function (): \Generator {
+                    yield 'duplicate' => 'foo';
+                    yield 'duplicate' => 'bar';
+                })();
+                return ['value' => $value];
+            },
+            'duplicate: bar / 2, duplicate: foo / 2, ',
+        ];
+
+        $value = new \ArrayObject(['foo', 'bar']);
+        yield 'iterator metadata works for countable traversable' => [
+            '<f:for each="{value}" as="item" iteration="iterator">{item}: {iterator.total} / {iterator.isFirst} / {iterator.isLast}, </f:for>',
+            ['value' => $value],
+            'foo: 2 / 1 / , bar: 2 /  / 1, ',
+        ];
+
         $value = ['item'];
         yield 'iterator not available if not requested' => [
             '<f:for each="{value}" as="item">Total: {iterator.total}</f:for>',
@@ -200,16 +341,16 @@ final class ForViewHelperTest extends AbstractFunctionalTestCase
 
     #[DataProvider('renderDataProvider')]
     #[Test]
-    public function render(string $template, array $variables, string $expected): void
+    public function render(string $template, array|callable $variables, string $expected): void
     {
         $view = new TemplateView();
-        $view->assignMultiple($variables);
+        $view->assignMultiple(is_callable($variables) ? $variables() : $variables);
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
         self::assertSame($expected, $view->render());
 
         $view = new TemplateView();
-        $view->assignMultiple($variables);
+        $view->assignMultiple(is_callable($variables) ? $variables() : $variables);
         $view->getRenderingContext()->setCache(self::$cache);
         $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
         self::assertSame($expected, $view->render());


### PR DESCRIPTION
## What changed

This PR improves how `ForViewHelper` handles generators and other traversables.

The ViewHelper sometimes has to look at all items before rendering them, for example when `reverse="true"` is used or when `{iterator.total}` is needed.
Until now, that was done with `iterator_to_array()`.
That works for simple cases, but it loses entries when a generator yields the same key more than once.
The implementation now keeps materialized traversable items as key-value pairs instead.
That way, every yielded item is preserved, including duplicate keys.

Plain generator loops are still rendered directly whenever possible, 
so we avoid consuming or buffering generators unless Fluid actually needs to know the full item list up front.

## Why
PHP `foreach` renders every yielded generator item, even if keys are duplicated.
`ForViewHelper` should behave the same way.
Without this change, using `iteration` or `reverse` could silently drop entries from a valid generator.

## Tests

This adds test coverage for:

  - non-countable traversables with `{iterator.total}`
  - plain generator rendering without look-ahead
  - generators with `{iterator.total}`
  - generators that yield duplicate keys
  - duplicate generator keys without exposing the key argument
  - empty generators with `{iterator.total}`
  - empty generators with `reverse="true"`
  - duplicate generator keys together with `reverse="true"`
  - generators with both `reverse="true"` and `{iterator.total}`
  - duplicate generator keys together with `reverse="true"` and `{iterator.total}`
  - countable traversables with iteration metadata